### PR TITLE
GH-2222 - Handle updated Chrome new tab page url

### DIFF
--- a/src/classes/EventHandlers.js
+++ b/src/classes/EventHandlers.js
@@ -652,7 +652,7 @@ class EventHandlers {
 
 	/**
 	 * Checks to see if the URL is valid. Also checks to make sure we
-	 * are not on the Chrome new tab page (_/chrome/newtab) or Firefox about:pages
+	 * are not on the legacy Chrome (< 75) new tab page (_/chrome/newtab).
 	 *
 	 * @private
 	 *

--- a/src/classes/PurpleBox.js
+++ b/src/classes/PurpleBox.js
@@ -42,11 +42,12 @@ class PurpleBox {
 	 */
 	createBox(tab_id) {
 		const tab = tabInfo.getTabInfo(tab_id);
-		// Skip in the event of pause, trust, prefetching, newtab page, or Firefox about:pages
+		// Skip in the event of pause, trust, prefetching, non http/s pages or legacy Chrome (< 75) new tab page
 		if (!conf.show_alert ||
 			globals.SESSION.paused_blocking ||
 			(conf.hide_alert_trusted && !!Policy.checkSiteWhitelist(tab.url)) ||
-			!tab || tab.purplebox || tab.path.includes('_/chrome/newtab') || tab.protocol === 'about' || globals.EXCLUDES.includes(tab.host) ||
+			!tab || tab.purplebox || !tab.protocol.startsWith('http') || tab.path.includes('_/chrome/newtab') ||
+			globals.EXCLUDES.includes(tab.host) ||
 			globals.BROWSER_INFO.os === 'android') {
 			return Promise.resolve(false);
 		}

--- a/src/utils/click2play.js
+++ b/src/utils/click2play.js
@@ -58,8 +58,8 @@ export function buildC2P(details, app_id) {
 	const { tab_id } = details;
 	const tab = tabInfo.getTabInfo(tab_id);
 
-	// If the tab is prefetched, a chrome newtab or Firefox about:page, we can't add C2P to it
-	if (!tab || tab.prefetched || tab.path.includes('_/chrome/newtab') || tab.protocol === 'about' || globals.EXCLUDES.includes(tab.host)) {
+	// If the tab is prefetched, non http/s page or legacy Chrome (< 75) new tab page, we can't add C2P to it
+	if (!tab || tab.prefetched || !tab.protocol.startsWith('http') || tab.path.includes('_/chrome/newtab') || globals.EXCLUDES.includes(tab.host)) {
 		return;
 	}
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -723,7 +723,7 @@ export function capitalize(phrase, separator = ' ') {
 
 /**
  * Inject content scripts and CSS into a given tabID (top-level frame only).
- * Note: Chrome 61 blocks content scripts on the new tab page (_/chrome/newtab). Be
+ * Note: Chrome 61 blocks content scripts on the new tab page. Be
  * sure to check the current URL before calling this function, otherwise Chrome will throw
  * a permission error
  *
@@ -774,8 +774,8 @@ export function injectNotifications(tab_id, importExport = false) {
 		return Promise.resolve(true);
 	}
 	const tab = tabInfo.getTabInfo(tab_id);
-	// check for prefetching, chrome new tab page and Firefox about:pages
-	if (tab && (tab.prefetched === true || tab.path.includes('_/chrome/newtab') || tab.protocol === 'about' || (!importExport && globals.EXCLUDES.includes(tab.host)))) {
+	// check for prefetching, non http/s pages and legacy Chrome (< 75) new tab page
+	if (tab && (tab.prefetched === true || !tab.protocol.startsWith('http') || tab.path.includes('_/chrome/newtab') || (!importExport && globals.EXCLUDES.includes(tab.host)))) {
 		// return false to prevent sendMessage calls
 		return Promise.resolve(false);
 	}


### PR DESCRIPTION
The Chrome new tab url is now chrome://new-tab-page. Prior to Chrome 75 the url was https://www.google.com/_/chrome/newtab.  For Purplebox and Click2Play, we only inject on http/s pages.  We still check for `_/chrome/newtab` as a fallback for legacy users. 
