### PR TITLE
Pass ghostery bug id to other handlers

### DIFF
--- a/src/classes/EventHandlers.js
+++ b/src/classes/EventHandlers.js
@@ -375,6 +375,8 @@ class EventHandlers {
 			this._throttleButtonUpdate();
 			return { cancel: false };
 		}
+		// add the bugId to the details object. This can then be read by other handlers on this pipeline.
+		details.ghosteryBug = bug_id;
 
 		/* ** SMART BLOCKING - Breakage ** */
 		// allow first party trackers


### PR DESCRIPTION
* [x] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do?
* [x] Does your submission pass tests?
* [x] Did you lint your code prior to submission?

This change passes the ghostery bug id to the following webrequest handlers, allowing us to aggregate stats per bugId on the cliqz side.