### PR TITLE
Smart Blocking: Allow blocking of first party tracking

### DIFF
--- a/src/classes/EventHandlers.js
+++ b/src/classes/EventHandlers.js
@@ -326,7 +326,6 @@ class EventHandlers {
 
 		// TODO fuse this into a single call to improve performance
 		const page_url = tabInfo.getTabInfo(tab_id, 'url');
-		const page_domain = tabInfo.getTabInfo(tab_id, 'domain');
 		const bug_id = (page_url ? isBug(eventMutable.url, page_url) : isBug(eventMutable.url));
 
 		// allow if not a tracker
@@ -338,12 +337,6 @@ class EventHandlers {
 		}
 		// add the bugId to the eventMutable object. This can then be read by other handlers on this pipeline.
 		eventMutable.ghosteryBug = bug_id;
-
-		/* ** SMART BLOCKING - Breakage ** */
-		// allow first party trackers
-		if (PolicySmartBlock.isFirstPartyRequest(tab_id, page_domain, processed.generalDomain)) {
-			return { cancel: false };
-		}
 
 		const app_id = bugDb.db.bugs[bug_id].aid;
 		const cat_id = bugDb.db.apps[app_id].cat;

--- a/src/classes/PolicySmartBlock.js
+++ b/src/classes/PolicySmartBlock.js
@@ -140,19 +140,6 @@ class PolicySmartBlock {
 	}
 
 	/**
-	 * Check if request domain matches page domain
-	 * @param  {number} tabId			tab id
-	 * @param  {string} pageDomain		domain of the page
-	 * @param  {string} requestDomain	domain of the request
-	 * @return {boolean}
-	 */
-	static isFirstPartyRequest(tabId, pageDomain = '', requestDomain = '') {
-		if (!PolicySmartBlock.shouldCheck(tabId)) { return false; }
-
-		return pageDomain === requestDomain;
-	}
-
-	/**
 	 * Check if tab was reloaded.
 	 * @param  {number} tabId		tab id
 	 * @return {boolean}

--- a/test/src/PolicySmartBlock.test.js
+++ b/test/src/PolicySmartBlock.test.js
@@ -38,29 +38,4 @@ describe('src/classes/PolicySmartBlock.js', () => {
 			return expect(policySmartBlock.allowedTypesList).toEqual(allowedTypesList);
 		});
 	});
-
-	describe('PolicySmartBlock isFirstPartyRequest tests', () => {
-		beforeAll(() => {
-			PolicySmartBlock.shouldCheck = jest.fn(() => true);
-		});
-
-		afterAll(() => {
-			policySmartBlock.mockClear();
-		});
-
-		test('PolicySmartBlock isFirstPartyRequest truthy assertion', () => {
-			expect(PolicySmartBlock.isFirstPartyRequest('tabId', 'example.com', 'example.com')).toBeTruthy();
-			// isFirstPartyRequest() expects pre-parsed domains, so we should parse the test urls
-			const parsedPage = processUrl('https://checkout.ghostery.com/insights');
-			const parsedRequest = processUrl('https://analytics.ghostery.com/piwik.js');
-			expect(PolicySmartBlock.isFirstPartyRequest('tabId', parsedPage.generalDomain, parsedRequest.generalDomain)).toBeTruthy();
-		});
-
-		test('PolicySmartBlock isFirstPartyRequest falsy assertion', () => {
-			expect(PolicySmartBlock.isFirstPartyRequest('tabId', 'www.example.com', 'example.com')).toBeFalsy();
-			expect(PolicySmartBlock.isFirstPartyRequest('tabId', 'sub.example.com', 'example.com')).toBeFalsy();
-			expect(PolicySmartBlock.isFirstPartyRequest('tabId', 'example.com', 'test.com')).toBeFalsy();
-			expect(PolicySmartBlock.isFirstPartyRequest('tabId', 'www.example.com', 'www.test.com')).toBeFalsy();
-		});
-	});
 });


### PR DESCRIPTION
In order to deal with cname cloaking we have to be able to block first party trackers. That way we can block Google Beacons.