### PR TITLE
Fix failure to display rewards data correctly in Panel rewards view

### DIFF
--- a/src/classes/PanelData.js
+++ b/src/classes/PanelData.js
@@ -373,8 +373,8 @@ class PanelData {
 
 		return {
 			enable_offers: conf.enable_offers,
-			storedOffers,
-			unreadOfferIds,
+			rewards: storedOffers,
+			unread_offer_ids: unreadOfferIds,
 		};
 	}
 


### PR DESCRIPTION
Rewards view was always incorrectly showing rewards as loading. This fixes that so that we see a 'no rewards' message if there are no rewards and the list of rewards if there are some.

* [X] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do?
* [X] Does your submission pass tests?
* [X] Did you lint your code prior to submission?
