### PR TITLE
Count aggregate blocking stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/ghostery/ghostery-extension#readme",
   "dependencies": {
     "base64-js": "^1.2.1",
-    "browser-core": "https://s3.amazonaws.com/cdncliqz/update/edge/ghostery/v7.31/7.31.2.c8b8533.tgz",
+    "browser-core": "https://s3.amazonaws.com/cdncliqz/update/edge/ghostery/v7.31/7.31.4.284d902.tgz",
     "classnames": "^2.2.5",
     "d3": "^5.7.0",
     "foundation-sites": "^6.4.4-rc1",

--- a/src/background.js
+++ b/src/background.js
@@ -77,6 +77,7 @@ const humanweb = cliqz.modules['human-web'];
 const { adblocker, antitracking, hpn } = cliqz.modules;
 const messageCenter = cliqz.modules['message-center'] || moduleMock;
 const offers = cliqz.modules['offers-v2'] || moduleMock;
+const insights = cliqz.modules.insights || moduleMock;
 // add ghostery module to expose ghostery state to cliqz
 cliqz.modules.ghostery = new GhosteryModule();
 
@@ -1377,6 +1378,15 @@ messageCenter.on('enabled', () => {
 			}
 		});
 	});
+});
+
+insights.on('enabled', () => {
+	events.addPageListener((tab_id, info, apps, bugs) => {
+		cliqz.modules.insights.action('pushGhosteryPageStats', tab_id, info, apps, bugs);
+	});
+});
+insights.on('disabled', () => {
+	events.clearPageListeners();
 });
 
 /**

--- a/src/background.js
+++ b/src/background.js
@@ -69,12 +69,17 @@ const onBeforeRequest = events.onBeforeRequest.bind(events);
 const onHeadersReceived = events.onHeadersReceived.bind(events);
 
 // Cliqz Modules
+const moduleMock = {
+	isEnabled: false,
+	on: () => {},
+};
 const humanweb = cliqz.modules['human-web'];
 const { adblocker, antitracking, hpn } = cliqz.modules;
-const messageCenter = cliqz.modules['message-center'];
-const offers = cliqz.modules['offers-v2'];
+const messageCenter = cliqz.modules['message-center'] || moduleMock;
+const offers = cliqz.modules['offers-v2'] || moduleMock;
 // add ghostery module to expose ghostery state to cliqz
 cliqz.modules.ghostery = new GhosteryModule();
+
 let OFFERS_ENABLE_SIGNAL;
 
 /**

--- a/src/classes/EventHandlers.js
+++ b/src/classes/EventHandlers.js
@@ -44,6 +44,7 @@ class EventHandlers {
 		this.policy = new Policy();
 		this.policySmartBlock = new PolicySmartBlock();
 		this.purplebox = new PurpleBox();
+		this._pageListeners = new Set();
 
 		// Use leading:false so button.update is called after requests are complete.
 		// Use a 1sec interval to limit calls on pages with a large number of requests.
@@ -733,8 +734,28 @@ class EventHandlers {
 	 * @param  {number} tab_id
 	 */
 	_clearTabData(tab_id) {
+		const lastTabBugs = foundBugs.getBugs(tab_id);
+		const lastTabApps = foundBugs.getApps(tab_id);
+		const lastTabInfo = tabInfo.getTabInfo(tab_id);
 		foundBugs.clear(tab_id);
 		tabInfo.clear(tab_id);
+		if (lastTabInfo && lastTabBugs) {
+			this._pageListeners.forEach((fn) => {
+				fn(tab_id, lastTabInfo, lastTabApps, lastTabBugs);
+			});
+		}
+	}
+
+	addPageListener(fn) {
+		this._pageListeners.add(fn);
+	}
+
+	removePageListener(fn) {
+		this._pageListeners.delete(fn);
+	}
+
+	clearPageListeners() {
+		this._pageListeners.clear();
 	}
 
 	/**

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,12 +138,13 @@
     traceur "0.0.105"
     uglify-js "^2.6.1"
 
-"@cliqz/adblocker@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@cliqz/adblocker/-/adblocker-0.2.1.tgz#9545d185dad832e3dcc9605a5b260f2b1a8234fc"
-  integrity sha512-fPAg7Nh1zLneuBYtuiSsS/o30nbFhWgd/EVoaSsPwqpweCWbUwTT+zMkZBoVEtPTk6Y9XF0reqEIQ0Uf07t7RQ==
+"@cliqz/adblocker@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@cliqz/adblocker/-/adblocker-0.3.0.tgz#c16c0a09b949ee369d232409cb0eac8d7ec0795b"
+  integrity sha512-VwvF3AhOr9XOUOtO5BGjHKE2PsqvqSEXYhQPkWEf8n75CRUxvxPPE4LyHJiSXQwe4WeEgpkEGDOVcCJPMZeQHQ==
   dependencies:
     tldts "^3.0.0"
+    tslib "^1.9.3"
 
 "@sinonjs/formatio@3.0.0":
   version "3.0.0"
@@ -1752,13 +1753,13 @@ brorand@^1.0.1:
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
-"browser-core@https://s3.amazonaws.com/cdncliqz/update/edge/ghostery/v7.31/7.31.2.c8b8533.tgz":
-  version "7.31.2"
-  resolved "https://s3.amazonaws.com/cdncliqz/update/edge/ghostery/v7.31/7.31.2.c8b8533.tgz#4ebcfcc163a39e0d74b2bbe1f55301c646822157"
+"browser-core@https://s3.amazonaws.com/cdncliqz/update/edge/ghostery/v7.31/7.31.4.284d902.tgz":
+  version "7.31.4"
+  resolved "https://s3.amazonaws.com/cdncliqz/update/edge/ghostery/v7.31/7.31.4.284d902.tgz#8e26b6a9e724dee1b40dbb7c57307bef2f38f4e2"
   dependencies:
     "@cliqz-oss/dexie" "^2.0.4"
     "@cliqz-oss/systemjs-builder" "^0.16.13"
-    "@cliqz/adblocker" "^0.2.1"
+    "@cliqz/adblocker" "^0.3.0"
     BigInt "^5.5.3"
     ajv "^6.5.0"
     anonymous-credentials "https://github.com/cliqz-oss/anonymous-credentials/releases/download/0.1.1/anonymous-credentials-0.1.1.tgz"
@@ -9775,7 +9776,7 @@ truncate-utf8-bytes@^1.0.0:
   dependencies:
     utf8-byte-length "^1.0.1"
 
-tslib@^1.9.0:
+tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==


### PR DESCRIPTION
Counts aggregated stats for each page visit, combining ghostery apps, anti-tracking and adblocker interventions. 

## API

First, enable the module to start logging stats:
`CLIQZ.app.modules.insights.enable()`

After a few page loads, you can fetch accumulated stats:
```javascript
insights.action('getDashboardStats').then(...)
=> 
{
adsBlocked: 1
cookiesBlocked: 4
dataSaved: 0
day: "2018-11-20"
fingerprintsRemoved: 0
loadTime: 1605
pages: 1
timeSaved: 501
trackerRequestsBlocked: 13
trackers: [43, 109, 187, 288, 378, 599, 2148, 2453, 13, 41, "youtube", "google", "google_photos", "google_users"]
trackersBlocked: 10
trackersDetected: 14
}
```
The `trackers` attribute is a set of app Ids, or WhoTracks.Me ids for trackers seen in this time period.

You can currently query for the last day, week or month:
```javascript
insights.action('getDashboardStats', 'day').then(...)
insights.action('getDashboardStats', 'week').then(...)
insights.action('getDashboardStats', 'month').then(...)
```

I can provide different views on the data as required. Data is currently stored in day buckets so timeseries should be easy to add.
