### PR TITLE
FIX: Change where demo state is set to avoid the graph blinking

### DIFF
--- a/app/panel/components/Stats.jsx
+++ b/app/panel/components/Stats.jsx
@@ -23,7 +23,7 @@ import { sendMessage, sendMessageInPromise, openSubscriptionPage } from '../util
 class Stats extends React.Component {
 	constructor(props) {
 		super(props);
-		this.state = this._reset(true);
+		this.state = this._reset();
 	}
 	/**
 	 * Lifecycle event
@@ -31,6 +31,8 @@ class Stats extends React.Component {
 	componentDidMount() {
 		sendMessage('ping', 'hist_stats_panel');
 		if (!this._isSupporter(this.props)) {
+			// eslint-disable-next-line
+			this.setState(this._reset(true));
 			return;
 		}
 		this._init();


### PR DESCRIPTION
Previously, on a slower load time the graph would display the beginning of an animation showing the demo graph because it was setting the demo state in the constructor. I moved that logic into the `componentDidMount()` lifecycle method to avoid this blinking behavior.

**Note**
I disabled eslint for the line in `componentDidMount()` where I set the state because it doesn't want state change there. There are many times where we do this, both in this component and other comonents, by simply moving the `this.setState()` call into another function that is called in `componentDidMount()`.

* [x] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do?
* [x] Does your submission pass tests?
* [x] Did you lint your code prior to submission?
