### PR TITLE
Fix site breakage related to the Tracker-Tally CSS

### DIFF
--- a/src/classes/ConfData.js
+++ b/src/classes/ConfData.js
@@ -135,7 +135,7 @@ class ConfData {
 			_initProperty('paid_subscription', false);
 			_initProperty('settings_last_imported', 0);
 			_initProperty('settings_last_exported', 0);
-			_initProperty('show_alert', !IS_ANDROID);
+			_initProperty('show_alert', false); // Tracker-Tally
 			_initProperty('show_badge', true);
 			_initProperty('show_cmp', true);
 			_initProperty('show_tracker_urls', true);

--- a/src/classes/ConfData.js
+++ b/src/classes/ConfData.js
@@ -21,7 +21,6 @@ import { prefsGet } from '../utils/common';
 
 const { IS_CLIQZ, BROWSER_INFO } = globals;
 const IS_FIREFOX = (BROWSER_INFO.name === 'firefox');
-const IS_ANDROID = (BROWSER_INFO.os === 'android');
 
 /**
  * Class for handling user configuration properties synchronously.

--- a/src/classes/PurpleBox.js
+++ b/src/classes/PurpleBox.js
@@ -117,7 +117,7 @@ class PurpleBox {
 				});
 			}
 		}
-		return injectScript(tab_id, 'dist/purplebox.js', 'dist/css/purplebox_styles.css', 'document_start').then(() => {
+		return injectScript(tab_id, 'dist/purplebox.js', 'dist/css/purplebox_styles.css', 'document_end').then(() => {
 			if (!this.channelsSupported) {
 				sendMessage(tab_id, 'createBox', this.createBoxParams, () => {
 					if (chrome.runtime.lastError) {


### PR DESCRIPTION
The Tracker-Tally can break sites that run JavaScript that interacts with the injected css code. A recent example is
"https://mycovidrecord.health.nz/", which fails with:

```
Uncaught DOMException: CSSStyleSheet.cssRules getter: Not allowed to access cross-origin stylesheet
```

These older examples could be duplicates as well:
* https://github.com/niklasvh/html2canvas/issues/2197
* https://stackoverflow.com/a/62475347/783510

We can delay the css injection to "document_end" instead of "document_start". It may still happen, but it should make it
less likely with little downsides. In the concrete example, I can no longer reproduce with the change.

* [ ] Have you followed the guidelines in [CONTRIBUTING.md](https://github.com/ghostery/ghostery-extension/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ ] Have you added an explanation of what your changes do?
* [ ] Does your submission pass tests?
* [ ] Did you lint your code prior to submission?
