### PR TITLE
Prevent bugs being stored in chrome.storage (android)

### DIFF
--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -93,6 +93,9 @@ export function prefsSet(prefs) {
 	log('PREFS SET', prefs);
 	return new Promise(((resolve, reject) => {
 		if (typeof prefs !== 'undefined') {
+			if (prefs.bugs) {
+				delete prefs.bugs;
+			}
 			chrome.storage.local.set(prefs, () => {
 				if (chrome.runtime.lastError) {
 					log('prefsSet ERROR', chrome.runtime.lastError);


### PR DESCRIPTION
On android loading chrome.storage is slow and blocks startup while the data is loaded from disk and parsed. The bulk of the size is from `bugs`, which is around 500kb. When testing extension startup on android devices loading chrome storage blocks the JS thread for around 2s on startup. Removing `bugs` from chrome storage reduces this loading time to ~200ms. Loading the bugs list via fetch to an internal extension page does not seem to be as costly as from chrome storage.

This PR simply prevents `bugs` being stored in chrome storage, ensuring that bugs are always loaded from local resource. For longer term it would be good to have a nicer solution for this, but I am not familiar enough with the resource loading logic here.

@jsignanini @christophertino can you see any unintended side effects that this might cause? How should we fix this more permanently?