### PR TITLE
Fix name fields of hub plus promo modal pings

### DIFF
--- a/app/hub/Views/HomeView/HomeViewContainer.jsx
+++ b/app/hub/Views/HomeView/HomeViewContainer.jsx
@@ -71,7 +71,7 @@ class HomeViewContainer extends Component {
 
 		sendMessage('SET_PLUS_PROMO_MODAL_SEEN', {});
 
-		sendMessage('ping', 'promo_modals_select_basic_hub');
+		sendMessage('SEND_PING', 'promo_modals_select_basic_hub');
 	}
 
 	/**
@@ -85,7 +85,7 @@ class HomeViewContainer extends Component {
 
 		sendMessage('SET_PLUS_PROMO_MODAL_SEEN', {});
 
-		sendMessage('ping', 'promo_modals_select_plus_hub');
+		sendMessage('SEND_PING', 'promo_modals_select_plus_hub');
 
 		window.open(`https://checkout.${DOMAIN}.com/plus?utm_source=gbe&utm_campaign=intro_hub`, '_blank');
 	}
@@ -112,7 +112,7 @@ class HomeViewContainer extends Component {
 
 		const showPromoModal = !isPlus && !plus_promo_modal_shown;
 		if (showPromoModal) {
-			sendMessage('ping', 'promo_modals_show_plus_choice_hub');
+			sendMessage('SEND_PING', 'promo_modals_show_plus_choice_hub');
 		}
 
 		return (

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,7 @@
 {
 	"manifest_version": 2,
+	"debug": true,
+	"log": true,
 	"applications": {
 		"gecko": {
 			"id": "firefox@ghostery.com",


### PR DESCRIPTION
While trying to pull plus promo metrics data for Jeremy, I discovered that the Hub plus promo pings were broken. This should get them working.

* [X] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do?
* [X] Does your submission pass tests?
* [X] Did you lint your code prior to submission?
