### PR TITLE
FIX: Correctly Aggregate Monthly Data

### DIFF
--- a/app/panel/components/Stats.jsx
+++ b/app/panel/components/Stats.jsx
@@ -378,12 +378,14 @@ class Stats extends React.Component {
 						monthTrackersAnonymized += dataItem.cookiesBlocked + dataItem.fingerprintsRemoved;
 						monthAdsBlocked += dataItem.adsBlocked;
 					} else {
-						const beginOfMonth = moment(endOfMonth).startOf('month');
+						if (moment(dataItem.day).isSameOrBefore(endOfMonth) && i === allData.length - 1) {
+							monthTrackersSeen += dataItem.trackersDetected;
+							monthTrackersBlocked += dataItem.trackersBlocked;
+							monthTrackersAnonymized += dataItem.cookiesBlocked + dataItem.fingerprintsRemoved;
+							monthAdsBlocked += dataItem.adsBlocked;
+						}
 
-						monthTrackersSeen += dataItem.trackersDetected;
-						monthTrackersBlocked += dataItem.trackersBlocked;
-						monthTrackersAnonymized += dataItem.cookiesBlocked + dataItem.fingerprintsRemoved;
-						monthAdsBlocked += dataItem.adsBlocked;
+						const beginOfMonth = moment(endOfMonth).startOf('month');
 
 						const monthlyObj = {
 							date: beginOfMonth.format('YYYY-MM-DD'),
@@ -407,10 +409,10 @@ class Stats extends React.Component {
 
 						endOfMonth = moment(dataItem.day).endOf('month');
 
-						monthTrackersSeen = 0;
-						monthTrackersBlocked = 0;
-						monthTrackersAnonymized = 0;
-						monthAdsBlocked = 0;
+						monthTrackersSeen = dataItem.trackersDetected;
+						monthTrackersBlocked = dataItem.trackersBlocked;
+						monthTrackersAnonymized = dataItem.cookiesBlocked + dataItem.fingerprintsRemoved;
+						monthAdsBlocked = dataItem.adsBlocked;
 					}
 				});
 				// Cumulative data totals


### PR DESCRIPTION
I noticed that the first day of each month was actually being added to the previous month rather than the current one, so I've changed the logic in the `_init()` class method to correct that. I also added in logic to handle the case where the iterator is currently on last day in the data set.

* [x] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do?
* [x] Does your submission pass tests?
* [x] Did you lint your code prior to submission?
