### PR TITLE
GH-1791 / add locale-appropriate formatting to historical stats numbers

### DIFF
--- a/app/panel/components/Settings/OptIn.jsx
+++ b/app/panel/components/Settings/OptIn.jsx
@@ -31,7 +31,7 @@ const OptIn = (props) => {
 					<h3>{ t('settings_support_ghostery') }</h3>
 					<h5>
 						{ t('settings_support_ghostery_by') }
-:
+						:
 					</h5>
 					<div className="s-option-group">
 						<div className="s-square-checkbox">

--- a/app/panel/components/StatsView.jsx
+++ b/app/panel/components/StatsView.jsx
@@ -147,7 +147,7 @@ const StatsView = (props) => {
 				<div id="trackersSeen" className={tile} onClick={selectView}>
 					<div className="tile-title"><p className={trackersSeenClassNames}>{t('panel_stats_trackers_seen')}</p></div>
 					<div className={trackersSeenValueClassNames}>
-						<p className="tile-value-content">{subscriber ? trackersSeen : ''}</p>
+						<p className="tile-value-content">{subscriber ? trackersSeen.toLocaleString() : ''}</p>
 						<div className="active-underline" />
 					</div>
 				</div>
@@ -155,7 +155,7 @@ const StatsView = (props) => {
 				<div id="trackersBlocked" className={tile} onClick={selectView}>
 					<div className="tile-title"><p className={trackersBlockedClassNames}>{t('panel_stats_trackers_blocked')}</p></div>
 					<div className={trackersBlockedValueClassNames}>
-						<p className="tile-value-content">{subscriber ? trackersBlocked : ''}</p>
+						<p className="tile-value-content">{subscriber ? trackersBlocked.toLocaleString() : ''}</p>
 						<div className="active-underline" />
 					</div>
 				</div>
@@ -163,7 +163,7 @@ const StatsView = (props) => {
 				<div id="trackersAnonymized" className={tile} onClick={selectView}>
 					<div className="tile-title"><p className={trackersAnonymizedClassNames}>{t('panel_stats_trackers_anonymized')}</p></div>
 					<div className={trackersAnonymizedValueClassNames}>
-						<p className="tile-value-content">{subscriber ? trackersAnonymized : ''}</p>
+						<p className="tile-value-content">{subscriber ? trackersAnonymized.toLocaleString() : ''}</p>
 						<div className="active-underline" />
 					</div>
 				</div>
@@ -171,7 +171,7 @@ const StatsView = (props) => {
 				<div id="adsBlocked" className={tile} onClick={selectView}>
 					<div className="tile-title"><p className={adsBlockedClassNames}>{t('panel_stats_ads_blocked')}</p></div>
 					<div className={adsBlockedValueClassNames}>
-						<p className="tile-value-content">{subscriber ? adsBlocked : ''}</p>
+						<p className="tile-value-content">{subscriber ? adsBlocked.toLocaleString() : ''}</p>
 						<div className="active-underline" />
 					</div>
 				</div>


### PR DESCRIPTION
* [X] Have you followed the guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do?
* [X] Does your submission pass tests?
* [X] Did you lint your code prior to submission?

A small improvement to display historical stats numbers with locale-appropriate formatting (e.g. "3625" becomes "3,625" in US locale)
