### PR TITLE
Desktop browser telemetry

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,6 @@ module.exports = {
 	extends: 'airbnb',
 	globals: {
 		chrome: true,
-		browser: true,
 		t: true,
 		Atomics: 'readonly',
 		SharedArrayBuffer: 'readonly',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
 	extends: 'airbnb',
 	globals: {
 		chrome: true,
+		browser: true,
 		t: true,
 		Atomics: 'readonly',
 		SharedArrayBuffer: 'readonly',

--- a/src/classes/Globals.js
+++ b/src/classes/Globals.js
@@ -194,13 +194,13 @@ class Globals {
 					this.BROWSER_INFO.name = 'ghostery_android';
 					this.BROWSER_INFO.token = 'ga';
 					this.BROWSER_INFO.os = 'android';
+					this.BROWSER_INFO.version = info.version;
 				} else {
 					this.BROWSER_INFO.displayName = 'Ghostery Desktop Browser';
 					this.BROWSER_INFO.name = 'ghostery_desktop';
 					this.BROWSER_INFO.token = 'gd';
-					this.BROWSER_INFO.version = info.version;
+					this.BROWSER_INFO.version = info.version.split('.').join('');
 				}
-				this.BROWSER_INFO.version = info.version;
 			}
 		});
 	}

--- a/src/classes/Globals.js
+++ b/src/classes/Globals.js
@@ -198,6 +198,7 @@ class Globals {
 					this.BROWSER_INFO.displayName = 'Ghostery Desktop Browser';
 					this.BROWSER_INFO.name = 'ghostery_desktop';
 					this.BROWSER_INFO.token = 'gd';
+					this.BROWSER_INFO.version = info.version;
 				}
 				this.BROWSER_INFO.version = info.version;
 			}


### PR DESCRIPTION
Adds extra telemetry for the desktop browser. These are fetched over inter-extension messaging from the ghostery search extension (see https://github.com/ghostery/ghostery-search-extension/pull/30) and then appended to metrics requests.