### PR TITLE
GH-1336: Send Historical Tracker Stats to Ghostery Tab Extension via Messaging

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1399,6 +1399,10 @@ messageCenter.on('enabled', () => {
 	});
 });
 
+/**
+ * Add page listeners for insights stats.
+ * @memberOf Background
+ */
 insights.on('enabled', () => {
 	events.addPageListener((tab_id, info, apps, bugs) => {
 		cliqz.modules.insights.action('pushGhosteryPageStats', tab_id, info, apps, bugs);
@@ -1407,6 +1411,32 @@ insights.on('enabled', () => {
 insights.on('disabled', () => {
 	events.clearPageListeners();
 });
+
+/**
+ * Pulls and aggregates data to be passed to Ghostery Tab extension.
+ * @memberOf Background
+ */
+function getDataForGhosteryTab() {
+	const passedData = {};
+	insights.action('getAllDays').then((data) => {
+		insights.action('getStatsTimeline', moment(data[0]), moment(), true, true).then((data) => {
+			const cumulativeData = {
+				adsBlocked: 0, cookiesBlocked: 0, dataSaved: 0, fingerprintsRemoved: 0, loadTime: 0, pages: 0, timeSaved: 0, trackerRequestsBlocked: 0, trackersBlocked: 0, trackersDetected: 0
+			};
+			data.forEach((entry) => {
+				Object.keys(cumulativeData).forEach((key) => {
+					cumulativeData[key] += entry[key];
+				});
+			});
+			passedData.cumulativeData = cumulativeData;
+		});
+	});
+	account.getUserSettings().then((settings) => {
+		passedData.adBlockEnabled = settings.enable_ad_block;
+		passedData.antiTrackingEnabled = settings.enable_anti_tracking;
+	});
+	return passedData;
+}
 
 /**
  * Initialize Ghostery panel.
@@ -1552,6 +1582,18 @@ function initializeEventListeners() {
 			rewards.panelPort = port;
 			rewards.panelPort.onDisconnect.addListener(rewards.panelHubClosedListener);
 		}
+	});
+
+	// Fired when another extension sends a message, accepts message if it's from Ghostery Tab
+	chrome.runtime.onMessageExternal.addListener((request, sender, sendResponse) => {
+		if (sender.id === globals.GHOSTERY_TAB_ID) {
+			const { name } = request;
+			if (name === 'getStatsAndSettings') {
+				sendResponse({ historicalDataAndSettings: getDataForGhosteryTab() });
+				return true;
+			}
+		}
+		return false;
 	});
 }
 

--- a/src/background.js
+++ b/src/background.js
@@ -1587,12 +1587,9 @@ function initializeEventListeners() {
 
 	// Fired when another extension sends a message, accepts message if it's from Ghostery Tab
 	chrome.runtime.onMessageExternal.addListener((request, sender, sendResponse) => {
-		if (sender.id === globals.GHOSTERY_TAB_ID) {
-			const { name } = request;
-			if (name === 'getStatsAndSettings') {
-				getDataForGhosteryTab(data => sendResponse({ historicalDataAndSettings: data }));
-				return true;
-			}
+		if (sender.id === globals.GHOSTERY_TAB_ID && request.name === 'getStatsAndSettings') {
+			getDataForGhosteryTab(data => sendResponse({ historicalDataAndSettings: data }));
+			return true;
 		}
 		return false;
 	});
@@ -1854,7 +1851,3 @@ function init() {
 
 // Initialize the application.
 init();
-
-// chrome.runtime.sendMessage('deegfjoplcahoocdeddpcdeemkaoldbg', { name: 'getStatsAndSettings' }, data => {
-// 	console.log(data);
-// });

--- a/src/classes/Globals.js
+++ b/src/classes/Globals.js
@@ -59,6 +59,9 @@ class Globals {
 		this.AUTH_SERVER = `https://consumerapi.${this.GHOSTERY_DOMAIN}.com`;
 		this.ACCOUNT_SERVER = `https://accountapi.${this.GHOSTERY_DOMAIN}.com`;
 
+		// extension IDs
+		this.GHOSTERY_TAB_ID = 'plmapebanmikcofllaaddgeocahboejc';
+
 		// data stores
 		this.REDIRECT_MAP = new Map();
 		this.BLOCKED_REDIRECT_DATA = {};


### PR DESCRIPTION
JIRA Ticket: https://cliqztix.atlassian.net/browse/GH-1336

**Notes**
This sets up a listener that waits for a message from another extension, and will execute a function that passes the locally stored historical stats (which are aggregated in that function) and some user settings if the extension ID associated with the message matches the Ghostery Tab extension and the name of the request is `'getStatsAndSettings'`. The Ghostery Tab needs this because it displays that information whenever a new tab is opened.