### PR TITLE
Fix scroll issue with tooltip

### DIFF
--- a/app/scss/partials/_summary.scss
+++ b/app/scss/partials/_summary.scss
@@ -15,7 +15,6 @@
 	position: absolute;
 	height: 479px;
 	width: 100%;
-	overflow-y: hidden;
 	&.expert { width: 235px; }
 	&.expert.condensed {
 		width: 66px;


### PR DESCRIPTION
Fixed a bug during the last Pull Request fixes where tooltips are shown within a horizontal scroll on the Summary View when in expert mode and condensed.