### PR TITLE
GH-1435: Unexpected Expansion of Filtered Categories

### DIFF
--- a/app/panel/reducers/settings.js
+++ b/app/panel/reducers/settings.js
@@ -330,11 +330,6 @@ const _filter = (state, action) => {
 	updated_categories.forEach((category) => {
 		category.num_total = 0;
 		category.num_blocked = 0;
-		if (action.data === 'all') {
-			category.expanded = false;
-		} else {
-			category.expanded = true;
-		}
 		category.trackers.forEach((tracker) => {
 			switch (action.data) {
 				case 'all':

--- a/app/panel/reducers/settings.js
+++ b/app/panel/reducers/settings.js
@@ -315,8 +315,7 @@ const _updateSearchValue = (state, action) => {
 };
 
 /**
- * Expands categories with trackers selected
- * according to the specified filter.
+ * Hides or displays trackers according to the specified filter.
  * @memberOf  PanelReactReducers
  * @private
  *


### PR DESCRIPTION
JIRA Ticket:
• https://cliqztix.atlassian.net/browse/GH-1435

**Notes**
• This ticket was initially created due to confusion about the "Expand All" option still being available after all the filtered categories were expanded (ie. the only possible trackers to display were already expanded). After speaking with Teresa, we thought the best way forward was to uncouple the filter options from the expansion option completely.

• After looking to see how the filter action prop was passed down to the BlockingHeader component to ensure that I wasn't changing this function for other components that needed the same expansion functionality, I genuinely could not trace it to any relevant action files or containers (even with help from José). Pretty strange...