### PR TITLE
Instantiate the global variable CLIQZ

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -50,6 +50,10 @@ import * as utils from './utils/utils';
 import { _getJSONAPIErrorsObject } from './utils/api';
 import { importCliqzSettings } from './utils/cliqzSettingImport';
 
+// For debug purposes, provide Access to the internals of `browser-core`
+// module from Developer Tools Console.
+window.CLIQZ = cliqz;
+
 // class instantiation
 const events = new Events();
 const panelData = new PanelData();


### PR DESCRIPTION
For `browser-core` module troubleshooting we use the global variable `CLIQZ` from Developer Tools Console. Recently, `browser-core` stopped to create this variable automatically and now it is the task of what uses `browser-core`.

* [x] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do?
* [ ] Does your submission pass tests?
* [x] Did you lint your code prior to submission?
