### PR TITLE
Account for singular case for day/hour/etc reward-expiration strings

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1935,16 +1935,16 @@
 		}
 	},
 	"rewards_expires_in_days": {
-		"message": "days"
+		"message": "day(s)"
 	},
 	"rewards_expires_in_hours": {
-		"message": "hours"
+		"message": "hour(s)"
 	},
 	"rewards_expires_in_mins": {
-		"message": "minutes"
+		"message": "minute(s)"
 	},
 	"rewards_expires_in_secs": {
-		"message": "seconds"
+		"message": "second(s)"
 	},
 	"rewards_terms_conditions": {
 		"message": "Terms & Conditions"


### PR DESCRIPTION
Update English-language strings used to notify user how much longer an offer is available for to account for when there's only one of that time unit left. E.g. 'days' -> 'day(s)'.

* [x] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do?
* [x] Does your submission pass tests?
* [x] Did you lint your code prior to submission?
