### PR TITLE
GH-1607/Lock smart blocking on Cliqz browser

### DIFF
--- a/app/hub/Views/SetupViews/SetupAntiSuiteView/SetupAntiSuiteViewContainer.jsx
+++ b/app/hub/Views/SetupViews/SetupAntiSuiteView/SetupAntiSuiteViewContainer.jsx
@@ -125,7 +125,10 @@ class SetupAntiSuiteViewContainer extends Component {
 				id: 'smart-blocking',
 				name: t('hub_setup_smartblocking_name_smartblocking'),
 				enabled: enable_smart_block,
-				toggle: () => this._handleToggle('smart-blocking'),
+				locked: IS_CLIQZ,
+				toggle: IS_CLIQZ ?
+					() => {} :
+					() => this._handleToggle('smart-blocking'),
 				description: t('hub_setup_smartblocking_description_smartblocking'),
 			}
 		];


### PR DESCRIPTION
* [x] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do?
* [x] Does your submission pass tests?
* [x] Did you lint your code prior to submission?

On the Cliqz browser, smart blocking should stay enabled in the hub.
