### PR TITLE
GH-1448 Make the SignIn/VerifyAccount link an icon for all panel views

### DIFF
--- a/app/panel/components/Header.jsx
+++ b/app/panel/components/Header.jsx
@@ -95,9 +95,7 @@ class Header extends React.Component {
 	}
 
 	generateLink = () => {
-		const { location, loggedIn, user } = this.props;
-		const { pathname } = location;
-		const showTabs = (pathname === '/' || pathname.startsWith('/detail'));
+		const { loggedIn, user } = this.props;
 
 		let text = '';
 		let handleOnClick = null;
@@ -131,7 +129,7 @@ class Header extends React.Component {
 
 		return (
 			<div onClick={handleOnClick} className="header-helper-text">
-				{showTabs ? accountIcon : text}
+				{accountIcon}
 			</div>
 		);
 	}


### PR DESCRIPTION
The "Sign In" / "Verify Account" link was changed from text to an icon for the Summary Panel (Simple and Detailed) views only.  Now it is changed to an icon for all panels.