### PR TITLE
Performance optimisations on critical path

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1093,8 +1093,8 @@ function initialiseWebRequestPipeline() {
  * @return {boolean}
  */
 function isWhitelisted(state) {
-	const { host } = state.sourceUrl.host;
-	return globals.SESSION.paused_blocking || state.ghosteryWhitelisted || events.policy.whitelisted(host) === 2;
+	const { host } = state.sourceUrlParts.host;
+	return globals.SESSION.paused_blocking || state.ghosteryWhitelisted || events.policy.whitelisted(host);
 }
 
 /**
@@ -1159,7 +1159,12 @@ adblocker.on('enabled', () => {
 				before: ['checkBlocklist']
 			}),
 			adblocker.action('addWhiteListCheck',
-				url => isWhitelisted({ sourceUrl: url }))
+				url => isWhitelisted({
+					sourceUrlParts: {
+						host: new URL(url)
+					}
+				})
+			)
 		])
 	);
 });

--- a/src/background.js
+++ b/src/background.js
@@ -1093,8 +1093,8 @@ function initialiseWebRequestPipeline() {
  * @return {boolean}
  */
 function isWhitelisted(state) {
-	const url = state.sourceUrl;
-	return globals.SESSION.paused_blocking || events.policy.getSitePolicy(url) === 2 || state.ghosteryWhitelisted;
+	const { host } = state.sourceUrl.host;
+	return globals.SESSION.paused_blocking || state.ghosteryWhitelisted || events.policy.whitelisted(host) === 2;
 }
 
 /**

--- a/src/classes/BrowserButton.js
+++ b/src/classes/BrowserButton.js
@@ -166,7 +166,7 @@ class BrowserButton {
 			if (trackerCount === '') {
 				this._setIcon(false, tabId, trackerCount, alert);
 			} else {
-				this._setIcon(!globals.SESSION.paused_blocking && !this.policy.whitelisted(new URL(tab.url).host), tabId, trackerCount, alert);
+				this._setIcon(!globals.SESSION.paused_blocking && !this.policy.whitelisted(new URL(tab.url).hostname), tabId, trackerCount, alert);
 			}
 		});
 	}

--- a/src/classes/BrowserButton.js
+++ b/src/classes/BrowserButton.js
@@ -166,7 +166,7 @@ class BrowserButton {
 			if (trackerCount === '') {
 				this._setIcon(false, tabId, trackerCount, alert);
 			} else {
-				this._setIcon(!globals.SESSION.paused_blocking && !this.policy.whitelisted(tab.url), tabId, trackerCount, alert);
+				this._setIcon(!globals.SESSION.paused_blocking && !this.policy.whitelisted(new URL(tab.url).host), tabId, trackerCount, alert);
 			}
 		});
 	}

--- a/src/classes/Policy.js
+++ b/src/classes/Policy.js
@@ -118,7 +118,7 @@ class Policy {
 	 * @param  {string} tab_url 	tab url
 	 * @return {BlockWithReason}	block result with reason
 	 */
-	shouldBlock(app_id, cat_id, tab_id, tab_host, tab_url) {
+	shouldBlock(app_id, cat_id, tab_id, tab_host) {
 		if (globals.SESSION.paused_blocking) {
 			return { block: false, reason: BLOCK_REASON_BLOCK_PAUSED };
 		}

--- a/src/classes/Policy.js
+++ b/src/classes/Policy.js
@@ -46,12 +46,14 @@ class Policy {
 	 * @return {boolean}
 	 */
 	getSitePolicy(url) {
-		const { host } = processUrl(url);
-		if (this.blacklisted(host)) {
-			return 1;
-		}
-		if (this.whitelisted(host)) {
-			return 2;
+		if (url) {
+			const { hostname } = processUrl(url);
+			if (this.blacklisted(hostname)) {
+				return 1;
+			}
+			if (this.whitelisted(hostname)) {
+				return 2;
+			}
 		}
 		return false;
 	}

--- a/src/classes/Policy.js
+++ b/src/classes/Policy.js
@@ -46,10 +46,11 @@ class Policy {
 	 * @return {boolean}
 	 */
 	getSitePolicy(url) {
-		if (this.blacklisted(url)) {
+		const { host } = processUrl(url);
+		if (this.blacklisted(host)) {
 			return 1;
 		}
-		if (this.whitelisted(url)) {
+		if (this.whitelisted(host)) {
 			return 2;
 		}
 		return false;
@@ -60,10 +61,9 @@ class Policy {
 	 * @param  {string} url 		site url
 	 * @return {string|boolean} 	corresponding whitelist entry or false, if none
 	 */
-	whitelisted(url) {
-		if (url) {
-			url = processUrl(url).host;
-			url = url.replace(/^www\./, '');
+	whitelisted(host) {
+		if (host) {
+			const url = host.replace(/^www\./, '');
 			const sites = conf.site_whitelist || [];
 			const num_sites = sites.length;
 
@@ -84,10 +84,9 @@ class Policy {
 	 * @param  {string} url 		site url
 	 * @return {string|boolean} 	corresponding blacklist entry or false, if none
 	 */
-	blacklisted(url) {
-		if (url) {
-			url = processUrl(url).host;
-			url = url.replace(/^www\./, '');
+	blacklisted(host) {
+		if (host) {
+			const url = host.replace(/^www\./, '');
 			const sites = conf.site_blacklist || [];
 			const num_sites = sites.length;
 
@@ -126,13 +125,13 @@ class Policy {
 
 		if (conf.selected_app_ids.hasOwnProperty(app_id)) {
 			if (conf.toggle_individual_trackers && conf.site_specific_unblocks.hasOwnProperty(tab_host) && conf.site_specific_unblocks[tab_host].includes(+app_id)) {
-				if (this.blacklisted(tab_url)) {
+				if (this.blacklisted(tab_host)) {
 					const allowedOnce = c2pDb.allowedOnce(tab_id, app_id);
 					return { block: !allowedOnce, reason: allowedOnce ? BLOCK_REASON_C2P_ALLOWED_ONCE : BLOCK_REASON_BLACKLISTED };
 				}
 				return { block: false, reason: BLOCK_REASON_SS_UNBLOCKED };
 			}
-			if (this.whitelisted(tab_url)) {
+			if (this.whitelisted(tab_host)) {
 				return { block: false, reason: BLOCK_REASON_WHITELISTED };
 			}
 			const allowedOnce = c2pDb.allowedOnce(tab_id, app_id);
@@ -140,13 +139,13 @@ class Policy {
 		}
 		// We get here when app_id is not selected for blocking
 		if (conf.toggle_individual_trackers && conf.site_specific_blocks.hasOwnProperty(tab_host) && conf.site_specific_blocks[tab_host].includes(+app_id)) {
-			if (this.whitelisted(tab_url)) {
+			if (this.whitelisted(tab_host)) {
 				return { block: false, reason: BLOCK_REASON_WHITELISTED };
 			}
 			const allowedOnce = c2pDb.allowedOnce(tab_id, app_id);
 			return { block: !allowedOnce, reason: allowedOnce ? BLOCK_REASON_C2P_ALLOWED_ONCE : BLOCK_REASON_SS_BLOCKED };
 		}
-		if (this.blacklisted(tab_url)) {
+		if (this.blacklisted(tab_host)) {
 			const allowedOnce = c2pDb.allowedOnce(tab_id, app_id);
 			return { block: !allowedOnce, reason: allowedOnce ? BLOCK_REASON_C2P_ALLOWED_ONCE : BLOCK_REASON_BLACKLISTED };
 		}

--- a/src/utils/matcher.js
+++ b/src/utils/matcher.js
@@ -40,9 +40,7 @@ export function isBug(src, tab_url) {
 		// class 1: check host hash
 		_matchesHost(db.patterns.host, processedSrc.host) ||
 		// class 3: check path hash
-		_matchesPath(processedSrc.path) ||
-		// class 4: check regex patterns
-		_matchesRegex(processedSrc.host_with_path);
+		_matchesPath(processedSrc.path);
 
 	if (typeof tab_url !== 'undefined') {
 		// check firstPartyExceptions
@@ -180,28 +178,6 @@ function _matchesHost(root, src_host, src_path) {
 	}
 
 	return bug_id;
-}
-
-// can still produce false positives (when something that
-// matches a tracker is in the path somewhere, for example)
-/**
- * Match a url against a list of regular expression which are mapped to bug ids.
- * @private
- *
- * @param {string} 	src			a url to find a matching entry for
- *
- * @return {int|boolean} 		bug id or false if the match was not found
- */
-function _matchesRegex(src) {
-	const regexes = bugDb.db.patterns.regex;
-
-	for (const bug_id in regexes) {
-		if (regexes[bug_id].test(src)) {
-			return +bug_id;
-		}
-	}
-
-	return false;
 }
 
 /**

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -158,7 +158,7 @@ export function processUrl(src) {
 	if (!src) {
 		return {};
 	}
-	const res = url.parse(src);
+	const res = new URL(src);
 
 	return {
 		protocol: res.protocol ? res.protocol.substr(0, res.protocol.length - 1) : '',

--- a/test/src/matcher.test.js
+++ b/test/src/matcher.test.js
@@ -106,15 +106,15 @@ describe('src/utils/matcher.js', () => {
 	describe('testing isBug()', () => {
 		describe('testing basic pattern matching', () => {
 			test('host+path tracker matching works', () => {
-				return expect(isBug('https://apis.google.com/js/plusone.js', 'example.com')).toBe(1240);
+				return expect(isBug('https://apis.google.com/js/plusone.js', 'https://example.com')).toBe(1240);
 			});
 
 			test('path only tracker matching works', () => {
-				return expect(isBug('https://apis.google.com/js/tracking.js', 'example.com')).toBe(13);
+				return expect(isBug('https://apis.google.com/js/tracking.js', 'https://example.com')).toBe(13);
 			});
 
 			test('pattern matching is case insensitive', () => {
-				return expect(isBug('https://APIS.Google.com/js/Tracking.js', 'example.com')).toBe(13);
+				return expect(isBug('https://APIS.Google.com/js/Tracking.js', 'https://example.com')).toBe(13);
 			});
 		});
 


### PR DESCRIPTION
Performance improvements to webrequest handling for android build.

 1. Use native url parsing from `URL` class.
 2. Avoid 4+ redundant parses of the tab url in `isWhitelist` checks.
 3. Drop regex matching.

@chrmod 