### PR TITLE
webpack: try to load commonjs entry point before checking for es6 modules

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -142,7 +142,8 @@ const config = {
 	},
 	resolve: {
 		symlinks: false,
-		extensions: ['.js', '.jsx']
+		extensions: ['.js', '.jsx'],
+		mainFields: ['main', 'module'],
 	},
 	plugins: buildPlugins,
 	module: {


### PR DESCRIPTION
This will allow webpack to deduplicates imports (e.g.: `tldts` which is used in both browser-core and adblocker). Note that we will still need to update the browser-core version to benefit from this (as currently the adblocker ships bundles instead of raw source)

* [ ] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ ] Have you added an explanation of what your changes do?
* [ ] Does your submission pass tests?
* [ ] Did you lint your code prior to submission?
