### PR TITLE
ABTest to switch users to new whitelist implementation

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -20,7 +20,7 @@
  */
 import _ from 'underscore';
 import moment from 'moment/min/moment-with-locales.min';
-import cliqz from './classes/Cliqz';
+import cliqz, { prefs } from './classes/Cliqz';
 // object classes
 import Events from './classes/EventHandlers';
 import PanelData from './classes/PanelData';
@@ -1136,6 +1136,9 @@ function setupABTest() {
 			log('antitracking', 'set config option', opt, val);
 			antitracking.action('setConfigOption', opt, val);
 		});
+	}
+	if (abtest.hasTest('antitracking_whitelist2')) {
+		prefs.set('attrackBloomFilter', false);
 	}
 }
 

--- a/src/classes/Cliqz.js
+++ b/src/classes/Cliqz.js
@@ -16,3 +16,4 @@ import CLIQZ from 'browser-core';
 import globals from './Globals';
 
 export default new (CLIQZ.App)({ debug: globals.DEBUG });
+export const { prefs } = CLIQZ;


### PR DESCRIPTION
We have a new implementation of the whitelist anti-tracking uses to detect trackers and fingerprints. This PR adds a abtest check to allow us to do a staged rollout to users once the next ghostery version is released.
