### PR TITLE
Fix A/B test timing bug

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1118,7 +1118,12 @@ function getAntitrackingTestConfig() {
  * @return {Object} 	Hub promotion configuration parameters
  */
 function setupHubPromoABTest() {
-	if (conf.hub_promo_variant !== 'not_yet_set') return;
+	if (
+		!abtest.hasBeenFetched
+		|| conf.hub_promo_variant !== 'not_yet_set'
+	) {
+		return;
+	}
 
 	if (abtest.hasTest('hub_plain')) {
 		conf.hub_promo_variant = 'plain';

--- a/src/classes/ABTest.js
+++ b/src/classes/ABTest.js
@@ -27,6 +27,7 @@ const { BROWSER_INFO, CMP_BASE_URL, EXTENSION_VERSION } = globals;
 class ABTest {
 	constructor() {
 		this.tests = {};
+		this.hasBeenFetched = false;
 	}
 
 	/**
@@ -63,6 +64,7 @@ class ABTest {
 					(tests, test) => Object.assign(tests, { [test.name]: test.data }),
 					{}
 				);
+				this.hasBeenFetched = true;
 			} else {
 				log('A/B Tests: no tests found.');
 			}


### PR DESCRIPTION
`conf.save.enable_human-web` is set during startup, which is intercepted by the dispatcher, which calls `setupABTest`, which calls `setupHubPromoABTest`. Because the call to `setupABTest` in the `dispatcher.on` handler is not then()-chained to an `abtest.fetch` call, `setupHubPromoABTest` may get called before the A/B tests have been fetched for the first time. The absence of either `hub_midnight` or `hub_plain` on the still-empty `abtest.tests` object would then have been incorrectly interpreted to mean that the user should be placed in the remaining test bucket.

I initially fixed this by putting the `setupABTest` call in the `dispatcher.on` handler in a then() clause of an `abtest.fetch` call, but I prefer the current fix because it avoids making an extra call to the A/B test server on every startup.

* [x] Have you followed the guidelines in [CONTRIBUTING.md](https://github.com/ghostery/ghostery-extension/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do?
* [x] Does your submission pass tests?
* [x] Did you lint your code prior to submission?
