### PR TITLE
GH-1799: Fix Sitewide Trust/Restrict & Update UI for Consistency

### DIFF
--- a/app/panel/components/Blocking/Categories.jsx
+++ b/app/panel/components/Blocking/Categories.jsx
@@ -34,6 +34,7 @@ class Categories extends React.Component {
 			expandAll,
 			antiTracking,
 			enable_anti_tracking,
+			sitePolicy,
 		} = this.props;
 		const globalBlocking = !!this.props.globalBlocking;
 		const filtered = !!this.props.filtered;
@@ -55,6 +56,7 @@ class Categories extends React.Component {
 							name: unknownTracker.name,
 							domains: unknownTracker.domains,
 							whitelisted: unknownTracker.whitelisted,
+							siteRestricted: sitePolicy === 1,
 							blocked: false,
 							catId: 'anti_tracking_unknown',
 							description: '',

--- a/app/panel/components/Blocking/Category.jsx
+++ b/app/panel/components/Blocking/Category.jsx
@@ -230,7 +230,7 @@ class Category extends React.Component {
 									</span>
 								</div>
 								{((!isUnknown && !!trackersBlockedCount)
-								|| (isUnknown && !!category.whitelistedTotal)) && (
+								|| (isUnknown && !!category.whitelistedTotal && sitePolicy !== 1)) && (
 									<div className={`blocked-count${isUnknown ? ' ghosty-blue' : ''}`}>
 										<span className="count">
 											{isUnknown ? `${category.whitelistedTotal} ` : `${trackersBlockedCount} `}

--- a/app/panel/components/Blocking/Tracker.jsx
+++ b/app/panel/components/Blocking/Tracker.jsx
@@ -316,7 +316,7 @@ class Tracker extends React.Component {
 		}
 
 		const trackerNameClasses = ClassNames('trk-name', {
-			'is-whitelisted': tracker.whitelisted,
+			'is-whitelisted': tracker.whitelisted && !tracker.siteRestricted,
 		});
 
 		return (
@@ -344,6 +344,7 @@ class Tracker extends React.Component {
 						) : renderUnknownTrackerButtons(
 							this.handleAntiTrackingWhitelist,
 							tracker.whitelisted,
+							tracker.siteRestricted,
 						)}
 					</div>
 				</div>

--- a/app/panel/components/Blocking/trackerButtonRenderHelpers.jsx
+++ b/app/panel/components/Blocking/trackerButtonRenderHelpers.jsx
@@ -53,8 +53,13 @@ export const renderKnownTrackerButtons = (
 	</div>
 );
 
-export const renderUnknownTrackerButtons = (handleAntiTrackingWhitelist, whitelisted) => {
-	const svgContainerClasses = ClassNames('unknown-svg-container', { whitelisted });
+export const renderUnknownTrackerButtons = (
+	handleAntiTrackingWhitelist, whitelisted, siteRestricted
+) => {
+	const svgContainerClasses = ClassNames('unknown-svg-container', {
+		whitelisted: whitelisted && !siteRestricted,
+		siteRestricted,
+	});
 
 	return (
 		<div className={svgContainerClasses}>

--- a/app/scss/partials/_blocking_tracker.scss
+++ b/app/scss/partials/_blocking_tracker.scss
@@ -184,6 +184,10 @@
 				visibility: visible;
 			}
 		}
+
+		&.siteRestricted {
+			pointer-events: none;
+		}
 	}
 }
 

--- a/src/background.js
+++ b/src/background.js
@@ -1279,11 +1279,8 @@ function initialiseWebRequestPipeline() {
  * @return {boolean}
  */
 function isWhitelisted(state) {
-	const hostUrl = utils.processUrl(state.tabUrl).host;
-	const trackerUrl = utils.processUrl(state.url).host;
-
 	// state.ghosteryWhitelisted is sometimes undefined so force to bool
-	return Boolean(globals.SESSION.paused_blocking || events.policy.getSitePolicy(hostUrl, trackerUrl) === 2 || state.ghosteryWhitelisted);
+	return Boolean(globals.SESSION.paused_blocking || events.policy.getSitePolicy(state.tabUrl, state.url) === 2 || state.ghosteryWhitelisted);
 }
 
 /**

--- a/src/classes/Policy.js
+++ b/src/classes/Policy.js
@@ -18,6 +18,7 @@
 import c2pDb from './Click2PlayDb';
 import conf from './Conf';
 import globals from './Globals';
+import { processUrl } from '../utils/utils';
 
 /**
  * Enum for reasons returned by shouldBlock
@@ -62,8 +63,9 @@ class Policy {
 	 * @return {string|boolean} 	corresponding whitelist entry or false, if none
 	 */
 	checkSiteWhitelist(url) {
-		if (url) {
-			const replacedUrl = url.replace(/^www\./, '');
+		const hostUrl = processUrl(url).host;
+		if (hostUrl) {
+			const replacedUrl = hostUrl.replace(/^www\./, '');
 			const sites = conf.site_whitelist || [];
 			const num_sites = sites.length;
 
@@ -86,11 +88,13 @@ class Policy {
 	 */
 	checkAntiTrackingWhitelist(hostUrl, trackerUrl) {
 		let isWhitelisted = false;
+		const processedHostUrl = processUrl(hostUrl).host;
+		const processedTrackerUrl = processUrl(trackerUrl).host;
 		const antiTrackingWhitelist = conf.anti_tracking_whitelist;
 
-		if (antiTrackingWhitelist[trackerUrl]) {
-			antiTrackingWhitelist[trackerUrl].hosts.some((host) => {
-				if (host === hostUrl) {
+		if (antiTrackingWhitelist[processedTrackerUrl]) {
+			antiTrackingWhitelist[processedTrackerUrl].hosts.some((host) => {
+				if (host === processedHostUrl) {
 					isWhitelisted = true;
 					return true;
 				}
@@ -107,8 +111,9 @@ class Policy {
 	 * @return {string|boolean} 	corresponding blacklist entry or false, if none
 	 */
 	blacklisted(url) {
-		if (url) {
-			const replacedUrl = url.replace(/^www\./, '');
+		const hostUrl = processUrl(url).host;
+		if (hostUrl) {
+			const replacedUrl = hostUrl.replace(/^www\./, '');
 			const sites = conf.site_blacklist || [];
 			const num_sites = sites.length;
 


### PR DESCRIPTION
JIRA Ticket: https://cliqztix.atlassian.net/browse/GH-1799


**Note**
I noticed when working on this ticket that the Unknown category was a bit confusing when you select "Restrict Site", since it looks different than all of the other categories. I updated the Unknown category trackers so that their whitelisting features were inaccessible in this state (to match the other categories) and coordinated with @vincentlai88 to ensure that the design was as aligned as possible.