### PR TITLE
Panel data get user settings for panel view fixes

### DIFF
--- a/src/classes/PanelData.js
+++ b/src/classes/PanelData.js
@@ -454,8 +454,15 @@ class PanelData {
 			current_theme, enable_ad_block, enable_anti_tracking, enable_smart_block,
 			is_expanded, is_expert, reload_banner_status, trackers_banner_status,
 		} = userSettings;
+		const currentAccount = conf.account;
+		if (currentAccount && currentAccount.user) {
+			currentAccount.user.subscriptionsPlus = account.hasScopesUnverified(['subscriptions:plus']);
+		}
 
-		this._postMessage('panel', {
+		console.log('IVZ currentAccount in _ghetUserSettingsForPanelView:');
+		console.log(currentAccount);
+
+		return {
 			current_theme,
 			enable_ad_block,
 			enable_anti_tracking,
@@ -464,7 +471,8 @@ class PanelData {
 			is_expert,
 			reload_banner_status,
 			trackers_banner_status,
-		});
+			account: currentAccount
+		};
 	}
 
 	/**

--- a/src/classes/PanelData.js
+++ b/src/classes/PanelData.js
@@ -254,7 +254,7 @@ class PanelData {
 
 	/**
 	 * Helper that retrieves the current account information
-	 * @return {Object / null}	the current account object or null
+	 * @return {Object|null}	the current account object or null
 	 */
 	_getCurrentAccount() {
 		const currentAccount = conf.account;

--- a/src/classes/PanelData.js
+++ b/src/classes/PanelData.js
@@ -253,6 +253,18 @@ class PanelData {
 	}
 
 	/**
+	 * Helper that retrieves the current account information
+	 * @return {Object / null}	the current account object or null
+	 */
+	_getCurrentAccount() {
+		const currentAccount = conf.account;
+		if (currentAccount && currentAccount.user) {
+			currentAccount.user.subscriptionsPlus = account.hasScopesUnverified(['subscriptions:plus']);
+		}
+		return currentAccount;
+	}
+
+	/**
 	 * Gets the data needed to update the Blocking view as a tab loads
 	 * @return	{Object}	the scan status, page url, and categories data that may change as new trackers are discovered on the page
 	 */
@@ -283,7 +295,8 @@ class PanelData {
 
 		return {
 			needsReload: needsReload || { changes: {} },
-			smartBlock
+			smartBlock,
+			account: this._getCurrentAccount(),
 		};
 	}
 
@@ -311,10 +324,6 @@ class PanelData {
 	_getPanelData() {
 		if (!this._activeTab) { return {}; }
 
-		const currentAccount = conf.account;
-		if (currentAccount && currentAccount.user) {
-			currentAccount.user.subscriptionsPlus = account.hasScopesUnverified(['subscriptions:plus']);
-		}
 		const { id: tab_id } = this._activeTab;
 		const {
 			enable_ad_block, enable_anti_tracking, enable_smart_block,
@@ -338,7 +347,6 @@ class PanelData {
 				current_theme,
 				tab_id,
 				unread_offer_ids: rewards.unreadOfferIds,
-				account: currentAccount,
 			},
 			this._getDynamicPanelData(tab_id),
 		);
@@ -454,13 +462,6 @@ class PanelData {
 			current_theme, enable_ad_block, enable_anti_tracking, enable_smart_block,
 			is_expanded, is_expert, reload_banner_status, trackers_banner_status,
 		} = userSettings;
-		const currentAccount = conf.account;
-		if (currentAccount && currentAccount.user) {
-			currentAccount.user.subscriptionsPlus = account.hasScopesUnverified(['subscriptions:plus']);
-		}
-
-		console.log('IVZ currentAccount in _ghetUserSettingsForPanelView:');
-		console.log(currentAccount);
 
 		return {
 			current_theme,
@@ -471,7 +472,7 @@ class PanelData {
 			is_expert,
 			reload_banner_status,
 			trackers_banner_status,
-			account: currentAccount
+			account: this._getCurrentAccount(),
 		};
 	}
 


### PR DESCRIPTION
Explicitly send null or the account object to panel for account value for any updates that run the UPDATE_PANEL_DATA action in the Account reducer

Return object from getUserSettingsForPanelView instead of calling _postMessage with it

* [X] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do?
* [X] Does your submission pass tests?
* [X] Did you lint your code prior to submission?
