### PR TITLE
Inter-extension communication with Cliqz

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-shadow": "^16.2.0",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
+    "spanan": "^2.0.0",
     "ua-parser-js": "^0.7.17",
     "underscore": "^1.8.3",
     "url-search-params": "^0.10.0"

--- a/src/background.js
+++ b/src/background.js
@@ -45,6 +45,7 @@ import * as accounts from './utils/accounts';
 import { allowAllwaysC2P } from './utils/click2play';
 import * as common from './utils/common';
 import * as utils from './utils/utils';
+import { importCliqzSettings } from './utils/cliqzSettingImport';
 
 // class instantiation
 const events = new Events();
@@ -1529,6 +1530,9 @@ function init() {
 			// persist Conf properties to storage only after init has completed
 			common.prefsSet(globals.initProps);
 			globals.INIT_COMPLETE = true;
+			if (IS_CLIQZ) {
+				importCliqzSettings(cliqz, conf);
+			}
 		})));
 	}).catch((err) => {
 		log('Error in init()', err);

--- a/src/classes/ConfData.js
+++ b/src/classes/ConfData.js
@@ -135,6 +135,7 @@ class ConfData {
 			_initProperty('setup_step', 0);
 			_initProperty('setup_path', 0);
 			_initProperty('setup_block', 1);
+			_initProperty('cliqz_import_state', 0);
 
 			// Complex props
 			_initProperty('bugs', {});

--- a/src/classes/ExtMessenger.js
+++ b/src/classes/ExtMessenger.js
@@ -1,0 +1,58 @@
+import Spanan from 'spanan';
+
+export class ExtMessenger {
+	addListener(fn) {
+		chrome.runtime.onMessageExternal.addListener(fn);
+	}
+
+	removeListener(fn) {
+		chrome.runtime.onMessageExternal.removeListener(fn);
+	}
+
+	sendMessage(extensionId, message) {
+		chrome.runtime.sendMessage(extensionId, message, () => {});
+	}
+}
+
+export default class KordInjector {
+	constructor() {
+		this.messenger = new ExtMessenger();
+		this.extensionId = 'cliqz@cliqz.com';
+		this.moduleWrappers = new Map();
+		this._messageHandler = this._messageHandler.bind(this);
+	}
+
+	init() {
+		this.messenger.addListener(this._messageHandler);
+	}
+
+	unload() {
+		this.messenger.removeListener(this._messageHandler);
+	}
+
+	module(moduleName) {
+		if (!this.moduleWrappers.has(moduleName)) {
+			this.moduleWrappers.set(moduleName, this._createModuleWrapper(moduleName));
+		}
+		const wrapper = this.moduleWrappers.get(moduleName);
+		return wrapper.createProxy();
+	}
+
+	_createModuleWrapper(moduleName) {
+		return new Spanan((message) => {
+			message.moduleName = moduleName;
+			this.messenger.sendMessage(this.extensionId, message);
+		});
+	}
+
+	_messageHandler(messageJSON, sender) {
+		const message = JSON.parse(messageJSON);
+		if (sender.id !== this.extensionId) {
+			return;
+		}
+		if (!this.moduleWrappers.has(message.moduleName)) {
+			console.error('unhandled message', message);
+		}
+		this.moduleWrappers.get(message.moduleName).handleMessage(message);
+	}
+}

--- a/src/utils/cliqzSettingImport.js
+++ b/src/utils/cliqzSettingImport.js
@@ -1,0 +1,70 @@
+import KordInjector from '../classes/ExtMessenger';
+import { log } from './common';
+
+function promiseTimeout(timeout) {
+	return new Promise((resolve, reject) => {
+		setTimeout(reject, timeout);
+	});
+}
+
+function runCliqzSettingsImport(cliqz, conf) {
+	log('run cliqz settings importer');
+	const inject = new KordInjector();
+  inject.init();
+	// inject modules in remote cliqz extension with which we want to communicate
+	const privacyMigration = inject.module('privacy-migration');
+
+	// fetch settings from antitracking and adblocker
+	// if we don't get a response, the promise will timeout after 5s
+	return Promise.race([privacyMigration.exportSettings(), promiseTimeout(5000)])
+		.then((result) => {
+			if (result === 'error') {
+				// no settings available at the moment
+				return Promise.reject();
+			}
+			log(result);
+			const modules = ['antitracking', 'adblocker'];
+
+			// active modules
+			modules.forEach((mod) => {
+				if (result[mod].enabled === true) {
+					log(`import ${mod} state: enabled`);
+					cliqz.enableModule(mod);
+				} else {
+					log(`import ${mod} state: disabled`);
+					cliqz.disableModule(mod);
+				}
+			});
+
+			// import site whitelists
+			const existingSites = new Set(conf.site_whitelist);
+			const newSites = new Set(modules.map(mod => result[mod].whitelistedSites)
+				.reduce((lst, val) => lst.concat(val), [])
+				.map(s => s.replace(/^(http[s]?:\/\/)?(www\.)?/, ''))
+				.filter(s => !existingSites.has(s)));
+			log('add whitelisted sites', [...newSites]);
+			newSites.forEach((s) => {
+				conf.site_whitelist.push(s);
+			});
+			return privacyMigration.cleanModuleData();
+		}).then(() => {
+			inject.unload();
+		});
+}
+
+// import settings from cliqz
+export function importCliqzSettings(cliqz, conf) {
+	const IMPORT_RUN_FLAG = 'cliqzImportState';
+	chrome.storage.local.get([IMPORT_RUN_FLAG], (result) => {
+		log(IMPORT_RUN_FLAG, result);
+		if (!result[IMPORT_RUN_FLAG]) {
+			runCliqzSettingsImport(cliqz, conf).then(() => {
+				log('cliqz settings import successful');
+				chrome.storage.local.set({ [IMPORT_RUN_FLAG]: 1 });
+			}, (e) => {
+				log('cliqz import not available at present');
+				console.error(e);
+			});
+		}
+	});
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9048,7 +9048,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
-spanan@2.0.0:
+spanan@2.0.0, spanan@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/spanan/-/spanan-2.0.0.tgz#61e82c3ba0a1b6ab3c3014c3a0f4592ae003adbe"
 


### PR DESCRIPTION
This is a PoC of messaging between Ghostery and Cliqz extension, allowing Ghostery to call actions on Cliqz modules.

The first use case is importing settings from the antitracking and adblocker modules in Cliqz browser, allowing for the migration of this functionality from cliqz extension to Ghostery. The Cliqz side of this communication is implemented [here](https://github.com/cliqz/navigation-extension/pull/5942). 

Further work is needed to define the on-boarding flow for this migration, as currently antitracking and adblocker are forced off in Cliqz browser.