### PR TITLE
GH-908 Un-swapped text on cliqz-features page on setup flow

### DIFF
--- a/app/setup/components/Views/AdditionalFeaturesView.jsx
+++ b/app/setup/components/Views/AdditionalFeaturesView.jsx
@@ -78,7 +78,7 @@ class AdditionalFeaturesView extends Component {
 	 * @return {Object}
 	 */
 	createAntiTrackDescriptionMarkup() {
-		return { __html: IS_CLIQZ ? t('setup_feature_active_in_cliqz') : t('setup_additional_view_adblock_desc') };
+		return { __html: IS_CLIQZ ? t('setup_feature_active_in_cliqz') : t('setup_additional_view_antitrack_desc') };
 	}
 
 	/**
@@ -86,7 +86,7 @@ class AdditionalFeaturesView extends Component {
 	 * @return {Object}
 	 */
 	createAdBlockDescriptionMarkup() {
-		return { __html: IS_CLIQZ ? t('setup_feature_active_in_cliqz') : t('setup_additional_view_antitrack_desc') };
+		return { __html: IS_CLIQZ ? t('setup_feature_active_in_cliqz') : t('setup_additional_view_adblock_desc') };
 	}
 
 	/**


### PR DESCRIPTION
GH-908: The description for Anti-Tracking and Ad Blocking were switched on the additional-features portion of the setup flow.  I un-swapped the descriptions.

@christophertino please approve