### PR TITLE
Detect ghostery browser without user-agent.

### DIFF
--- a/src/classes/Globals.js
+++ b/src/classes/Globals.js
@@ -17,6 +17,20 @@ import parser from 'ua-parser-js';
 
 const manifest = chrome.runtime.getManifest();
 const isCliqzBrowser = !!(chrome.runtime.isCliqz);
+
+/**
+* Check for information about this browser
+* Note: This is asynchronous and not available at runtime.
+* @private
+* @return boolean
+*/
+function _checkBrowserInfo() {
+	if (typeof chrome.runtime.getBrowserInfo === 'function') {
+		return chrome.runtime.getBrowserInfo();
+	}
+	return Promise.resolve(false);
+}
+
 /**
  * Structure which holds parameters to be used throughout the code, a.k.a. global values.
  * Most of them (but not all) are const.
@@ -171,11 +185,6 @@ class Globals {
 			this.BROWSER_INFO.displayName = 'Yandex';
 			this.BROWSER_INFO.name = 'yandex';
 			this.BROWSER_INFO.token = 'yx';
-		} else if (navigator.userAgent.includes('Ghostery')) {
-			// ua-parser library doesn't parse the desktop browser UA properly
-			this.BROWSER_INFO.displayName = 'Ghostery Desktop Browser';
-			this.BROWSER_INFO.name = 'ghostery_desktop';
-			this.BROWSER_INFO.token = 'gd';
 		}
 
 		// Set OS property
@@ -192,26 +201,20 @@ class Globals {
 		// Set version property
 		this.BROWSER_INFO.version = version;
 
-		// Check for the Ghostery Android browser
-		if (platform.includes('android')) {
-			this._checkForGhosteryAndroid();
-		}
-	}
-
-	/**
-	 * Check for Ghostery Android Browser and update BROWSER_INFO.
-	 * Note: This is asynchronous and not available at runtime.
-	 * @private
-	 * @return boolean
-	 */
-	_checkForGhosteryAndroid() {
-		if (typeof chrome.runtime.getBrowserInfo === 'function') {
-			chrome.runtime.getBrowserInfo().then((info) => {
+		// Check for Ghostery browsers
+		if (browser.includes('firefox') || browser.includes('mozilla')) {
+			_checkBrowserInfo().then((info) => {
 				if (info.name === 'Ghostery') {
-					this.BROWSER_INFO.displayName = 'Ghostery Android Browser';
-					this.BROWSER_INFO.name = 'ghostery_android';
-					this.BROWSER_INFO.token = 'ga';
-					this.BROWSER_INFO.os = 'android';
+					if (platform.includes('android')) {
+						this.BROWSER_INFO.displayName = 'Ghostery Android Browser';
+						this.BROWSER_INFO.name = 'ghostery_android';
+						this.BROWSER_INFO.token = 'ga';
+						this.BROWSER_INFO.os = 'android';
+					} else {
+						this.BROWSER_INFO.displayName = 'Ghostery Desktop Browser';
+						this.BROWSER_INFO.name = 'ghostery_desktop';
+						this.BROWSER_INFO.token = 'gd';
+					}
 					this.BROWSER_INFO.version = info.version;
 				}
 			});


### PR DESCRIPTION
Improves ghostery browser detection: Uses `chrome.runtime.getBrowserInfo` on any Firefox UA to determine if it is a Ghostery browser or Firefox from the browser name field.

This will allow us to avoid using a custom UA on desktop.