### PR TITLE
GH-2216: Disable sidebar links on last page of Tutorial and Customize Setup in the hub

### DIFF
--- a/app/hub/Views/SideNavigationView/SideNavigationViewContainer.jsx
+++ b/app/hub/Views/SideNavigationView/SideNavigationViewContainer.jsx
@@ -52,7 +52,7 @@ class SideNavigationViewContainer extends Component {
 	 */
 	render() {
 		const { user, location } = this.props;
-		const disableRegEx = /^(\/setup)|(\/tutorial(?!\/6$))/;
+		const disableRegEx = /^(\/setup)|(\/tutorial)/;
 
 		const menuItems = ah ? [
 			{ href: '/home', icon: 'home', text: t('hub_side_navigation_home') },


### PR DESCRIPTION
* [x] Have you followed the guidelines in [CONTRIBUTING.md](https://github.com/ghostery/ghostery-extension/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do?
* [x] Does your submission pass tests?
* [x] Did you lint your code prior to submission?

- Modify the `disableRegEx` in the render() method of `sideNavigationViewContainer.jsx` to disable the sidebar links

Ticket: https://ghostery.atlassian.net/browse/GH-2216