### PR TITLE
GH-2090: Fix settings dropdown menu for russian translation

### DIFF
--- a/app/scss/partials/_header.scss
+++ b/app/scss/partials/_header.scss
@@ -99,7 +99,6 @@
 	.dropdown-pane {
 		display: block;
 		width: 217px;
-		height: 364px;
 		border: none;
 		background-color: #4a4a4a;
 		top: 0px !important;
@@ -200,11 +199,7 @@
 
 		.account-info {
 			@extend %pointer;
-			position: absolute;
-			bottom: 0px;
-			left: 0;
-			padding: 16px;
-			width: 100%;
+			margin-top: 16px;
 			.signed-in-as {
 				padding-bottom: 0;
 				span {


### PR DESCRIPTION
* [x] Have you followed the guidelines in [CONTRIBUTING.md](https://github.com/ghostery/ghostery-extension/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do?
* [x] Does your submission pass tests?
* [x] Did you lint your code prior to submission?

- The length of the russian bullet copy is pushing everything down into an absolute div. Let's change that div to `position: relative` and remove the height from the dropdown div to let it size itself

Ticket: https://ghostery.atlassian.net/browse/GH-2090?focusedCommentId=17757