### PR TITLE
Feature/gh 1239

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -672,14 +672,8 @@
 	"panel_tracker_slow_non_secure_end": {
 		"message": " on this page."
 	},
-	"tracker_signular": {
-		"message": "tracker"
-	},
-	"tracker_plural": {
-		"message": "trackers"
-	},
-	"tracker_found": {
-		"message": "found"
+	"panel_tracker_total_tooltip": {
+		"message": "Total count of trackers found, ads blocked and data points anonymized."
 	},
 	"panel_signin_success": {
 		"message": "You are now signed in as "

--- a/app/panel/components/Blocking.jsx
+++ b/app/panel/components/Blocking.jsx
@@ -68,7 +68,8 @@ class Blocking extends React.Component {
 		// Update the summary blocking count whenever the blocking component updated.
 		// This will also show pending blocking changes if the panel is re-opened
 		// before a page refresh
-		updateSummaryBlockingCount(this.props.categories, this.props.smartBlock, this.props.actions.updateTrackerCounts);
+		const smartBlock = this.props.smartBlockActive && this.props.smartBlock || { blocked: {}, unblocked: {} };
+		updateSummaryBlockingCount(this.props.categories, smartBlock, this.props.actions.updateTrackerCounts);
 	}
 	/**
 	* Filter trackers by category, or reset filters. Trigger action.
@@ -106,7 +107,8 @@ class Blocking extends React.Component {
 		updated_categories.forEach((category) => {
 			let count = 0;
 			category.trackers.forEach((tracker) => {
-				if ((tracker.blocked && !tracker.ss_allowed) || tracker.ss_blocked) {
+				const isSbBlocked = this.props.smartBlockActive && tracker.warningSmartBlock;
+				if ((tracker.blocked && !tracker.ss_allowed) || isSbBlocked || tracker.ss_blocked) {
 					tracker.shouldShow = true;
 					count++;
 				} else {
@@ -253,6 +255,7 @@ class Blocking extends React.Component {
 					sitePolicy={this.props.sitePolicy}
 					paused_blocking={this.props.paused_blocking}
 					selected_app_ids={this.props.selected_app_ids}
+					smartBlockActive={this.props.smartBlockActive}
 					smartBlock={this.props.smartBlock}
 				/>
 				{(this.state.disableBlocking && this.props.is_expanded) ?
@@ -267,6 +270,7 @@ class Blocking extends React.Component {
 								sitePolicy={this.props.sitePolicy}
 								paused_blocking={this.props.paused_blocking}
 								language={this.props.language}
+								smartBlockActive={this.props.smartBlockActive}
 								smartBlock={this.props.smartBlock}
 							/>
 						}

--- a/app/panel/components/Blocking/BlockingHeader.jsx
+++ b/app/panel/components/Blocking/BlockingHeader.jsx
@@ -55,7 +55,8 @@ class BlockingHeader extends React.Component {
 
 		if (typeof this.props.actions.updateTrackerCounts === 'function') {
 			// if we're on GlobalSettings, we don't need to run this function
-			updateSummaryBlockingCount(this.props.categories, this.props.smartBlock, this.props.actions.updateTrackerCounts);
+			const smartBlock = this.props.smartBlockActive && this.props.smartBlock || { blocked: {}, unblocked: {} };
+			updateSummaryBlockingCount(this.props.categories, smartBlock, this.props.actions.updateTrackerCounts);
 		}
 	}
 	/**
@@ -117,13 +118,15 @@ class BlockingHeader extends React.Component {
 				}
 
 				this.props.actions.updateBlockAllTrackers({
-					allBlocked,
+					smartBlockActive: this.props.smartBlockActive,
 					smartBlock: this.props.smartBlock,
+					allBlocked,
 				});
 
 				if (typeof this.props.actions.updateTrackerCounts === 'function') {
 					// if we're on GlobalSettings, we don't need to run this function
-					updateSummaryBlockingCount(this.props.categories, this.props.smartBlock, this.props.actions.updateTrackerCounts);
+					const smartBlock = this.props.smartBlockActive && this.props.smartBlock || { blocked: {}, unblocked: {} };
+					updateSummaryBlockingCount(this.props.categories, smartBlock, this.props.actions.updateTrackerCounts);
 				}
 
 				this.props.actions.showNotification({

--- a/app/panel/components/Blocking/Categories.jsx
+++ b/app/panel/components/Blocking/Categories.jsx
@@ -43,6 +43,7 @@ class Categories extends React.Component {
 				sitePolicy={this.props.sitePolicy}
 				paused_blocking={this.props.paused_blocking}
 				language={this.props.language}
+				smartBlockActive={this.props.smartBlockActive}
 				smartBlock={this.props.smartBlock}
 			/>
 		));

--- a/app/panel/components/Blocking/Category.jsx
+++ b/app/panel/components/Blocking/Category.jsx
@@ -119,6 +119,7 @@ class Category extends React.Component {
 		}
 
 		this.props.actions.updateCategoryBlocked({
+			smartBlockActive: this.props.smartBlockActive,
 			smartBlock: this.props.smartBlock,
 			category: this.props.category.id,
 			blocked,
@@ -233,6 +234,7 @@ class Category extends React.Component {
 						sitePolicy={this.props.sitePolicy}
 						paused_blocking={this.props.paused_blocking}
 						language={this.props.language}
+						smartBlockActive={this.props.smartBlockActive}
 						smartBlock={this.props.smartBlock}
 					/>
 				}

--- a/app/panel/components/Blocking/Category.jsx
+++ b/app/panel/components/Blocking/Category.jsx
@@ -112,7 +112,7 @@ class Category extends React.Component {
 	 */
 	clickCategoryStatus() {
 		const globalBlocking = !!this.props.globalBlocking;
-		const blocked = !(this.props.category.num_blocked === this.props.category.num_total);
+		const blocked = !this.state.allShownBlocked;
 
 		if ((this.props.paused_blocking || this.props.sitePolicy) && !globalBlocking) {
 			return;

--- a/app/panel/components/Blocking/Tracker.jsx
+++ b/app/panel/components/Blocking/Tracker.jsx
@@ -148,10 +148,11 @@ class Tracker extends React.Component {
 		}
 
 		this.props.actions.updateTrackerBlocked({
+			smartBlockActive: this.props.smartBlockActive,
+			smartBlock: this.props.smartBlock,
 			app_id: this.props.tracker.id,
 			cat_id: this.props.cat_id,
 			blocked,
-			smartBlock: this.props.smartBlock,
 		});
 
 		this.props.actions.showNotification({

--- a/app/panel/components/Blocking/Trackers.jsx
+++ b/app/panel/components/Blocking/Trackers.jsx
@@ -70,6 +70,7 @@ class Trackers extends React.Component {
 					sitePolicy={this.props.sitePolicy}
 					paused_blocking={this.props.paused_blocking}
 					language={this.props.language}
+					smartBlockActive={this.props.smartBlockActive}
 					smartBlock={this.props.smartBlock}
 				/>
 			));

--- a/app/panel/components/BuildingBlocks/CliqzFeatures.jsx
+++ b/app/panel/components/BuildingBlocks/CliqzFeatures.jsx
@@ -65,17 +65,7 @@ class CliqzFeatures extends React.Component {
 		if (!this.props.antiTrackingActive) {
 			return '-';
 		}
-		let antiTrackingTotal = 0;
-		for (const category in this.props.antiTracking) {
-			if (this.props.antiTracking.hasOwnProperty(category)) {
-				for (const app in this.props.antiTracking[category]) {
-					if (this.props.antiTracking[category][app] === 'unsafe') {
-						antiTrackingTotal++;
-					}
-				}
-			}
-		}
-		return antiTrackingTotal;
+		return this.props.antiTracking && this.props.antiTracking.totalUnsafeCount || 0;
 	}
 
 	/**

--- a/app/panel/components/BuildingBlocks/DonutGraph.jsx
+++ b/app/panel/components/BuildingBlocks/DonutGraph.jsx
@@ -15,6 +15,7 @@ import React, { Component } from 'react';
 import ClassNames from 'classnames';
 import * as d3 from 'd3';
 import { scaleLinear } from 'd3-scale';
+import Tooltip from '../Tooltip';
 
 /**
  * @class Generate donut graph. Used to display tracker data in the Summary View.
@@ -271,12 +272,13 @@ class DonutGraph extends React.Component {
 				</div>
 				<div className="graph-ref" ref={(node) => { this.node = node; }} />
 				<div className="graph-text clickable" onClick={this.clickGraphText}>
-					<div className="graph-text-count">{totalCount}</div>
-					<div className="graph-text-trackers">
-						{(totalCount === 1) ? t('tracker_signular') : t('tracker_plural')}
-						<div className="show-on-big">
-							{t('tracker_found')}
-						</div>
+					<div className="graph-text-count g-tooltip">
+						{totalCount}
+						<Tooltip
+							delay="0"
+							body={t('panel_tracker_total_tooltip')}
+							position="right"
+						/>
 					</div>
 				</div>
 			</div>

--- a/app/panel/components/BuildingBlocks/GhosteryFeatures.jsx
+++ b/app/panel/components/BuildingBlocks/GhosteryFeatures.jsx
@@ -141,7 +141,7 @@ class GhosteryFeatures extends React.Component {
 								{this.getTrustText()}
 							</span>
 						</span>
-						<Tooltip header={(sitePolicy === 2) ? t('tooltip_trust_on') : t('tooltip_trust')} position={(isStacked) ? 'right' : 'top'} />
+						<Tooltip body={(sitePolicy === 2) ? t('tooltip_trust_on') : t('tooltip_trust')} position={(isStacked) ? 'right' : 'top'} />
 					</div>
 					{isAbPause && (
 						<div className={customClassNames} onClick={this.clickCustomButton}>
@@ -150,7 +150,7 @@ class GhosteryFeatures extends React.Component {
 									{t('summary_custom_settings')}
 								</span>
 							</span>
-							<Tooltip header={t('tooltip_custom_settings')} position={(isStacked) ? 'right' : 'top'} />
+							<Tooltip body={t('tooltip_custom_settings')} position={(isStacked) ? 'right' : 'top'} />
 						</div>
 					)}
 					<div className={restrictClassNames} onClick={this.clickRestrictButton}>
@@ -159,7 +159,7 @@ class GhosteryFeatures extends React.Component {
 								{this.getRestrictText()}
 							</span>
 						</span>
-						<Tooltip header={(sitePolicy === 1) ? t('tooltip_restrict_on') : t('tooltip_restrict')} position={(isStacked) ? 'right' : 'top'} />
+						<Tooltip body={(sitePolicy === 1) ? t('tooltip_restrict_on') : t('tooltip_restrict')} position={(isStacked) ? 'right' : 'top'} />
 					</div>
 				</div>
 			</div>

--- a/app/panel/components/BuildingBlocks/PauseButton.jsx
+++ b/app/panel/components/BuildingBlocks/PauseButton.jsx
@@ -169,7 +169,7 @@ class PauseButton extends React.Component {
 						{this.renderPauseButtonText()}
 						{!this.props.isAbPause && (
 							<Tooltip
-								header={this.props.isPaused ? t('summary_resume_ghostery_tooltip') : t('summary_pause_ghostery_tooltip')}
+								body={this.props.isPaused ? t('summary_resume_ghostery_tooltip') : t('summary_pause_ghostery_tooltip')}
 								position={(this.props.isCentered) ? 'right' : 'top'}
 							/>
 						)}

--- a/app/panel/components/Summary.jsx
+++ b/app/panel/components/Summary.jsx
@@ -275,6 +275,8 @@ class Summary extends React.Component {
 		const { abPause } = this.state;
 		const { is_expert, is_expanded, paused_blocking } = this.props;
 		const showCondensed = is_expert && is_expanded;
+		const antiTrackUnsafe = this.props.antiTracking && this.props.antiTracking.totalUnsafeCount || 0;
+		const adBlockBlocked = this.props.adBlock && this.props.adBlock.totalCount || 0;
 
 		const summaryClassNames = ClassNames('', {
 			expert: is_expert,
@@ -327,7 +329,7 @@ class Summary extends React.Component {
 							categories={this.props.categories}
 							renderRedscale={this.props.sitePolicy === 1}
 							renderGreyscale={this.props.paused_blocking}
-							totalCount={this.props.trackerCounts.allowed + this.props.trackerCounts.blocked || 0}
+							totalCount={this.props.trackerCounts.allowed + this.props.trackerCounts.blocked + antiTrackUnsafe + adBlockBlocked || 0}
 							ghosteryFeatureSelect={this.props.sitePolicy}
 							isSmall={is_expert}
 							clickDonut={this.clickDonut}
@@ -351,7 +353,7 @@ class Summary extends React.Component {
 						<div className={blockedTrackersClassNames} onClick={this.clickTrackersBlocked}>
 							<span className="text">{t('trackers_blocked')} </span>
 							<span className="value">
-								{this.props.trackerCounts.blocked || 0}
+								{this.props.trackerCounts.blocked + antiTrackUnsafe + adBlockBlocked || 0}
 							</span>
 						</div>
 						<div className={pageLoadClassNames}>

--- a/app/panel/components/Summary.jsx
+++ b/app/panel/components/Summary.jsx
@@ -13,6 +13,7 @@
 
 import React, { Component } from 'react';
 import ClassNames from 'classnames';
+import Tooltip from './Tooltip';
 import { sendMessage } from '../utils/msg';
 import globals from '../../../src/classes/Globals';
 import {
@@ -338,7 +339,13 @@ class Summary extends React.Component {
 				)}
 				{!this.state.disableBlocking && showCondensed && (
 					<div className="total-tracker-count clickable" onClick={this.clickTrackersCount}>
-						{this.props.trackerCounts.allowed + this.props.trackerCounts.blocked || 0}
+						<span className="summary-total-tracker-count g-tooltip">
+							{this.props.trackerCounts.allowed + this.props.trackerCounts.blocked + antiTrackUnsafe + adBlockBlocked || 0}
+							<Tooltip
+								header={t('panel_tracker_total_tooltip')}
+								position="right"
+							/>
+						</span>
 					</div>
 				)}
 

--- a/app/panel/containers/BlockingContainer.js
+++ b/app/panel/containers/BlockingContainer.js
@@ -32,6 +32,7 @@ const mapStateToProps = (state, ownProps) => Object.assign({}, state.blocking, {
 	pageHost: state.summary.pageHost,
 	paused_blocking: state.summary.paused_blocking,
 	sitePolicy: state.summary.sitePolicy,
+	smartBlockActive: state.panel.enable_smart_block,
 	smartBlock: state.panel.smartBlock,
 });
 /**

--- a/app/panel/reducers/__tests__/summary.js
+++ b/app/panel/reducers/__tests__/summary.js
@@ -57,7 +57,9 @@ describe('app/panel/reducers/summary.js', () => {
 
 		expect(summaryReducer(initState, action)).toEqual({
 			adBlock: {},
-			antiTracking: {},
+			antiTracking: {
+				totalUnsafeCount: 0
+			},
 		});
 	});
 

--- a/app/panel/reducers/summary.js
+++ b/app/panel/reducers/summary.js
@@ -51,6 +51,18 @@ export default (state = initialState, action) => {
 			return Object.assign({}, state, action.data);
 		}
 		case GET_CLIQZ_MODULE_DATA: {
+			const antiTracking = action.data.antitracking;
+			let totalUnsafeCount = 0;
+			for (const category in antiTracking) {
+				if (antiTracking.hasOwnProperty(category)) {
+					for (const app in antiTracking[category]) {
+						if (antiTracking[category][app] === 'unsafe') {
+							totalUnsafeCount++;
+						}
+					}
+				}
+			}
+			antiTracking.totalUnsafeCount = totalUnsafeCount;
 			return Object.assign({}, state, { adBlock: action.data.adblock, antiTracking: action.data.antitracking });
 		}
 		case UPDATE_GHOSTERY_PAUSED: {

--- a/app/panel/utils/blocking.js
+++ b/app/panel/utils/blocking.js
@@ -71,14 +71,14 @@ export function updateSummaryBlockingCount(categories = [], smartBlock, updateTr
  * @memberOf PanelUtils
  * @param  {Object} state 				current state
  * @param  {Object} action 				current action which provides data
- *
  * @return {Object} 					updated categories and selected app ids
  */
 export function updateBlockAllTrackers(state, action) {
 	const blocked = !action.data.allBlocked;
 	const updated_app_ids = JSON.parse(JSON.stringify(state.selected_app_ids)) || {};
 	const updated_categories = JSON.parse(JSON.stringify(state.categories)) || [];
-	const smartBlock = action.data.smartBlock || { blocked: {}, unblocked: {} };
+	const smartBlockActive = action.data.smartBlockActive;
+	const smartBlock = smartBlockActive && action.data.smartBlock || { blocked: {}, unblocked: {} };
 
 	updated_categories.forEach((category) => {
 		category.num_blocked = 0;
@@ -118,8 +118,8 @@ export function updateBlockAllTrackers(state, action) {
  * @return {Object} 		    updated categories and selected app ids
  */
 export function updateCategoryBlocked(state, action) {
-	const { blocked } = action.data;
-	const smartBlock = action.data.smartBlock || { blocked: {}, unblocked: {} };
+	const { blocked, smartBlockActive } = action.data;
+	const smartBlock = smartBlockActive && action.data.smartBlock || { blocked: {}, unblocked: {} };
 	const updated_app_ids = JSON.parse(JSON.stringify(state.selected_app_ids)) || {};
 	const updated_categories = JSON.parse(JSON.stringify(state.categories)); // deep clone
 	const catIndex = updated_categories.findIndex(item => item.id === action.data.category);
@@ -205,8 +205,8 @@ export function updateTrackerBlocked(state, action) {
 		return {};
 	}
 
-	const { blocked } = action.data;
-	const smartBlock = action.data.smartBlock || { blocked: {}, unblocked: {} };
+	const { blocked, smartBlockActive } = action.data;
+	const smartBlock = smartBlockActive && action.data.smartBlock || { blocked: {}, unblocked: {} };
 	const updated_app_ids = JSON.parse(JSON.stringify(state.selected_app_ids)) || {};
 	const updated_categories = JSON.parse(JSON.stringify(state.categories)) || []; // deep clone
 	const catIndex = updated_categories.findIndex(item => item.id === action.data.cat_id);

--- a/app/panel/utils/blocking.js
+++ b/app/panel/utils/blocking.js
@@ -77,7 +77,7 @@ export function updateBlockAllTrackers(state, action) {
 	const blocked = !action.data.allBlocked;
 	const updated_app_ids = JSON.parse(JSON.stringify(state.selected_app_ids)) || {};
 	const updated_categories = JSON.parse(JSON.stringify(state.categories)) || [];
-	const smartBlockActive = action.data.smartBlockActive;
+	const { smartBlockActive } = action.data;
 	const smartBlock = smartBlockActive && action.data.smartBlock || { blocked: {}, unblocked: {} };
 
 	updated_categories.forEach((category) => {

--- a/app/scss/partials/_donut_graph.scss
+++ b/app/scss/partials/_donut_graph.scss
@@ -12,35 +12,33 @@
  */
 
 .sub-component.donut-graph {
-	.show-on-big { display: none; }
-	&.big .show-on-big { display: block; }
-
 	.graph-text {
 		text-transform: capitalize;
 		text-align: center;
 		font-size: 12px;
 		line-height: 16px;
 		font-weight: 500;
+		padding: 13px 0;
 		color: #4a4a4a;
 	}
 	&.big .graph-text {
 		margin-top: -125px;
-		padding-top: 22px;
 		height: 120px;
 	}
 	&.small .graph-text {
 		margin-top: -99px;
-		padding-top: 18px;
 		height: 94px;
 	}
 	.graph-text-count {
-		font-size: 30px;
-		line-height: 41px;
+		height: 94px;
+		font-size: 42px;
+		line-height: 90px;
 		font-weight: 700;
 	}
 	&.small .graph-text-count {
+		height: 68px;
 		font-size: 28px;
-		line-height: 35px;
+		line-height: 64px;
 	}
 
 	.tooltip-container {

--- a/app/scss/partials/_summary.scss
+++ b/app/scss/partials/_summary.scss
@@ -101,8 +101,6 @@
 		font-weight: 600;
 		margin-bottom: 40px;
 		.blocked-trackers .value { color: #e74055; }
-		.blocked-trackers.paused .value { color: #f9d0d5; }
-		.blocked-trackers.paused .text { color: #cccccc; }
 		.page-load .value { color: #ffc063; }
 		.page-load.fast .value { color: #9ecc42; }
 		.page-load.slow .value { color: #e74055; }

--- a/app/scss/partials/_tooltip.scss
+++ b/app/scss/partials/_tooltip.scss
@@ -100,15 +100,27 @@
 	}
 }
 
+.summary-total-tracker-count.g-tooltip .tooltip-content.right {
+	margin-top: -20px;
+	margin-left: 24px;
+}
+.sub-component.donut-graph.small .g-tooltip .tooltip-content.right {
+	margin-top: -8px;
+	margin-left: 15px;
+}
+.sub-component.donut-graph.big .g-tooltip .tooltip-content.right {
+	margin-top: 5px;
+	margin-left: 10px;
+}
 .expert .sub-component.cliqz-features .g-tooltip .tooltip-content.right {
 	margin-left: 16px;
 }
 .expert .sub-component.ghostery-features .g-tooltip .tooltip-content.right {
-	top: -50%;
+	margin-top: -18px;
 }
 .expert .sub-component.pause-button .g-tooltip .tooltip-content.right {
+	margin-top: -12px;
 	margin-left: 28px;
-	top: -33%;
 }
 .sub-component.pause-button .g-tooltip .tooltip-content.top {
 	left: 75px;

--- a/src/classes/BrowserButton.js
+++ b/src/classes/BrowserButton.js
@@ -15,11 +15,14 @@
 
 import conf from './Conf';
 import foundBugs from './FoundBugs';
+import cliqz from './Cliqz';
 import rewards from './Rewards';
 import Policy from './Policy';
 import { getTab } from '../utils/utils';
 import { log } from '../utils/common';
 import globals from './Globals';
+
+const { adblocker, antitracking } = cliqz.modules;
 
 /**
  * @class for handling Ghostery button.
@@ -140,18 +143,77 @@ class BrowserButton {
 			// 	+ Ghostery was enabled after the tab started loading
 			// 	+ or, this is a tab onBeforeRequest doesn't run in (non-http/https page)
 			trackerCount = '';
-		} else {
-			const apps = foundBugs.getAppsCountByIssues(tabId, tabUrl);
-			trackerCount = apps.all.toString();
-			alert = (apps.total > 0);
+			this._setIcon(false, tabId, trackerCount, alert);
+			return;
 		}
 
-		// gray-out the icon when blocking has been disabled for whatever reason
-		if (trackerCount === '') {
-			this._setIcon(false, tabId, trackerCount, alert);
-		} else {
-			this._setIcon(!globals.SESSION.paused_blocking && !this.policy.whitelisted(tab.url), tabId, trackerCount, alert);
+		this._getAntiTrackCount(tabId).then((antiTrackingCount) => {
+			const { appsCount, appsAlertCount } = this._getTrackerCount(tabId);
+			const adBlockingCount = this._getAdBlockCount(tabId);
+
+			alert = (appsAlertCount > 0);
+			trackerCount = (appsCount + antiTrackingCount + adBlockingCount).toString();
+
+			// gray-out the icon when blocking has been disabled for whatever reason
+			if (trackerCount === '') {
+				this._setIcon(false, tabId, trackerCount, alert);
+			} else {
+				this._setIcon(!globals.SESSION.paused_blocking && !this.policy.whitelisted(tab.url), tabId, trackerCount, alert);
+			}
+		});
+	}
+
+	/**
+	 * Gets tracker count the traditional way, from BugDb
+	 * @param  {number} tabId  the Tab Id
+	 * @param  {string} tabUrl the Tab URL
+	 * @return {Object}        the number of total trackers and alerted trackers in an Object
+	 */
+	_getTrackerCount(tabId, tabUrl) {
+		const apps = foundBugs.getAppsCountByIssues(tabId, tabUrl);
+		return {
+			appsCount: apps.all,
+			appsAlertCount: apps.total,
+		};
+	}
+
+	/**
+	 * Get tracker count for Anti Tracking in a promise
+	 * @param  {number} tabId  the Tab Id
+	 * @return {Promise}       the number of trackers as a Promise
+	 */
+	_getAntiTrackCount(tabId) {
+		return new Promise((resolve, reject) => {
+			if (!conf.enable_anti_tracking) {
+				resolve(0);
+			}
+			antitracking.background.actions.aggregatedBlockingStats(tabId).then((antiTracking) => {
+				let totalUnsafeCount = 0;
+				for (const category in antiTracking) {
+					if (antiTracking.hasOwnProperty(category)) {
+						for (const app in antiTracking[category]) {
+							if (antiTracking[category][app] === 'unsafe') {
+								totalUnsafeCount++;
+							}
+						}
+					}
+				}
+				resolve(totalUnsafeCount);
+			});
+		});
+	}
+
+	/**
+	 * Get tracker count for Ad Blocking
+	 * @param  {number} tabId  the Tab Id
+	 * @return {number}        the number of trackers in an object
+	 */
+	_getAdBlockCount(tabId) {
+		if (!conf.enable_ad_block) {
+			return 0;
 		}
+		const adBlocking = adblocker.background.actions.getAdBlockInfoForTab(tabId);
+		return adBlocking && adBlocking.totalCount || 0;
 	}
 }
 

--- a/src/classes/PanelData.js
+++ b/src/classes/PanelData.js
@@ -409,6 +409,7 @@ class PanelData {
 		const pageBlocks = this._confData.get('site_specific_blocks')[pageHost] || [];
 		const categories = {};
 		const categoryArray = [];
+		const smartBlockActive = this._confData.get('enable_smart_block');
 		const smartBlock = tabInfo.getTabInfo(tab_id, 'smartBlock');
 
 		trackerList.forEach((tracker) => {
@@ -416,8 +417,8 @@ class PanelData {
 			const blocked = selectedAppIds.hasOwnProperty(tracker.id);
 			const ss_allowed = pageUnblocks.includes(+tracker.id);
 			const ss_blocked = pageBlocks.includes(+tracker.id);
-			const sb_blocked = smartBlock.blocked.hasOwnProperty(`${tracker.id}`);
-			const sb_allowed = smartBlock.unblocked.hasOwnProperty(`${tracker.id}`);
+			const sb_blocked = smartBlockActive && smartBlock.blocked.hasOwnProperty(`${tracker.id}`);
+			const sb_allowed = smartBlockActive && smartBlock.unblocked.hasOwnProperty(`${tracker.id}`);
 
 			if (t(`category_${category}`) === `category_${category}`) {
 				category = 'uncategorized';

--- a/test/setup.js
+++ b/test/setup.js
@@ -26,6 +26,28 @@ chrome.runtime.getManifest.returns({
 	debug: true
 });
 
+// Create Mock for
+jest.mock('../src/classes/Cliqz', () => {
+	return {
+		modules: {
+			adblocker: {
+				background: {
+					actions: {
+						getAdBlockInfoForTab: jest.fn()
+					}
+				}
+			},
+			antitracking: {
+				background: {
+					actions: {
+						aggregatedBlockingStats: jest.fn()
+					}
+				}
+			}
+		}
+	};
+});
+
 // Create Mock for the Cliqz dependencies
 jest.mock('browser-core', () => {
 	return { App: class App {} }


### PR DESCRIPTION
GH-1239: The Total Trackers and Trackers Blocked counters on the Summary View now incorporate blocking numbers from the Anti-Tracking and Ad-Blocking.
GH-1246: The Trackers Blocked counter now shows the future blocked value when toggling Trust/Restrict/Pause.
GH-1256: The Trackers Blocked count now incorporates blocking/unblocking numbers from Smart-Blocking.