### PR TITLE
GH-2168: Change hub logo link

### DIFF
--- a/app/hub/Views/SideNavigationView/SideNavigationView.jsx
+++ b/app/hub/Views/SideNavigationView/SideNavigationView.jsx
@@ -15,6 +15,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ClassNames from 'classnames';
 import { NavLink } from 'react-router-dom';
+import globals from '../../../../src/classes/Globals';
+
+const { GHOSTERY_BASE_URL } = globals;
 
 /**
  * Helper render function for rendering a list item for the Navigation Main section
@@ -96,7 +99,13 @@ const SideNavigationView = (props) => {
 
 	return (
 		<div className={containerClassNames}>
-			<NavLink to="/" className={topClassNames} />
+			<a
+				href={GHOSTERY_BASE_URL}
+				aria-label="Ghostery website"
+				rel="noopener noreferrer"
+				target="_blank"
+				className={topClassNames}
+			/>
 			<div className="SideNavigation__menu flex-child-grow flex-container flex-dir-column">
 				{menuItems.map(item => _renderMenuItem(item, disableNav))}
 			</div>

--- a/app/hub/Views/SideNavigationView/__tests__/__snapshots__/SideNavigationView.test.jsx.snap
+++ b/app/hub/Views/SideNavigationView/__tests__/__snapshots__/SideNavigationView.test.jsx.snap
@@ -5,11 +5,11 @@ exports[`app/hub/Views/SideNavigationView component More Snapshot tests with rea
   className="SideNavigation flex-container flex-dir-column"
 >
   <a
-    aria-current="page"
-    className="SideNavigation__top active"
-    href="/"
-    onClick={[Function]}
-    style={Object {}}
+    aria-label="Ghostery website"
+    className="SideNavigation__top"
+    href="https://ghosterystage.com"
+    rel="noopener noreferrer"
+    target="_blank"
   />
   <div
     className="SideNavigation__menu flex-child-grow flex-container flex-dir-column"
@@ -25,11 +25,11 @@ exports[`app/hub/Views/SideNavigationView component Snapshot tests with react-te
   className="SideNavigation flex-container flex-dir-column"
 >
   <a
-    aria-current="page"
-    className="SideNavigation__top active"
-    href="/"
-    onClick={[Function]}
-    style={Object {}}
+    aria-label="Ghostery website"
+    className="SideNavigation__top"
+    href="https://ghosterystage.com"
+    rel="noopener noreferrer"
+    target="_blank"
   />
   <div
     className="SideNavigation__menu flex-child-grow flex-container flex-dir-column"
@@ -224,11 +224,11 @@ exports[`app/hub/Views/SideNavigationView component Snapshot tests with react-te
   className="SideNavigation flex-container flex-dir-column disabled"
 >
   <a
-    aria-current="page"
-    className="SideNavigation__top disabled active"
-    href="/"
-    onClick={[Function]}
-    style={Object {}}
+    aria-label="Ghostery website"
+    className="SideNavigation__top disabled"
+    href="https://ghosterystage.com"
+    rel="noopener noreferrer"
+    target="_blank"
   />
   <div
     className="SideNavigation__menu flex-child-grow flex-container flex-dir-column"


### PR DESCRIPTION
This PR changes the link for the Ghostery hub logo to direct the user to the Ghostery website in a new tab, instead of the root of the Intro Hub. As a result, I've also updated the snapshot for the component's test.

The Ghostery website that opens will be either the staging site or the prod site depending on whether the `DEBUG` environment variable is `true` or `false`.

---
* [x] Have you followed the guidelines in [CONTRIBUTING.md](https://github.com/ghostery/ghostery-extension/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do?
* [x] Does your submission pass tests?
* [x] Did you lint your code prior to submission?
