### PR TITLE
GH-1318 logout sync - remove cookie change event

### DIFF
--- a/app/content-scripts/platform_pages.js
+++ b/app/content-scripts/platform_pages.js
@@ -19,39 +19,27 @@
 import msgModule from './utils/msg';
 
 const msg = msgModule('platform_pages');
-const { sendMessage, sendMessageToBackground } = msg;
+const { sendMessage, sendMessageInPromise } = msg;
 /**
  * Use to call init to initialize functionality
  * @var  {Object} initialized to an object with init method as its property
  */
-const PlatformPagesContentScript = (function (window, document) {
+const PlatformPagesContentScript = (function (window) {
 	/**
 	 * Initialize functionality of this script.
 	 * @memberOf PlatformPagesContentScript
 	 * @package
 	 */
 	const _initialize = function () {
-		// Add listener to logout-link in platform header
-		let logoutLink = document.getElementsByClassName('logout-link');
-		logoutLink = logoutLink ? logoutLink[0] : null;
-		if (logoutLink) {
-			logoutLink.addEventListener('click', () => {
-				sendMessageToBackground('userLogout'); // send empty object to log out
-			});
-		}
-		// Add listener to cancelModal
-		const cancelDialog = document.getElementById('cancelModal');
-		if (cancelDialog) {
-			let yesButton = cancelDialog.getElementsByClassName('button blue float-right');
-			yesButton = yesButton ? yesButton[0] : null;
-			if (yesButton) {
-				yesButton.addEventListener('click', () => {
-					sendMessageToBackground('userLogout'); // send empty object to log out
-				});
-			}
-		}
 		// alert background that this content script has loaded
 		sendMessage('platformPageLoaded');
+		window.addEventListener('account.logout', () => {
+			sendMessageInPromise('account.logout')
+				.then(() => {
+					const logoutSuccesEvt = new CustomEvent('logoutSuccess');
+					window.dispatchEvent(logoutSuccesEvt);
+				});
+		});
 	};
 
 	return {
@@ -66,6 +54,10 @@ const PlatformPagesContentScript = (function (window, document) {
 	};
 }(window, document));
 
-window.addEventListener('load', () => {
+if (document.readyState === 'complete') {
 	PlatformPagesContentScript.init();
-});
+} else {
+	window.addEventListener('load', () => {
+		PlatformPagesContentScript.init();
+	});
+}

--- a/src/background.js
+++ b/src/background.js
@@ -242,7 +242,7 @@ function getSiteData() {
  * @param  {string} 	name 		message name
  * @param  {string}		tab_url 	tab url
  */
-function handleGhosteryPlatformPages(name) {
+function handleGhosteryPlatformPages(name, callback) {
 	if (name === 'platformPageLoaded') {
 		account._getUserIDFromCookie()
 			.then((userID) => {
@@ -253,6 +253,16 @@ function handleGhosteryPlatformPages(name) {
 			.catch((err) => {
 				log('handleGhosteryPlatformPages error', err);
 			});
+	} else if (name === 'account.logout') {
+		account.logout()
+			.then((response) => {
+				callback(response);
+			})
+			.catch((err) => {
+				log('LOGOUT ERROR', err);
+				callback(err);
+			});
+		return true;
 	}
 	return false;
 }
@@ -552,7 +562,7 @@ function onMessageHandler(request, sender, callback) {
 	const { tab } = sender;
 	const tab_id = tab && tab.id;
 	// Edge does not have url on tab object, as of Build 14342_rc1
-	const tab_url = tab && (tab.url ? tab.url : (sender.url ? sender.url : ''));
+	// const tab_url = tab && (tab.url ? tab.url : (sender.url ? sender.url : ''));
 
 	// On Edge 39.14965.1001.0 callback is lost when multiple
 	// Edge instances running. So instead we shoot message back
@@ -575,7 +585,7 @@ function onMessageHandler(request, sender, callback) {
 	// HANDLE PAGE EVENTS HERE
 	if (origin === 'platform_pages') {
 		// Platform pages
-		return handleGhosteryPlatformPages(name, tab_url);
+		return handleGhosteryPlatformPages(name, callback);
 	} else if (origin === 'purplebox') {
 		// Purplebox script events
 		return handlePurplebox(name, message, tab_id, callback);

--- a/src/classes/Account.js
+++ b/src/classes/Account.js
@@ -67,11 +67,6 @@ class Account {
 			)
 		};
 		api.init(apiConfig, opts);
-		// logout on user_id cookie removed
-		// NOTE: Edge does not support chrome.cookies.onChanged
-		if (!IS_EDGE) {
-			chrome.cookies.onChanged.addListener(this._logoutOnUserIDCookieRemoved);
-		}
 	}
 
 	login = (email, password) => {
@@ -455,15 +450,6 @@ class Account {
 				log(`Removed cookie with name: ${details.name}`);
 			});
 		});
-	}
-
-	_logoutOnUserIDCookieRemoved = (changeInfo) => {
-		const { removed, cookie, cause } = changeInfo;
-		const { name, domain } = cookie;
-		// skip if cause === 'overwrite' to avoid logging out on token refresh
-		if (name === 'user_id' && domain === `.${GHOSTERY_DOMAIN}.com` && removed && cause !== 'overwrite') {
-			this.logout();
-		}
 	}
 }
 


### PR DESCRIPTION
remove the cookie change event that handles logout syncing from account-web to the extension.
cookie change event produces unexpected results in FF.
instead, use custom event in [account-web](https://github.com/ghostery/account-web) and call `account.logout` from the content script

* [x] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do?
* [x] Does your submission pass tests?
* [x] Did you lint your code prior to submission?