### PR TITLE
Compatibility with the Adblocker API in browser-core v7.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "babel-core": "^7.0.0-bridge.0"
   },
   "dependencies": {
-    "@cliqz/adblocker": "0.3.1",
     "base64-js": "^1.2.1",
     "browser-core": "https://s3.amazonaws.com/cdncliqz/update/edge/ghostery/v7.35/7.35.1.8ec615c.tgz",
     "classnames": "^2.2.5",

--- a/src/background.js
+++ b/src/background.js
@@ -1293,19 +1293,7 @@ antitracking.on('enabled', () => {
  * @memberOf Background
  */
 adblocker.on('enabled', () => {
-	adblocker.isReady().then(() =>
-		Promise.all([
-			adblocker.action('removePipelineStep', 'checkWhitelist'),
-			adblocker.action('addPipelineStep', {
-				name: 'checkGhosteryWhitelist',
-				spec: 'break',
-				fn: state => !isWhitelisted(state),
-				before: ['checkBlocklist']
-			}),
-			adblocker.action('addWhiteListCheck',
-				url => isWhitelisted({ sourceUrl: url }))
-		])
-	);
+	adblocker.isReady().then(() => adblocker.action('addWhiteListCheck', url => isWhitelisted({ sourceUrl: url })));
 });
 
 /**


### PR DESCRIPTION
When we upgrade to browser-core 7.36 (or higher), the API of the Adblocker will change. This patch shows how to updates the API in Ghostery.

Do not merge before upgrading to browser-core 7.36.

* [ ] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ ] Have you added an explanation of what your changes do?
* [ ] Does your submission pass tests?
* [ ] Did you lint your code prior to submission?
