### PR TITLE
GH-1246 grey out Trackers Blocked count from Summary View when Ghoste…

### DIFF
--- a/app/panel/components/Summary.jsx
+++ b/app/panel/components/Summary.jsx
@@ -273,7 +273,7 @@ class Summary extends React.Component {
 	*/
 	render() {
 		const { abPause } = this.state;
-		const { is_expert, is_expanded } = this.props;
+		const { is_expert, is_expanded, paused_blocking } = this.props;
 		const showCondensed = is_expert && is_expanded;
 
 		const summaryClassNames = ClassNames('', {
@@ -284,6 +284,7 @@ class Summary extends React.Component {
 
 		const blockedTrackersClassNames = ClassNames('blocked-trackers', {
 			clickable: is_expert,
+			paused: paused_blocking,
 		});
 		const pageLoadClassNames = ClassNames('page-load', {
 			fast: +this.state.trackerLatencyTotal < 5,

--- a/app/scss/partials/_summary.scss
+++ b/app/scss/partials/_summary.scss
@@ -101,6 +101,8 @@
 		font-weight: 600;
 		margin-bottom: 40px;
 		.blocked-trackers .value { color: #e74055; }
+		.blocked-trackers.paused .value { color: #f9d0d5; }
+		.blocked-trackers.paused .text { color: #cccccc; }
 		.page-load .value { color: #ffc063; }
 		.page-load.fast .value { color: #9ecc42; }
 		.page-load.slow .value { color: #e74055; }


### PR DESCRIPTION
We now grey out `Trackers Blocked: ##` on the Summary view when Ghostery is Paused.
@christophertino Please approve