### PR TITLE
Bumping version of browser-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/ghostery/ghostery-extension#readme",
   "dependencies": {
     "base64-js": "^1.2.1",
-    "browser-core": "https://s3.amazonaws.com/cdncliqz/update/edge/ghostery/v7.24/7.24.2.tgz",
+    "browser-core": "https://s3.amazonaws.com/cdncliqz/update/edge/ghostery/v7.24/7.24.3.tgz",
     "classnames": "^2.2.5",
     "d3": "^4.13.0",
     "d3-scale": "^1.0.6",


### PR DESCRIPTION
`browser-core` failed the installation on latest node LTS (>= 8.9.4), due to dependency with fixed list of supported node engines. The dependency was fixed https://github.com/cliqz-oss/IndexedDBShim/commit/50c9e08f1e71815dec70c08b8c12c6503e27b75a and new version of browser-core was released. 