### PR TITLE
GH-2255: Allow Dawn's newtab extension to query GBE historical stats

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1393,7 +1393,8 @@ function initializeEventListeners() {
 				globals.GHOSTERY_TAB_CHROME_PRERELEASE_ID,
 				globals.GHOSTERY_TAB_CHROME_TEST_ID,
 				globals.GHOSTERY_TAB_FIREFOX_PRODUCTION_ID,
-				globals.GHOSTERY_TAB_FIREFOX_TEST_ID
+				globals.GHOSTERY_TAB_FIREFOX_TEST_ID,
+				globals.DAWN_NEWTAB_PRODUCTION_ID,
 			].indexOf(sender.id) !== -1;
 
 			if (recognized && request.name === 'getStatsAndSettings') {

--- a/src/classes/Globals.js
+++ b/src/classes/Globals.js
@@ -72,6 +72,7 @@ class Globals {
 		this.GHOSTERY_TAB_CHROME_TEST_ID = 'ifnpgdmcliingpambkkihjlhikmbbjid';
 		this.GHOSTERY_TAB_FIREFOX_PRODUCTION_ID = 'firefoxtab@ghostery.com';
 		this.GHOSTERY_TAB_FIREFOX_TEST_ID = '{0ea88bc4-03bd-4baa-8153-acc861589c1c}';
+		this.DAWN_NEWTAB_PRODUCTION_ID = 'newtab@ghostery.com';
 
 		// Site Policy named constants
 		this.BLACKLISTED = 1;


### PR DESCRIPTION
Adds `newtab@ghostery.com` to the list of outside extensions that may query the GBE for historical stats. This is in support of displays historical stats info on new tab pages in Dawn.

* [X] Have you followed the guidelines in [CONTRIBUTING.md](https://github.com/ghostery/ghostery-extension/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do?
* [X] Does your submission pass tests?
* [X] Did you lint your code prior to submission?
