### PR TITLE
GH-2072: Add subscription interval to ping params and change UpgradePlan CTA link params

### DIFF
--- a/app/hub/Views/UpgradePlanView/UpgradePlanView.jsx
+++ b/app/hub/Views/UpgradePlanView/UpgradePlanView.jsx
@@ -169,7 +169,7 @@ const UpgradePlanView = (props) => {
 	// UTM and Query Params
 	// Subscription_interval is the query param to show monthly/yearly pricing in checkout web
 	const interval = show_yearly_prices ? 'year' : 'month';
-	const utmParams = `utm_source=gbe&subscription_interval=${interval}`;
+	const utmParams = `utm_source=gbe&interval=${interval}`;
 
 	const plusCTAButton = (position) => {
 		const utm_campaign = position === 'top' ? 'c_1' : 'c_2';

--- a/app/hub/Views/UpgradePlanView/UpgradePlanView.jsx
+++ b/app/hub/Views/UpgradePlanView/UpgradePlanView.jsx
@@ -169,11 +169,11 @@ const UpgradePlanView = (props) => {
 	// UTM and Query Params
 	// Subscription_interval is the query param to show monthly/yearly pricing in checkout web
 	const interval = show_yearly_prices ? 'year' : 'month';
-	const utmParams = `utm_source=gbe&interval=${interval}`;
+	const params = `utm_source=gbe&interval=${interval}`;
 
 	const plusCTAButton = (position) => {
 		const utm_campaign = position === 'top' ? 'c_1' : 'c_2';
-		const plusCheckoutLink = `${globals.CHECKOUT_BASE_URL}/plus?${utmParams}&utm_campaign=intro_hub_${utm_campaign}`;
+		const plusCheckoutLink = `${globals.CHECKOUT_BASE_URL}/plus?${params}&utm_campaign=intro_hub_${utm_campaign}`;
 
 		return (
 			<a className="button button-gold" href={plusCheckoutLink} target="_blank" rel="noopener noreferrer" title="Upgrade to Plus">
@@ -184,7 +184,7 @@ const UpgradePlanView = (props) => {
 
 	const premiumCTAButton = (position) => {
 		const utm_campaign = position === 'top' ? 'c_3' : 'c_4';
-		const premiumCheckoutLink = `${globals.CHECKOUT_BASE_URL}/premium?${utmParams}&utm_campaign=intro_hub_${utm_campaign}`;
+		const premiumCheckoutLink = `${globals.CHECKOUT_BASE_URL}/premium?${params}&utm_campaign=intro_hub_${utm_campaign}`;
 
 		return (
 			<a className="button button-premium" href={premiumCheckoutLink} target="_blank" rel="noopener noreferrer" title="Upgrade to Premium">

--- a/app/hub/Views/UpgradePlanView/UpgradePlanView.jsx
+++ b/app/hub/Views/UpgradePlanView/UpgradePlanView.jsx
@@ -166,16 +166,10 @@ const UpgradePlanView = (props) => {
 		mobileComparisonTableRef.current.scrollIntoView({ behavior: 'smooth' });
 	};
 
-	// UTM params
-	const signedIn = +!!user;
-	const subscriptionType = () => {
-		if (isPremium) return 'PREMIUM';
-		if (isPlus) return 'SUPPORTER';
-		return '-1';
-	};
-	// Interval is the query Param to show monthly/yearly pricing in checkout web, also used as a ping parameter
+	// UTM and Query Params
+	// Subscription_interval is the query param to show monthly/yearly pricing in checkout web
 	const interval = show_yearly_prices ? 'year' : 'month';
-	const utmParams = `utm_source=gbe&signedIn=${signedIn}&st=${subscriptionType()}&subscription_interval=${interval}`;
+	const utmParams = `utm_source=gbe&subscription_interval=${interval}`;
 
 	const plusCTAButton = (position) => {
 		const utm_campaign = position === 'top' ? 'c_1' : 'c_2';

--- a/app/hub/Views/UpgradePlanView/UpgradePlanView.jsx
+++ b/app/hub/Views/UpgradePlanView/UpgradePlanView.jsx
@@ -167,12 +167,12 @@ const UpgradePlanView = (props) => {
 	};
 
 	// UTM and Query Params
-	// Subscription_interval is the query param to show monthly/yearly pricing in checkout web
+	// interval is the query param to show monthly/yearly pricing in checkout web
 	const interval = show_yearly_prices ? 'year' : 'month';
 	const params = `utm_source=gbe&interval=${interval}`;
 
 	const plusCTAButton = (position) => {
-		const utm_campaign = position === 'top' ? 'c_1' : 'c_2';
+		const utm_campaign = (position === 'top' ? 'c_1' : 'c_2');
 		const plusCheckoutLink = `${globals.CHECKOUT_BASE_URL}/plus?${params}&utm_campaign=intro_hub_${utm_campaign}`;
 
 		return (
@@ -183,7 +183,7 @@ const UpgradePlanView = (props) => {
 	};
 
 	const premiumCTAButton = (position) => {
-		const utm_campaign = position === 'top' ? 'c_3' : 'c_4';
+		const utm_campaign = (position === 'top' ? 'c_3' : 'c_4');
 		const premiumCheckoutLink = `${globals.CHECKOUT_BASE_URL}/premium?${params}&utm_campaign=intro_hub_${utm_campaign}`;
 
 		return (

--- a/src/background.js
+++ b/src/background.js
@@ -823,7 +823,7 @@ function onMessageHandler(request, sender, callback) {
 			.catch((err) => {
 				log('LOGIN ERROR', err);
 				callback({ errors: _getJSONAPIErrorsObject(err) });
-			})
+			});
 		return true;
 	}
 	if (name === 'account.register') {

--- a/src/background.js
+++ b/src/background.js
@@ -823,7 +823,7 @@ function onMessageHandler(request, sender, callback) {
 			.catch((err) => {
 				log('LOGIN ERROR', err);
 				callback({ errors: _getJSONAPIErrorsObject(err) });
-			});
+			})
 		return true;
 	}
 	if (name === 'account.register') {

--- a/src/classes/Metrics.js
+++ b/src/classes/Metrics.js
@@ -372,7 +372,7 @@ class Metrics {
 			// Hub Promo variant
 			`&hp=${encodeURIComponent(Metrics._getHubPromoVariant().toString())}` +
 			// Subscription Interval
-			`&si=${encodeURIComponent(Metrics._getSubscriptionInterval().toString())}`;
+			`&subscription_interval=${encodeURIComponent(Metrics._getSubscriptionInterval().toString())}`;
 
 		if (CAMPAIGN_METRICS.includes(type)) {
 			// only send campaign attribution when necessary

--- a/src/classes/Metrics.js
+++ b/src/classes/Metrics.js
@@ -560,17 +560,14 @@ class Metrics {
 	static _getSubscriptionInterval() {
 		const subscriptionInterval = conf && conf.account && conf.account.subscriptionData && conf.account.subscriptionData.planInterval;
 
-		if (subscriptionInterval) {
-			switch (subscriptionInterval) {
-				case 'month':
-					return 1;
-				case 'year':
-					return 2;
-				default:
-					return 0;
-			}
+		switch (subscriptionInterval) {
+			case 'month':
+				return 1;
+			case 'year':
+				return 2;
+			default:
+				return 0;
 		}
-		return 0;
 	}
 
 	/**

--- a/src/classes/Metrics.js
+++ b/src/classes/Metrics.js
@@ -370,7 +370,7 @@ class Metrics {
 
 			// New parameter for Ghostery 8.5.2
 			// Hub Promo variant
-			`&hp=${encodeURIComponent(Metrics._getHubPromoVariant().toString())}`;
+			`&hp=${encodeURIComponent(Metrics._getHubPromoVariant().toString())}` +
 			// Subscription Interval
 			`&si=${encodeURIComponent(Metrics._getSubscriptionInterval().toString())}`;
 

--- a/src/classes/Metrics.js
+++ b/src/classes/Metrics.js
@@ -371,6 +371,8 @@ class Metrics {
 			// New parameter for Ghostery 8.5.2
 			// Hub Promo variant
 			`&hp=${encodeURIComponent(Metrics._getHubPromoVariant().toString())}`;
+			// Subscription Interval
+			`&si=${encodeURIComponent(Metrics._getSubscriptionInterval().toString())}`;
 
 		if (CAMPAIGN_METRICS.includes(type)) {
 			// only send campaign attribution when necessary
@@ -548,6 +550,27 @@ class Metrics {
 			default:
 				return 0;
 		}
+	}
+
+	/**
+	 * Get the Int associated with the users subscription interval
+	 * @private
+	 * @return {number} String associated with the users subscription interval
+	 */
+	static _getSubscriptionInterval() {
+		const subscriptionInterval = conf && conf.account && conf.account.subscriptionData && conf.account.subscriptionData.planInterval;
+
+		if (subscriptionInterval) {
+			switch (subscriptionInterval) {
+				case 'month':
+					return 1;
+				case 'year':
+					return 2;
+				default:
+					return 0;
+			}
+		}
+		return 0;
 	}
 
 	/**


### PR DESCRIPTION
* [x] Have you followed the guidelines in [CONTRIBUTING.md](https://github.com/ghostery/ghostery-extension/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do?
* [x] Does your submission pass tests?
* [x] Did you lint your code prior to submission?

- Add `subscription interval` parameter to all pings, taken from the account conf variable
- 0 if the user is a free user or not signed in
- 1 if monthly
- 2 if yearly

The login ping will send a 0 regardless of subscription status. All other pings without refreshing the panel will send the updated value. Let me know if there is a way to fix this

- Change CTA param in `UpgradePlanView` from `subscription_interval` to `interval` to match the query param in checkout-web

Ticket: https://ghostery.atlassian.net/browse/GH-2072