### PR TITLE
GH-1442: Edge Scroll Method Support

### DIFF
--- a/app/hub/Views/AppView/AppView.jsx
+++ b/app/hub/Views/AppView/AppView.jsx
@@ -32,7 +32,7 @@ class AppView extends Component {
 	 */
 	componentDidUpdate(prevProps) {
 		if (prevProps.children !== this.props.children) {
-			this.mainContent.current.scroll(0, 0);
+			this.mainContent.current.scrollIntoView(true);
 		}
 	}
 

--- a/app/hub/Views/AppView/AppView.jsx
+++ b/app/hub/Views/AppView/AppView.jsx
@@ -32,7 +32,7 @@ class AppView extends Component {
 	 */
 	componentDidUpdate(prevProps) {
 		if (prevProps.children !== this.props.children) {
-			this.mainContent.current.scrollIntoView(true);
+			this.mainContent.current.scrollTop = 0;
 		}
 	}
 


### PR DESCRIPTION
JIRA Ticket: https://cliqztix.atlassian.net/browse/GH-1442

**Notes**
Edge browser does not support `.scroll(0,0)` method on DOM elements, so I'm switching it to `.scrollTop = 0` on the mainContent element in the AppView component