### PR TITLE
(8.5.4) GH-2186: Always open promo modal links in same window as panel

### DIFF
--- a/app/shared-components/PromoModal/PromoModal.jsx
+++ b/app/shared-components/PromoModal/PromoModal.jsx
@@ -63,7 +63,7 @@ class PromoModal extends React.Component {
 	 * Handle clicks on the download buttons
 	 */
 	_handlePromoTryProductClick = (product, utm_campaign) => {
-		const { actions } = this.props;
+		const { actions, tab_id } = this.props;
 		actions.togglePromoModal();
 
 		let url;
@@ -84,6 +84,7 @@ class PromoModal extends React.Component {
 		sendMessage('openNewTab', {
 			url,
 			become_active: true,
+			tab_id, // Make sure we open the tab in the window with the open extension panel, even if another window is active
 		});
 	}
 
@@ -199,6 +200,7 @@ PromoModal.propTypes = {
 	type: PropTypes.string.isRequired,
 	location: PropTypes.string,
 	isPlus: PropTypes.bool,
+	tab_id: PropTypes.number.isRequired,
 };
 
 PromoModal.defaultProps = {

--- a/app/shared-components/PromoModal/index.js
+++ b/app/shared-components/PromoModal/index.js
@@ -11,6 +11,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
+import { connect } from 'react-redux';
 import PromoModalContainer from './PromoModalContainer';
 
-export default PromoModalContainer;
+const mapStateToProps = state => ({ tab_id: state.panel.tab_id });
+
+export default connect(mapStateToProps, undefined)(PromoModalContainer);


### PR DESCRIPTION
Fixes bug where promo modal links would open in whatever browser window is active, regardless of whether it's the one with the panel

* [X] Have you followed the guidelines in [CONTRIBUTING.md](https://github.com/ghostery/ghostery-extension/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do?
* [X] Does your submission pass tests?
* [X] Did you lint your code prior to submission?
