### PR TITLE
Update moab version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:8
 
-RUN curl https://s3.amazonaws.com/cdncliqz/update/ghostery/moab/moab_8319dab > /bin/moab && \
+RUN curl https://s3.amazonaws.com/cdncliqz/update/ghostery/moab/moab_6a9b26e > /bin/moab && \
     chmod +x /bin/moab
 
 RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.6.0 \


### PR DESCRIPTION
New moab uses yarn. Old version with npm was hanging on CI.
