### PR TITLE
Update the URL to submit trackers

### DIFF
--- a/app/panel/components/HeaderMenu.jsx
+++ b/app/panel/components/HeaderMenu.jsx
@@ -94,7 +94,7 @@ class HeaderMenu extends React.Component {
 	 */
 	clickSubmitTracker = () => {
 		sendMessage('openNewTab', {
-			url: 'https://www.ghostery.com/support/submit-tracker/',
+			url: 'https://www.ghostery.com/submit-a-tracker',
 			become_active: true,
 		});
 		window.close();


### PR DESCRIPTION
Found by Draco18s. The old URL still works, but goes through redirects. In all other places, we are using `/submit-a-tracker`.

fixes #725
