### PR TITLE
GH-2152: Shorten subscription_interval uninstall URL param to si

### DIFF
--- a/src/classes/Metrics.js
+++ b/src/classes/Metrics.js
@@ -372,7 +372,7 @@ class Metrics {
 			// Hub Promo variant
 			`&hp=${encodeURIComponent(Metrics._getHubPromoVariant().toString())}` +
 			// Subscription Interval
-			`&subscription_interval=${encodeURIComponent(Metrics._getSubscriptionInterval().toString())}` +
+			`&si=${encodeURIComponent(Metrics._getSubscriptionInterval().toString())}` +
 			// Product ID Parameter
 			`&pi=${encodeURIComponent('gbe')}`;
 


### PR DESCRIPTION
Our uninstall URL currently exceeds the 255 character limit imposed by `runtime.setUninstallURL`. This stopgap fix brings the char count under the limit for now.

* [X] Have you followed the guidelines in [CONTRIBUTING.md](https://github.com/ghostery/ghostery-extension/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do?
* [X] Does your submission pass tests?
* [X] Did you lint your code prior to submission?
