### PR TITLE
GH-1426. Save new user email to store on account creation

### DIFF
--- a/app/panel/reducers/panel.js
+++ b/app/panel/reducers/panel.js
@@ -123,11 +123,14 @@ export default (state = initialState, action) => {
 			return Object.assign({}, state, updated);
 		}
 		case REGISTER_SUCCESS: {
-			action.payload.text = t('panel_email_verification_sent', action.payload.email);
+			const { email } = action.payload;
+			action.payload.text = t('panel_email_verification_sent', email);
 			action.payload.classes = 'success';
 			action.payload.overrideNotificationShown = true;
 			const updated = _showNotification(state, action);
-			return Object.assign({}, state, updated);
+			return Object.assign({}, state, updated, {
+				email
+			});
 		}
 		case REGISTER_FAIL: {
 			const { errors } = action.payload;


### PR DESCRIPTION
Updated REGISTER_SUCCESS action in reducers/panel.js to save the new user's email to the store so that it can be displayed back correctly on the account creation success page.

* [X] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do?
* [X] Does your submission pass tests?
* [X] Did you lint your code prior to submission?
