### PR TITLE
GH-2022 Make radio button labels one line

### DIFF
--- a/app/panel/components/BuildingBlocks/RadioButtonGroup.jsx
+++ b/app/panel/components/BuildingBlocks/RadioButtonGroup.jsx
@@ -23,20 +23,31 @@ import RadioButton from './RadioButton';
  */
 const RadioButtonGroup = (props) => {
 	const { indexClicked, handleItemClick } = props;
+
+	const labels = props.labels.map(label => (
+		<div key={label} className="RadioButtonGroup__label">
+			{t(label)}
+		</div>
+	));
+
+	const buttons = props.labels.map((label, index) => (
+		<div className="RadioButtonGroup__button">
+			<RadioButton
+				checked={index === indexClicked}
+				handleClick={() => handleItemClick(index)}
+			/>
+		</div>
+	));
+
 	return (
-		props.labels.map((label, index) => (
-			<div className="flex-container align-justify RadioButtonGroup__container" key={label}>
-				<span className="RadioButtonGroup__label">
-					{t(label)}
-				</span>
-				<div>
-					<RadioButton
-						checked={index === indexClicked}
-						handleClick={() => handleItemClick(index)}
-					/>
-				</div>
+		<div className="RadioButtonGroup__container">
+			<div className="flex-container align-justify RadioButtonGroup__labelContainer">
+				{labels}
 			</div>
-		))
+			<div className="flex-container align-justify RadioButtonGroup__buttonsContainer">
+				{buttons}
+			</div>
+		</div>
 	);
 };
 

--- a/app/scss/partials/_radio_button.scss
+++ b/app/scss/partials/_radio_button.scss
@@ -11,13 +11,25 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-.RadioButtonGroup__label {
-	margin-right: 10px;
-	font-weight: bolder;
-}
 .RadioButtonGroup__container {
-	margin: 16px 0;
-	width: 138px;
+	margin-top: 20px;
+	display: flex;
+}
+.RadioButtonGroup__labelContainer {
+	display: flex;
+	flex-direction: column;
+	margin-right: 15px;
+}
+.RadioButtonGroup__label {
+	font-weight: bolder;
+	margin-bottom: 15px;
+}
+.RadioButtonGroup__buttonsContainer {
+	display: flex;
+	flex-direction: column;
+}
+.RadioButtonGroup__button {
+	margin-bottom: 15px;
 }
 .RadioButton__outerCircle {
 	border: 1px solid #4a4a4a;


### PR DESCRIPTION
* [x] Have you followed the guidelines in [CONTRIBUTING.md](https://github.com/ghostery/ghostery-extension/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do?
* [x] Does your submission pass tests?
* [x] Did you lint your code prior to submission?

- This PR addresses translation kickbacks on GH-2022 where the radio button labels should be on one line
- Radio buttons are used in the theme view for Plus subscribers and the Ad blocker lists view in Settings

Ticket: https://cliqztix.atlassian.net/browse/GH-2022