### PR TITLE
Bugfix/trust restrict pause hover state colors

### DIFF
--- a/app/scss/partials/_ghostery_feature.scss
+++ b/app/scss/partials/_ghostery_feature.scss
@@ -63,19 +63,13 @@
 	border-color: #cccccc;
 	background-color: $white;
 	box-shadow: inset 0 0 0 0 rgba($white, 0);
-	&:hover {
-		//background-color: #0093bd;
-		background-color: $ghosty-blue;
-		color: $tundora;
-	}
+	&:hover { color: $tundora; }
 
-	&.trust .GhosteryFeatureButton__text {
-		background-image: buildIconTrust($tundora);
-	}
+	&.trust:hover { background-color: $atlantis; }
+	&.trust .GhosteryFeatureButton__text { background-image: buildIconTrust($tundora); }
 
-	&.restrict .GhosteryFeatureButton__text {
-		background-image: buildIconRestrict($tundora);
-	}
+	&.restrict:hover { background-color: $red; }
+	&.restrict .GhosteryFeatureButton__text { background-image: buildIconRestrict($tundora); }
 }
 
 .GhosteryFeatureButton--inactive.not-clickable {
@@ -102,7 +96,7 @@
 		background-color: $atlantis;
 		box-shadow: inset 0px 1px 7px 2px #85b329;
 	}
-	&.trust:hover { background-color: $ghosty-blue; }
+	&.trust:hover { box-shadow: none; }
 	&.trust .GhosteryFeatureButton__text {
 		background-image: buildIconTrust($white);
 	}
@@ -112,7 +106,7 @@
 		background-color: $red;
 		box-shadow: inset 0px 1px 7px 2px #ce273c;
 	}
-	&.restrict:hover { background-color: $ghosty-blue; }
+	&.restrict:hover { box-shadow: none; }
 	&.restrict .GhosteryFeatureButton__text {
 		background-image: buildIconRestrict($white);
 	}

--- a/app/scss/partials/_ghostery_feature.scss
+++ b/app/scss/partials/_ghostery_feature.scss
@@ -64,7 +64,8 @@
 	background-color: $white;
 	box-shadow: inset 0 0 0 0 rgba($white, 0);
 	&:hover {
-		background-color: #0093bd;
+		//background-color: #0093bd;
+		background-color: $ghosty-blue;
 		color: $tundora;
 	}
 
@@ -101,7 +102,7 @@
 		background-color: $atlantis;
 		box-shadow: inset 0px 1px 7px 2px #85b329;
 	}
-	&.trust:hover { background-color: #85b329; }
+	&.trust:hover { background-color: $ghosty-blue; }
 	&.trust .GhosteryFeatureButton__text {
 		background-image: buildIconTrust($white);
 	}
@@ -111,7 +112,7 @@
 		background-color: $red;
 		box-shadow: inset 0px 1px 7px 2px #ce273c;
 	}
-	&.restrict:hover { background-color: #ce273c; }
+	&.restrict:hover { background-color: $ghosty-blue; }
 	&.restrict .GhosteryFeatureButton__text {
 		background-image: buildIconRestrict($white);
 	}

--- a/app/scss/partials/_pause_button.scss
+++ b/app/scss/partials/_pause_button.scss
@@ -36,6 +36,7 @@
 	.button.active:hover {
 		border-color: #0093bd;
 		background-color: $ghosty-blue;
+		box-shadow: none;
 	}
 
 	.button-pause {

--- a/app/scss/partials/_pause_button.scss
+++ b/app/scss/partials/_pause_button.scss
@@ -32,10 +32,10 @@
 			border-left-color: #efefea;
 		}
 	}
-	.button:hover { background-color: #0093bd; }
+	.button:hover { background-color: $ghosty-blue; }
 	.button.active:hover {
 		border-color: #0093bd;
-		background-color: #0093bd;
+		background-color: $ghosty-blue;
 	}
 
 	.button-pause {


### PR DESCRIPTION
Restores color-on-hover behavior of trust, restrict, and pause buttons to what's in production, while retaining the disabling of hover on trust and restrict while extension is paused.

* [X] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do?
* [X] Does your submission pass tests?
* [X] Did you lint your code prior to submission?
