### PR TITLE
GH-1436: Collapse Scrolling Bug

### DIFF
--- a/app/scss/partials/_blocking.scss
+++ b/app/scss/partials/_blocking.scss
@@ -34,11 +34,10 @@
 	background-repeat: no-repeat;
 	background-image: url('../../app/images/panel/tracker-list-background.svg');
 	position: relative;
-	overflow: hidden;
+	overflow: scroll;
 	.scroll-content {
-		height: inherit;
+		height: auto;
 		overflow-y: scroll;
-		overflow-x: hidden;
 		.blocking-category {
 			&:last-of-type {
 				border-bottom: 1px solid #e8e8e8;


### PR DESCRIPTION
Only a few lines of CSS, but an important fix for:
• https://cliqztix.atlassian.net/browse/GH-1436

**Note**
I removed `overflow-x: hidden ` from `.blocking-trackers .scroll-content` because it did not appear to have any effect on the styling of the tracker list when I tested after removing that attribute. Please let me know if I'm missing something there.