### PR TITLE
Make terms & conditions tooltip bigger so that longer T&C fit

### DIFF
--- a/app/panel/components/BuildingBlocks/RewardDetail.jsx
+++ b/app/panel/components/BuildingBlocks/RewardDetail.jsx
@@ -142,7 +142,7 @@ class RewardDetail extends React.Component {
 							<span className="RewardDetail__terms">
 								{ t('rewards_terms_conditions') }
 							</span>
-							<Tooltip header={conditions} position="top" delay="0" theme="dark" />
+							<Tooltip header={conditions} position="top-left-wide" delay="0" theme="dark" />
 						</div>
 					)}
 				</div>

--- a/app/scss/partials/_tooltip.scss
+++ b/app/scss/partials/_tooltip.scss
@@ -38,12 +38,23 @@
 		}
 		&.top {
 			width: 150px;
-			bottom: 140%;
 			left: 50%;
+			&:after {
+				left: 50%;
+			}
+		}
+		&.top-left-wide {
+			width: 375px;
+			left: -200px;
+			&:after {
+				left: 83.5%;
+			}
+		}
+		&.top, &.top-left-wide {
+			bottom: 140%;
 			margin-left: -75px;
 			&:after {
 				top: 100%; /* At the bottom of the tooltip */
-				left: 50%;
 				margin-left: -10px;
 				transform: rotate(-45deg);
 			}


### PR DESCRIPTION
Addresses https://cliqztix.atlassian.net/browse/GH-1424.

Widen tooltip that displays terms and conditions for offers. Move its tick to right. Change its css class accordingly.

* [x] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do?
* [x] Does your submission pass tests?
* [x] Did you lint your code prior to submission?
