### PR TITLE
Remove finally from background

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1692,11 +1692,12 @@ function initializeGhosteryModules() {
 				abtest.fetch()
 					.then(() => {
 						setupABTest();
+						resolve();
 					})
 					.catch(() => {
 						log('Unable to reach abtest server');
-					})
-					.finally(() => resolve());
+						resolve();
+					});
 			} else {
 				resolve();
 			}


### PR DESCRIPTION
Removes `finally` from the `background.js` code, because it is not supported in some of the older Chrome and Opera versions the extension supports.

* [x] Have you followed the guidelines in [CONTRIBUTING.md](https://github.com/ghostery/ghostery-extension/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x]  Have you added an explanation of what your changes do?
* [x] Does your submission pass tests?
* [x] Did you lint your code prior to submission?
