### PR TITLE
[GDA-113] Detailed stats for the new tab page addon

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1416,6 +1416,12 @@ function initializeEventListeners() {
 				getDataForGhosteryTab(data => sendResponse({ historicalDataAndSettings: data }));
 				return true;
 			}
+
+			if (recognized && request.name === 'getDashboardStats') {
+				insights.action('getDashboardStats', ...(request.args || [])).then(sendResponse);
+				return true;
+			}
+
 			return false;
 		});
 	}


### PR DESCRIPTION
Required for GDA-113

Ghostery Dawn New Tab Page is going to show WTM popup with number of trackers blocked grouped by category. Fortunately commons `insight` module already provide all required information.

Design for reference:
![1dawn](https://user-images.githubusercontent.com/1228153/110126779-0f151000-7dc5-11eb-8e66-00e92effd809.png)
