### PR TITLE
Counter incorrect with no trackers but ads blocked

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -681,6 +681,7 @@ function onMessageHandler(request, sender, callback) {
 	} else if (name === 'getCliqzModuleData') {
 		const modules = { adblock: {}, antitracking: {} };
 		utils.getActiveTab((tab) => {
+			button.update();
 			if (conf.enable_anti_tracking) {
 				cliqz.modules.antitracking.background.actions.aggregatedBlockingStats(tab.id).then((data) => {
 					modules.antitracking = data;
@@ -1561,4 +1562,3 @@ function init() {
 
 // Initialize the application.
 init();
-

--- a/src/classes/BrowserButton.js
+++ b/src/classes/BrowserButton.js
@@ -184,7 +184,7 @@ class BrowserButton {
 	 */
 	_getAntiTrackCount(tabId) {
 		return new Promise((resolve, reject) => {
-			if (!conf.enable_anti_tracking) {
+			if (!conf.enable_anti_tracking || !antitracking.background) {
 				resolve(0);
 			}
 			antitracking.background.actions.aggregatedBlockingStats(tabId).then((antiTracking) => {
@@ -212,7 +212,7 @@ class BrowserButton {
 	 * @return {number}        the number of trackers in an object
 	 */
 	_getAdBlockCount(tabId) {
-		if (!conf.enable_ad_block) {
+		if (!conf.enable_ad_block || !adblocker.background) {
 			return 0;
 		}
 		const adBlocking = adblocker.background.actions.getAdBlockInfoForTab(tabId);

--- a/src/classes/EventHandlers.js
+++ b/src/classes/EventHandlers.js
@@ -46,6 +46,14 @@ class EventHandlers {
 		this.policy = new Policy();
 		this.policySmartBlock = new PolicySmartBlock();
 		this.purplebox = new PurpleBox();
+
+		// Use leading:false so button.update is called after requests are complete.
+		// Use a 1sec interval to limit calls on pages with a large number of requests.
+		// Don't use tabId with button.update for cases where tab is switched before throttle delay is reached.
+		// ToDo: Remove this function when there is an event for AdBlocker:foundAd.
+		this._throttleButtonUpdate = _.throttle(() => {
+			button.update();
+		}, 1000, { leading: false });
 	}
 
 	/**
@@ -362,6 +370,9 @@ class EventHandlers {
 
 		// allow if not a tracker
 		if (!bug_id) {
+			// Make a throttled call to button.update() for when there are no trackers but an ad was blocked
+			// ToDo: Remove this call when there is an event for AdBlocker:foundAd.
+			this._throttleButtonUpdate();
 			return { cancel: false };
 		}
 


### PR DESCRIPTION
Fix issue with the button counter when the adBlocker finds an ad but no other trackers on page resulting in the button reporting 0 but the panel reporting 1 (or more)