### PR TITLE
Inject ghostery whitelist check to cliqz adblokcer

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/ghostery/ghostery-extension#readme",
   "dependencies": {
     "base64-js": "^1.2.1",
-    "browser-core": "https://s3.amazonaws.com/cdncliqz/update/edge/ghostery/v7.27/7.27.4.tgz?v=1",
+    "browser-core": "https://s3.amazonaws.com/cdncliqz/update/edge/ghostery/v7.27/7.27.5.tgz?v=1",
     "classnames": "^2.2.5",
     "d3": "^4.13.0",
     "d3-scale": "^1.0.6",

--- a/src/background.js
+++ b/src/background.js
@@ -1047,7 +1047,9 @@ adblocker.on('enabled', () => {
 				spec: 'break',
 				fn: state => !isWhitelisted(state),
 				before: ['checkBlocklist']
-			})
+			}),
+			adblocker.action('addWhiteListCheck',
+				url => isWhitelisted({ sourceUrl: url }))
 		])
 	);
 });


### PR DESCRIPTION
I added an action from cliqz side. Now we can inject a whitelist check from ghostery side and make cosmetic filters  to respect the whitelist setting