### PR TITLE
GH-2097 bugfix: make sure alternate Hub view is used when expected

### DIFF
--- a/src/classes/ABTest.js
+++ b/src/classes/ABTest.js
@@ -102,6 +102,8 @@ class ABTest {
 		);
 		// update conf
 		globals.SESSION.abtests = this.tests;
+		// let clients know that if a test is absent it is not because tests have not yet been fetched
+		this.hasBeenFetched = true;
 	}
 }
 


### PR DESCRIPTION
Fixes a bug that made ABTest clients always think the tests had not been fetched yet.

* [X] Have you followed the guidelines in [CONTRIBUTING.md](https://github.com/ghostery/ghostery-extension/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do?
* [X] Does your submission pass tests?
* [X] Did you lint your code prior to submission?
