### PR TITLE
Update cliqz staging offers URL

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1322,7 +1322,7 @@ offers.on('enabled', () => {
 		if (DEBUG) {
 			offers.action('setConfiguration', {
 				config_location: 'de',
-				triggersBE: 'https://offers-api-staging.clyqz.com',
+				triggersBE: 'https://offers-api-staging-myo.myoffrz.ninja',
 				showConsoleLogs: true,
 				offersLogsEnabled: true,
 				offersDevFlag: true,


### PR DESCRIPTION
Cliqz has moved its offers-api environment to its MyOffrz AWS account and updated the staging and production URLs.

The production API URL remains the same for our Ghostery channel (`https://offers-api.ghostery.net`), so I've just updated the staging API URL to the new `https://offers-api-staging-myo.myoffrz.ninja` value.

* [X] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do?
* [X] Does your submission pass tests?
* [X] Did you lint your code prior to submission?
