### PR TITLE
Show offer card instead of hot dog if user has explicitly opted in to…

### DIFF
--- a/app/content-scripts/rewards/OfferCard.jsx
+++ b/app/content-scripts/rewards/OfferCard.jsx
@@ -160,7 +160,6 @@ class OfferCard extends Component {
 	}
 
 	handlePrompt(promptNumber, option) {
-		// @TODO update user settings
 		if (promptNumber === 1) {
 			if (!option) {
 				sendMessage('ping', 'rewards_first_reject');
@@ -169,6 +168,7 @@ class OfferCard extends Component {
 				});
 				return;
 			}
+			this.props.actions.messageBackground('rewardsPromptOptedIn');
 			this.props.actions.sendSignal('offer_first_optin');
 			sendMessage('ping', 'rewards_first_accept');
 		} else if (promptNumber === 2) {

--- a/app/content-scripts/rewards/index.jsx
+++ b/app/content-scripts/rewards/index.jsx
@@ -183,9 +183,13 @@ class RewardsApp {
 	}
 
 	handleMessages(request) {
-		if (request.name === 'showHotDog') {
+		if (request.name === 'showOffer' || request.name === 'showHotDog') {
 			this.reward = request.reward;
 			this.conf = request.conf;
+		}
+
+		if (request.name === 'showOffer') {
+			history.push('/offercard');
 		}
 
 		// in FF 61 react sees some elements in iframes as non interactive

--- a/src/background.js
+++ b/src/background.js
@@ -492,6 +492,9 @@ function handleRewards(name, message, callback) {
 		case 'rewardsPromptAccepted':
 			conf.rewards_accepted = true;
 			break;
+		case 'rewardsPromptOptedIn':
+			conf.rewards_opted_in = true;
+			break;
 		case 'ping':
 			metrics.ping(message);
 			break;

--- a/src/background.js
+++ b/src/background.js
@@ -1394,7 +1394,7 @@ messageCenter.on('enabled', () => {
 					utils.getActiveTab((tab) => {
 						let tabId = 0;
 						if (tab) tabId = tab.id;
-						rewards.showHotDog(tabId, msg.data);
+						rewards.showHotDogOrOffer(tabId, msg.data);
 					});
 				}
 			}

--- a/src/classes/ConfData.js
+++ b/src/classes/ConfData.js
@@ -121,6 +121,7 @@ class ConfData {
 			_initProperty('notify_library_updates', false);
 			_initProperty('notify_upgrade_updates', true);
 			_initProperty('rewards_accepted', false);
+			_initProperty('rewards_opted_in', false);
 			_initProperty('settings_last_imported', 0);
 			_initProperty('settings_last_exported', 0);
 			_initProperty('show_alert', true);

--- a/src/classes/Rewards.js
+++ b/src/classes/Rewards.js
@@ -108,10 +108,11 @@ class Rewards {
 						if (!this.ports.has(tabId)) {
 							this.ports.set(tabId, port);
 							this.ports.get(tabId).onMessage.addListener((message) => {
+								const responseMessage = conf.rewards_opted_in ? 'showOffer' : 'showHotDog';
 								switch (message.name) {
 									case 'rewardsLoaded':
 										this.ports.get(tabId).postMessage({
-											name: 'showHotDog',
+											name: responseMessage,
 											reward: this.currentOffer,
 											conf: {
 												rewardsPromptAccepted: conf.rewards_accepted

--- a/src/classes/Rewards.js
+++ b/src/classes/Rewards.js
@@ -79,7 +79,7 @@ class Rewards {
 		prefsSet({ unreadOfferIds: this.unreadOfferIds }).then(() => { button.update(); });
 	}
 
-	showHotDog(tab_id, offer) {
+	showHotDogOrOffer(tab_id, offer) {
 		this.updateStoredOffers();
 		this.totalOffersSeen++;
 		prefsSet({ totalOffersSeen: this.totalOffersSeen });


### PR DESCRIPTION
Implements GH-1382:

Iff the user has explicitly opted in to rewards by clicking Yes on the first screen of the rewards offer card prompt, immediately show them the offer card on pages that would otherwise trigger the hot dog.

* [X] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do?
* [ ] Does your submission pass tests?
Tests are broken pending the completion and merging of https://github.com/ghostery/ghostery-extension/pull/266
* [X] Did you lint your code prior to submission?
