### PR TITLE
GH-1774 et al; promo modal logic bug fixes

### DIFF
--- a/app/panel/components/Panel.jsx
+++ b/app/panel/components/Panel.jsx
@@ -229,11 +229,19 @@ class Panel extends React.Component {
 	_handlePromoSelectBasicClick = () => {
 		this.props.actions.togglePromoModal();
 
+		// we do not mark the choice-required initial plus promo as 'seen' until
+		// the user has clicked Select Basic or Select Plus
+		sendMessage('promoModals.sawPlusPromo', {});
+
 		sendMessage('ping', 'promo_modals_select_basic_panel');
 	};
 
 	_handlePromoSelectPlusClick = () => {
 		this.props.actions.togglePromoModal();
+
+		// we do not mark the choice-required initial plus promo as 'seen' until
+		// the user has clicked Select Basic or Select Plus
+		sendMessage('promoModals.sawPlusPromo', {});
 
 		sendMessage('ping', 'promo_modals_select_plus_panel');
 	};
@@ -273,9 +281,9 @@ class Panel extends React.Component {
 	_renderPlusPromoModal = () => {
 		if (this._plusSubscriber() || this._insightsSubscriber()) return null;
 
-		sendMessage('promoModals.sawPlusPromo', {});
-
 		if (this.props.promoModal === 'plus_upgrade') {
+			// the upgrade promo does not require the user to make a choice, so we mark it as 'seen' immediately
+			sendMessage('promoModals.sawPlusPromo', {});
 			sendMessage('ping', 'promo_modals_show_upgrade_plus');
 			return (
 				<PlusUpgradePromoModal

--- a/src/classes/PromoModals.js
+++ b/src/classes/PromoModals.js
@@ -20,7 +20,7 @@ const DAYS_BETWEEN_PROMOS = {
 	insights: globals.DEBUG ? 0.00025 : 30
 };
 const WEEKLY_INSIGHTS_TARGET = globals.DEBUG ? 1 : 3;
-const DAILY_INSIGHTS_TARGET = 3;
+const DAILY_INSIGHTS_TARGET = globals.DEBUG ? 7 : 3;
 
 const MSECS_IN_DAY = 86400000; // 1000 msecs-in-sec * 60 secs-in-min * 60 mins-in-hour * 24 hours-in-day
 const PLUS = 'plus';

--- a/src/classes/PromoModals.js
+++ b/src/classes/PromoModals.js
@@ -16,8 +16,8 @@ import globals from './Globals';
 import panelData from './PanelData';
 
 const DAYS_BETWEEN_PROMOS = {
-	plus: globals.DEBUG ? 0.00025 : 30,
-	insights: globals.DEBUG ? 0.00025 : 30
+	plus: globals.DEBUG ? 0.0005 : 30,
+	insights: globals.DEBUG ? 0.0005 : 30
 };
 const WEEKLY_INSIGHTS_TARGET = globals.DEBUG ? 1 : 3;
 const DAILY_INSIGHTS_TARGET = globals.DEBUG ? 7 : 3;
@@ -66,6 +66,11 @@ class PromoModals {
 
 		if (type === INSIGHTS && !this._hasEngagedFrequently()) {
 			return false;
+		}
+
+		// don't wait 30 days to show the first Insights promo if user meets the criteria before then
+		if (type === INSIGHTS && lastSeenInsightsPromo === 0) {
+			return true;
 		}
 
 		return (


### PR DESCRIPTION
* Pop first Insights modal as soon as engagement conditions are met - do not wait 30 days after  install (a late addition to GH-1774 that had slipped through the cracks)
* Keep popping Initial Plus promo in Panel until user makes a required choice of either Select Basic or Select Plus (an OG requirement, was implemented but changes had introduced a regression breaking this)
* Up the engagement (open panel) target for the Insights modal on staging from 3 to 7 to facilitate testing.
* Upped the period from 20 to 40 seconds on staging.

* [X] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do?
* [X] Does your submission pass tests?
* [X] Did you lint your code prior to submission?
