### PR TITLE
Enable community blocklists for trackers and annoyances by default

### DIFF
--- a/src/classes/ConfData.js
+++ b/src/classes/ConfData.js
@@ -105,7 +105,7 @@ class ConfData {
 			_initProperty('block_by_default', false);
 			_initProperty('bugs_last_checked', 0);
 			_initProperty('bugs_last_updated', nowTime);
-			_initProperty('cliqz_adb_mode', 0);
+			_initProperty('cliqz_adb_mode', 2); // 2 == Ads + Trackers + Annoyances
 			_initProperty('cliqz_legacy_opt_in', false);
 			_initProperty('cliqz_import_state', 0);
 			_initProperty('cmp_version', 0);


### PR DESCRIPTION
With this change, "ads + trackers + annoyances" blocklists are the default (before only "ads").

(To change in the UI: Settings -> Ad-Block-List)
