### PR TITLE
Fix: Historical Stats Routing

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -734,7 +734,7 @@
 	},
 	"panel_detail_menu_stats_title": {
 		"message": "Historical stats"
-	},	
+	},
 	"panel_detail_menu_premium_title": {
 		"message": "Premium"
 	},
@@ -2025,7 +2025,7 @@
 		"message": "Priority Support"
 	},
 	"subscription_history_stats": {
-		"message": "History Stats"
+		"message": "Historical Stats"
 	},
 	"subscribe_pitch": {
 		"message": "While Ghostery is free, you can choose to support us through a small subscription of &#36;2 per month in exchange for cool perks, such as color themes, priority help service, and more. Join our mission and subscribe!"
@@ -2123,28 +2123,28 @@
 		"message": "Data Points Anonymized"
 	},
 	"panel_stats_ads_blocked": {
-		"message": "Ads Blocked"		
+		"message": "Ads Blocked"
 	},
 	"panel_stats_total_trackers_seen": {
-		"message": "Total Trackers Seen"	
+		"message": "Total Trackers Seen"
 	},
 	"panel_stats_total_trackers_blocked": {
-		"message": "Total Trackers Blocked"	
+		"message": "Total Trackers Blocked"
 	},
 	"panel_stats_total_trackers_anonymized": {
-		"message": "Total Trackers Anonymized"	
+		"message": "Total Trackers Anonymized"
 	},
 	"panel_stats_total_ads_blocked": {
-		"message": "Total Ads Blocked"	
+		"message": "Total Ads Blocked"
 	},
 	"panel_stats_cumulative": {
-		"message": "Cumulative"	
+		"message": "Cumulative"
 	},
 	"panel_stats_monthly": {
-		"message": "Monthly"	
+		"message": "Monthly"
 	},
 	"panel_stats_daily": {
-		"message": "Daily"	
+		"message": "Daily"
 	},
 	"panel_stats_reset": {
 		"message": "Reset all stats"

--- a/app/panel/components/Header.jsx
+++ b/app/panel/components/Header.jsx
@@ -137,8 +137,9 @@ class Header extends React.Component {
 
 	determineBackPath = () => {
 		const { entries, location } = this.props.history;
+		const subscriptionRegEx = /^(\/subscription)/;
 		if (location.pathname === '/stats' && (entries.length > 1 &&
-		entries[entries.length - 2].pathname.slice(0, 13) === '/subscription')) {
+		subscriptionRegEx.test(entries[entries.length - 2].pathname))) {
 			return 'subscription/info';
 		}
 		return this.props.is_expert ? '/detail/blocking' : '/';

--- a/app/panel/components/Header.jsx
+++ b/app/panel/components/Header.jsx
@@ -135,6 +135,12 @@ class Header extends React.Component {
 	}
 
 	clickLogo = () => {
+		const { entries, location } = this.props.history;
+		if (location.pathname === '/stats' &&
+		entries[entries.length - 2].pathname === '/subscription/info') {
+			this.props.history.push('/subscription/info');
+			return;
+		}
 		this.props.history.push(this.props.is_expert ? '/detail/blocking' : '/');
 	}
 

--- a/app/panel/components/Header.jsx
+++ b/app/panel/components/Header.jsx
@@ -12,6 +12,7 @@
  */
 
 import React from 'react';
+import { Link } from 'react-router-dom';
 import ReactSVG from 'react-svg';
 import ClassNames from 'classnames';
 import Tooltip from './Tooltip';
@@ -134,14 +135,13 @@ class Header extends React.Component {
 		);
 	}
 
-	clickLogo = () => {
+	determineBackPath = () => {
 		const { entries, location } = this.props.history;
 		if (location.pathname === '/stats' && (entries.length > 1 &&
-			entries[entries.length - 2].pathname === '/subscription/info')) {
-			this.props.history.push('/subscription/info');
-			return;
+		entries[entries.length - 2].pathname.slice(0, 13) === '/subscription')) {
+			return 'subscription/info';
 		}
-		this.props.history.push(this.props.is_expert ? '/detail/blocking' : '/');
+		return this.props.is_expert ? '/detail/blocking' : '/';
 	}
 
 	clickBadge = () => {
@@ -191,8 +191,10 @@ class Header extends React.Component {
 					</div>
 				)}
 				<div className="top-bar">
-					<span onClick={this.clickLogo} className="header-logo">
-						<ReactSVG path="/app/images/panel/header-back-arrow.svg" className={headerArrowClasses} />
+					<span className="header-logo">
+						<Link to={this.determineBackPath()}>
+							<ReactSVG path="/app/images/panel/header-back-arrow.svg" className={headerArrowClasses} />
+						</Link>
 						<ReactSVG path="/app/images/panel/header-logo-icon.svg" className="logo-icon" />
 					</span>
 					<div>

--- a/app/panel/components/Header.jsx
+++ b/app/panel/components/Header.jsx
@@ -136,8 +136,8 @@ class Header extends React.Component {
 
 	clickLogo = () => {
 		const { entries, location } = this.props.history;
-		if (location.pathname === '/stats' &&
-		entries[entries.length - 2].pathname === '/subscription/info') {
+		if (location.pathname === '/stats' && (entries.length > 1 &&
+			entries[entries.length - 2].pathname === '/subscription/info')) {
 			this.props.history.push('/subscription/info');
 			return;
 		}

--- a/app/scss/partials/_header.scss
+++ b/app/scss/partials/_header.scss
@@ -50,7 +50,7 @@
 					display: inline-flex;
 					box-sizing: content-box;
 					margin: auto;
-					padding-right: 5px;
+					padding: 4px 7px 0 0;
 					width: 8px;
 					height: 13px;
 					div {


### PR DESCRIPTION
JIRA Ticket: https://cliqztix.atlassian.net/browse/GH-1427

**Notes**
Previously, the historical stats view would route back to the main view whenever you selected the back arrow in the header. In this branch, if you go to the historical stats view from the subscription menu, then it will now route back to the subscription menu.