### PR TITLE
GH-2173: Account#getUserSettings() failure handling

### DIFF
--- a/src/classes/Account.js
+++ b/src/classes/Account.js
@@ -164,6 +164,10 @@ class Account {
 				this._setAccountUserSettings(settings_json);
 				return settings_json;
 			})
+			// Fetching the settings from the account server failed,
+			// or they have simply never been synced to the account server yet
+			// In that case, just use the local settings
+			.catch(() => this.buildUserSettings())
 	)
 
 	/**


### PR DESCRIPTION
Handle the case where `Account#getUserSettings()` fails because user settings have never  been synced to the account server, which will be the case for a user who creates a new account until they change a setting for the first time.

* [X] Have you followed the guidelines in [CONTRIBUTING.md](https://github.com/ghostery/ghostery-extension/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do?
* [X] Does your submission pass tests?
* [X] Did you lint your code prior to submission?
