### PR TITLE
GH-2158: Subscription_type ping parameter not sending on login

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -836,9 +836,6 @@ function onMessageHandler(request, sender, callback) {
 		const { email, password } = message;
 		account.login(email, password)
 			.then((response) => {
-				if (!response.hasOwnProperty('errors')) {
-					metrics.ping('sign_in_success');
-				}
 				callback(response);
 			})
 			.catch((err) => {

--- a/src/classes/Account.js
+++ b/src/classes/Account.js
@@ -198,7 +198,6 @@ class Account {
 				}
 
 				return subscriptions;
-
 			})
 			.finally(() => {
 				if (options && options.calledFrom === 'login') {


### PR DESCRIPTION
* [x] Have you followed the guidelines in [CONTRIBUTING.md](https://github.com/ghostery/ghostery-extension/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do?
* [x] Does your submission pass tests?
* [x] Did you lint your code prior to submission?

The `sign_in_success` ping is not being fired when signing in with a free account. This is because the `.then()` chain on the `getUserSubscriptionData()` api call will not run if a user does not have any subscriptions. Let's add a finally block to make sure the ping runs regardless of what is returned from that call

Ticket: https://ghostery.atlassian.net/browse/GH-2158