### PR TITLE
GH-2071 A/B testing console error

### DIFF
--- a/app/hub/Views/HomeView/HomeViewContainer.jsx
+++ b/app/hub/Views/HomeView/HomeViewContainer.jsx
@@ -119,7 +119,7 @@ class HomeViewContainer extends Component {
 		} = home;
 
 		// Flag to display promo modal (used in A/B testing)
-		const { pm } = QueryString.parse(window.location.search);
+		const pm = QueryString.parse(window.location.search).pm || false;
 		// Logic to display premium modal if it is the case that it is being shown once per hub refresh to non-premium users
 		const showPromoModal = pm && pm === 'true' && !premium_promo_modal_shown && !isPremium;
 


### PR DESCRIPTION
* [x] Have you followed the guidelines in [CONTRIBUTING.md](https://github.com/ghostery/ghostery-extension/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do?
* [x] Does your submission pass tests?
* [x] Did you lint your code prior to submission?

- `pm` is undefined when logging into plus or premium account and the user has a midnight promo modal A/B test

Steps to replicate:

- Set `conf.hub_promo_variant = 'midnight'` in `background#setupHubPromoABTest()`
- Load the extension (automatically routed to the Home View with Premium promo modal shown)
- Log into a plus account and be redirected to the HomeUpgradePlanView
- Click the Home View and notice the error in the console

![image](https://user-images.githubusercontent.com/10860129/88699425-51f76280-d0d5-11ea-8c9f-964b93894c8b.png)

Ticket: https://ghostery.atlassian.net/browse/GH-2071