### PR TITLE
GH-1432 fix Ghostery Hub subscribe link

### DIFF
--- a/app/hub/Views/SupporterView/SupporterView.jsx
+++ b/app/hub/Views/SupporterView/SupporterView.jsx
@@ -28,8 +28,10 @@ class SupporterView extends Component {
 	 * @return {JSX} JSX of the Supporter Button
 	 */
 	_renderButton = (additionalClasses) => {
-		const { isSupporter, onSupporterClick } = this.props;
-		const buttonHref = `https://account.${globals.GHOSTERY_DOMAIN}.com/subscription`;
+		const { isSignedIn, isSupporter, onSupporterClick } = this.props;
+		const buttonHref = (isSignedIn) ?
+			`https://account.${globals.GHOSTERY_DOMAIN}.com/subscription?target=subscribe` :
+			`https://signon.${globals.GHOSTERY_DOMAIN}.com/subscribe`;
 		const buttonClassNames = ClassNames('SupporterView__button', 'button', additionalClasses, {
 			disabled: isSupporter,
 		});
@@ -198,6 +200,7 @@ class SupporterView extends Component {
 
 // PropTypes ensure we pass required props of the correct type
 SupporterView.propTypes = {
+	isSignedIn: PropTypes.bool.isRequired,
 	isSupporter: PropTypes.bool.isRequired,
 	onSupporterClick: PropTypes.func.isRequired,
 };

--- a/app/hub/Views/SupporterView/SupporterViewContainer.jsx
+++ b/app/hub/Views/SupporterView/SupporterViewContainer.jsx
@@ -43,15 +43,20 @@ class SupporterViewContainer extends Component {
 	 * @return {JSX} JSX for rendering the Supporter View of the Hub app
 	 */
 	render() {
-		const isSupporter = this.props.user && this.props.user.subscriptionsSupporter || false;
+		const childProps = {
+			isSignedIn: !!(this.props.user && this.props.user.email),
+			isSupporter: this.props.user && this.props.user.subscriptionsSupporter || false,
+			onSupporterClick: this._sendSupporterPing,
+		};
 
-		return <SupporterView isSupporter={isSupporter} onSupporterClick={this._sendSupporterPing} />;
+		return <SupporterView {...childProps} />;
 	}
 }
 
 // PropTypes ensure we pass required props of the correct type
 SupporterViewContainer.propTypes = {
 	user: PropTypes.shape({
+		email: PropTypes.string,
 		subscriptionsSupporter: PropTypes.bool,
 	}),
 	actions: PropTypes.shape({
@@ -63,6 +68,7 @@ SupporterViewContainer.propTypes = {
 // Default props used in the Supporter View
 SupporterViewContainer.defaultProps = {
 	user: {
+		email: false,
 		subscriptionsSupporter: false,
 	},
 };

--- a/app/hub/Views/SupporterView/__tests__/SupporterView.test.jsx
+++ b/app/hub/Views/SupporterView/__tests__/SupporterView.test.jsx
@@ -20,6 +20,20 @@ describe('app/hub/Views/SupporterView component', () => {
 	describe('Snapshot tests with react-test-renderer', () => {
 		test('supporter view is rendered correctly when the user is not a supporter', () => {
 			const initialState = {
+				isSignedIn: false,
+				isSupporter: false,
+				onSupporterClick: () => {},
+			};
+
+			const component = renderer.create(
+				<SupporterView {...initialState} />
+			).toJSON();
+			expect(component).toMatchSnapshot();
+		});
+
+		test('supporter view is rendered correctly when the user is signed in but not a supporter', () => {
+			const initialState = {
+				isSignedIn: true,
 				isSupporter: false,
 				onSupporterClick: () => {},
 			};
@@ -32,6 +46,7 @@ describe('app/hub/Views/SupporterView component', () => {
 
 		test('supporter view is rendered correctly when the user is a supporter', () => {
 			const initialState = {
+				isSignedIn: true,
 				isSupporter: true,
 				onSupporterClick: () => {},
 			};
@@ -46,6 +61,7 @@ describe('app/hub/Views/SupporterView component', () => {
 	describe('Shallow snapshot tests rendered with Enzyme', () => {
 		test('the happy path of the component', () => {
 			const initialState = {
+				isSignedIn: false,
 				isSupporter: false,
 				onSupporterClick: jest.fn(),
 			};
@@ -68,6 +84,10 @@ describe('app/hub/Views/SupporterView component', () => {
 			expect(initialState.onSupporterClick.mock.calls.length).toBe(0);
 			component.find('.SupporterView__button').first().simulate('click');
 			expect(initialState.onSupporterClick.mock.calls.length).toBe(1);
+
+			expect(component.find('.SupporterView__button').first().props().href).toBe('https://signon.ghosterystage.com/subscribe')
+			component.setProps({ isSignedIn: true });
+			expect(component.find('.SupporterView__button').first().props().href).toBe('https://account.ghosterystage.com/subscription?target=subscribe')
 
 			expect(component.find('.SupporterView__button').length).toBe(6);
 			expect(component.find('.SupporterView__button.disabled').length).toBe(0);

--- a/app/hub/Views/SupporterView/__tests__/__snapshots__/SupporterView.test.jsx.snap
+++ b/app/hub/Views/SupporterView/__tests__/__snapshots__/SupporterView.test.jsx.snap
@@ -306,7 +306,7 @@ exports[`app/hub/Views/SupporterView component Snapshot tests with react-test-re
       >
         <a
           className="SupporterView__button button"
-          href="https://account.ghosterystage.com/subscription"
+          href="https://signon.ghosterystage.com/subscribe"
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
@@ -413,7 +413,7 @@ exports[`app/hub/Views/SupporterView component Snapshot tests with react-test-re
         </div>
         <a
           className="SupporterView__button button show-for-large"
-          href="https://account.ghosterystage.com/subscription"
+          href="https://signon.ghosterystage.com/subscribe"
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
@@ -442,7 +442,7 @@ exports[`app/hub/Views/SupporterView component Snapshot tests with react-test-re
         />
         <a
           className="SupporterView__button button SupporterView--addSideMargin"
-          href="https://account.ghosterystage.com/subscription"
+          href="https://signon.ghosterystage.com/subscribe"
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
@@ -485,7 +485,7 @@ exports[`app/hub/Views/SupporterView component Snapshot tests with react-test-re
         </div>
         <a
           className="SupporterView__button button show-for-large"
-          href="https://account.ghosterystage.com/subscription"
+          href="https://signon.ghosterystage.com/subscribe"
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
@@ -514,7 +514,7 @@ exports[`app/hub/Views/SupporterView component Snapshot tests with react-test-re
         />
         <a
           className="SupporterView__button button SupporterView--addSideMargin"
-          href="https://account.ghosterystage.com/subscription"
+          href="https://signon.ghosterystage.com/subscribe"
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"
@@ -564,7 +564,309 @@ exports[`app/hub/Views/SupporterView component Snapshot tests with react-test-re
         />
         <a
           className="SupporterView__button button SupporterView--addSideMargin"
-          href="https://account.ghosterystage.com/subscription"
+          href="https://signon.ghosterystage.com/subscribe"
+          onClick={[Function]}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          hub_supporter_button_text
+        </a>
+        <div
+          className="SupporterView__bar flex-child-grow"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`app/hub/Views/SupporterView component Snapshot tests with react-test-renderer supporter view is rendered correctly when the user is signed in but not a supporter 1`] = `
+<div
+  className="SupporterView"
+>
+  <div
+    className="row align-center"
+  >
+    <div
+      className="columns"
+    >
+      <div
+        className="SupporterView__headingImage"
+      />
+      <div
+        className="SupporterView__headingTitle text-center"
+      >
+        hub_supporter_header_title
+      </div>
+      <div
+        className="SupporterView__headingDescription text-center"
+      >
+        hub_supporter_header_description
+      </div>
+      <div
+        className="SupporterView__costContainer flex-container align-middle align-justify"
+      >
+        <a
+          className="SupporterView__button button"
+          href="https://account.ghosterystage.com/subscription?target=subscribe"
+          onClick={[Function]}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          hub_supporter_button_text
+        </a>
+        <div
+          className="SupporterView__headingCost flex-container align-middle"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "hub_supporter_price",
+            }
+          }
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className="SupporterView--addPaddingTop row small-up-1 large-up-3 align-center"
+  >
+    <div
+      className="SupporterView__perk columns text-center"
+    >
+      <div
+        className="SupporterView__perkIcon themes"
+      />
+      <div
+        className="SupporterView__perkTitle"
+      >
+        hub_supporter_perk_themes_title
+      </div>
+      <div
+        className="SupporterView__perkDescription"
+      >
+        hub_supporter_perk_themes_description
+      </div>
+    </div>
+    <div
+      className="SupporterView__perk columns text-center"
+    >
+      <div
+        className="SupporterView__perkIcon support"
+      />
+      <div
+        className="SupporterView__perkTitle"
+      >
+        hub_supporter_perk_support_title
+      </div>
+      <div
+        className="SupporterView__perkDescription"
+      >
+        hub_supporter_perk_support_description
+      </div>
+    </div>
+    <div
+      className="SupporterView__perk columns text-center"
+    >
+      <div
+        className="SupporterView__perkIcon more"
+      />
+      <div
+        className="SupporterView__perkTitle"
+      >
+        hub_supporter_perk_more_title
+      </div>
+      <div
+        className="SupporterView__perkDescription"
+      >
+        hub_supporter_perk_more_description
+      </div>
+    </div>
+  </div>
+  <div
+    className="SupporterView__manifestoContainer"
+  >
+    <div
+      className="SupporterView__manifestoBackground row align-center"
+    >
+      <div
+        className="SupporterView__manifestoText columns small-12 medium-10 large-8 text-center"
+      >
+        hub_supporter_manifesto
+      </div>
+    </div>
+  </div>
+  <div
+    className="SupporterView--addPaddingTop SupporterView--addPaddingBottom"
+  >
+    <div
+      className="row small-up-1 large-up-3"
+    >
+      <div
+        className="SupporterView__feature columns large-offset-1"
+      >
+        <div
+          className="SupporterView__headingTitle SupporterView--addPaddingTop"
+        >
+          hub_supporter_feature_theme_title
+        </div>
+        <div
+          className="SupporterView__headingDescription"
+        >
+          hub_supporter_feature_theme_description
+        </div>
+        <a
+          className="SupporterView__button button show-for-large"
+          href="https://account.ghosterystage.com/subscription?target=subscribe"
+          onClick={[Function]}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          hub_supporter_button_text
+        </a>
+      </div>
+      <div
+        className="SupporterView__feature columns small-12 medium-6"
+      >
+        <img
+          alt="hub_supporter_feature_theme_title"
+          className="SupporterView__featureImage theme"
+          src="/app/images/hub/supporter/feature-theme.png"
+        />
+      </div>
+    </div>
+    <div
+      className="SupporterView--addPaddingTop hide-for-large"
+    >
+      <div
+        className="row align-center-middle"
+      >
+        <div
+          className="SupporterView__bar flex-child-grow"
+        />
+        <a
+          className="SupporterView__button button SupporterView--addSideMargin"
+          href="https://account.ghosterystage.com/subscription?target=subscribe"
+          onClick={[Function]}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          hub_supporter_button_text
+        </a>
+        <div
+          className="SupporterView__bar flex-child-grow"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className="SupporterView--addPaddingTop SupporterView--addPaddingBottom SupporterView--rowDarken"
+  >
+    <div
+      className="row align-middle small-up-1 large-up-3"
+    >
+      <div
+        className="SupporterView__feature columns large-offset-1 show-for-large"
+      >
+        <img
+          alt="hub_supporter_feature_support_title"
+          className="SupporterView__featureImage support"
+          src="/app/images/hub/supporter/feature-support.svg"
+        />
+      </div>
+      <div
+        className="SupporterView__feature columns large-offset-1"
+      >
+        <div
+          className="SupporterView__headingTitle"
+        >
+          hub_supporter_feature_support_title
+        </div>
+        <div
+          className="SupporterView__headingDescription"
+        >
+          hub_supporter_feature_support_description
+        </div>
+        <a
+          className="SupporterView__button button show-for-large"
+          href="https://account.ghosterystage.com/subscription?target=subscribe"
+          onClick={[Function]}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          hub_supporter_button_text
+        </a>
+      </div>
+      <div
+        className="SupporterView__feature columns hide-for-large"
+      >
+        <img
+          alt="hub_supporter_feature_support_title"
+          className="SupporterView__featureImage support"
+          src="/app/images/hub/supporter/feature-support.svg"
+        />
+      </div>
+    </div>
+    <div
+      className="SupporterView--addPaddingTop hide-for-large"
+    >
+      <div
+        className="row align-center-middle"
+      >
+        <div
+          className="SupporterView__bar flex-child-grow"
+        />
+        <a
+          className="SupporterView__button button SupporterView--addSideMargin"
+          href="https://account.ghosterystage.com/subscription?target=subscribe"
+          onClick={[Function]}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          hub_supporter_button_text
+        </a>
+        <div
+          className="SupporterView__bar flex-child-grow"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className="SupporterView--addPaddingTop"
+  >
+    <div
+      className="row align-middle-center"
+    >
+      <div
+        className="SupporterView__feature columns large-8 large-offset-2 text-center"
+      >
+        <div
+          className="SupporterView__headingTitle"
+        >
+          hub_supporter_feature_more_title
+        </div>
+        <div
+          className="SupporterView__headingDescription"
+        >
+          hub_supporter_feature_more_description
+        </div>
+        <img
+          alt="hub_supporter_feature_more_title"
+          className="SupporterView__featureImage more"
+          src="/app/images/hub/supporter/feature-more.svg"
+        />
+      </div>
+    </div>
+    <div
+      className="SupporterView--addPaddingTop"
+    >
+      <div
+        className="row align-center-middle"
+      >
+        <div
+          className="SupporterView__bar flex-child-grow"
+        />
+        <a
+          className="SupporterView__button button SupporterView--addSideMargin"
+          href="https://account.ghosterystage.com/subscription?target=subscribe"
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"


### PR DESCRIPTION
GH-1432 fixed the Get Ghostery Plus link on the Ghostery Hub to correctly link to 
  https://signon.ghosterystage.com/en/subscribe if not signed in or,
  https://account.ghosterystage.com/en/subscription?target=subscribe if signed in but not already a supporter.