### PR TITLE
Fix sign in tooltip alignment.

### DIFF
--- a/app/scss/partials/_tooltip.scss
+++ b/app/scss/partials/_tooltip.scss
@@ -69,14 +69,13 @@
 			}
 		}
 		&.bottom {
-			width: 150px;
-			top: 125%;
-			left: 50%;
-			margin-left: -60px;
+			width: 90px;
+			top: 97%;
+			left: -60px;
 			&:after {
 				bottom: calc(100% - 10px);  /* At the top of the tooltip */
-				left: 50%;
-				margin-left: -8px;
+				left: 100%;
+				margin-left: -7px;
 				border-width: 5px;
 				transform: rotate(135deg);
 			}


### PR DESCRIPTION
Bottom-left aligned the sign-in tooltip to ensure it doesn't run off the right edge of the panel regardless of how close the sign-in header icon is to that edge. Set width to minimum necessary to accommodate all supported languages without a line break (the longest string is the Hungarian, in case you were curious). Pushed tooltip up closer to the icon.

* [X ] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do?
* [X] Does your submission pass tests?
* [X] Did you lint your code prior to submission?
