### PR TITLE
Synchronize steps when switching rewards on/off

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1087,24 +1087,28 @@ function initializeDispatcher() {
 			setCliqzModuleEnabled(humanweb, false);
 		}
 	});
-	dispatcher.on('conf.save.enable_offers', (enableOffers) => {
+	dispatcher.on('conf.save.enable_offers', (enableOffersIn) => {
 		button.update();
-		if (!IS_EDGE && !IS_CLIQZ) {
-			if (!enableOffers) {
-				const actions = cliqz &&
+		let firstStep = Promise.resolve();
+		let enableOffers = enableOffersIn;
+		if (IS_EDGE || IS_CLIQZ) {
+			enableOffers = false;
+		} else if (!enableOffers) {
+			const actions = cliqz &&
 				cliqz.modules['offers-v2'] &&
 				cliqz.modules['offers-v2'].background &&
 				cliqz.modules['offers-v2'].background.actions;
-				if (actions) {
-					actions.flushSignals();
-				}
-				OFFERS_ENABLE_SIGNAL = undefined;
-				registerWithOffers(offers, enableOffers);
+			if (actions) {
+				firstStep = actions.flushSignals();
 			}
-			setCliqzModuleEnabled(offers, enableOffers);
+			OFFERS_ENABLE_SIGNAL = undefined;
+		}
+		const toggleModule = () => setCliqzModuleEnabled(offers, enableOffers);
+		const toggleConnection = () => registerWithOffers(offers, enableOffers);
+		if (enableOffers) {
+			firstStep.then(toggleModule).then(toggleConnection);
 		} else {
-			setCliqzModuleEnabled(offers, false);
-			registerWithOffers(offers, false);
+			firstStep.then(toggleConnection).then(toggleModule);
 		}
 	});
 	dispatcher.on('conf.save.enable_anti_tracking', (enableAntitracking) => {


### PR DESCRIPTION
When disabling Ghostery Rewards in Chrome, error messages appear in the browser console:
```background.js:formatted:100329 Uncaught (in promise) TypeError: Cannot read property 'offer_triggered' of null
at background.js:formatted:100329
at Generator.next (<anonymous>)
at r (background.js:formatted:100265)
at background.js:formatted:100272
...
```
The problem is due to a race condition: offers-module is disabled before the signals are flushed.

The new code for `dispatcher.on('conf.save.enable_offers', ...)` synchronizes the calls. It is easier to review the new code as whole than as diffs.

* [x] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do?
* [ ] Does your submission pass tests?
* [ ] Did you lint your code prior to submission?
