### PR TITLE
GH-1895 and GH-1896: Insights promo modal logic bugfix

### DIFF
--- a/src/classes/PromoModals.js
+++ b/src/classes/PromoModals.js
@@ -96,7 +96,7 @@ class PromoModals {
 	static _hasEngagedFrequently() {
 		const { engaged_daily_count } = conf.metrics || [];
 
-		const very_engaged_days = engaged_daily_count.reduce((acc, count) => (count >= DAILY_INSIGHTS_TARGET ? acc++ : acc), 0);
+		const very_engaged_days = engaged_daily_count.reduce((acc, count) => (count >= DAILY_INSIGHTS_TARGET ? ++acc : acc), 0);
 
 		return very_engaged_days >= WEEKLY_INSIGHTS_TARGET;
 	}


### PR DESCRIPTION
Insights modal broke because I refactored PromoModals#_hasEngagedFrequently to use `reduce` and postfix incremented the accumulator instead of prefix incrementing it.

Let this be a lesson to me not to fix what is not broken in the middle of a crunch.

* [X] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do?
* [X] Does your submission pass tests?
* [X]  Did you lint your code prior to submission?
