### PR TITLE
Extenal API getUser edge case handling

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1423,7 +1423,9 @@ function initializeEventListeners() {
 			}
 
 			if (recognized && request.name === 'getUser') {
-				account.getUser().then(sendResponse);
+				account.getUser()
+					.then(sendResponse)
+					.catch(() => sendResponse(null));
 				return true;
 			}
 


### PR DESCRIPTION
In case user is not logged in - the API was not sending a response as the `getUser` promise was rejecting.

