### PR TITLE
Block new trackers iff their category is mostly blocked

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "Von Websitebesitzern erstellte Tracker zulassen"
 	},
-	"settings_block_trackers": {
-		"message": "Neue zu Ghostery hinzugefügte Tracker standardmäßig blockieren"
-	},
 	"settings_show_purple_box": {
 		"message": "Tracker-Tally in der Ecke meines Browsers anzeigen"
 	},

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "Allow trackers created by site owners"
 	},
-	"settings_block_trackers": {
-		"message": "Block new trackers added to Ghostery by default"
-	},
 	"settings_show_purple_box": {
 		"message": "Show the tracker-tally in the corner of my browser"
 	},

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "Permitir rastreadores creados por los propietarios del sitio"
 	},
-	"settings_block_trackers": {
-		"message": "Bloquear por defecto los nuevos rastreadores agregados a Ghostery"
-	},
 	"settings_show_purple_box": {
 		"message": "Mostrar el recuento de rastreadores en la esquina de mi navegador"
 	},

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "Autoriser les mouchards générés par les créateurs de sites."
 	},
-	"settings_block_trackers": {
-		"message": "Bloquer les nouveaux mouchards ajoutés à Ghostery par défaut"
-	},
 	"settings_show_purple_box": {
 		"message": "Afficher le mouchard Tally dans le coin du navigateur"
 	},

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "Oldaltulajdonosok által létrehozott trackerek engedélyezése"
 	},
-	"settings_block_trackers": {
-		"message": "A Ghostery-hez hozzáadott új trackerek blokkolása alapértelmezés szerint"
-	},
 	"settings_show_purple_box": {
 		"message": "Trackerek számának megjelenítése a böngésző sarkában"
 	},

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "Consenti i tracker creati dai titolari del sito"
 	},
-	"settings_block_trackers": {
-		"message": "Blocca i nuovi tracker aggiunti a Ghostery per impostazione predefinita"
-	},
 	"settings_show_purple_box": {
 		"message": "Mostra il conteggio tracker nell'angolo del browser in uso"
 	},

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "サイト所有者が作成したトラッカーを許可します"
 	},
-	"settings_block_trackers": {
-		"message": "Ghosteryにデフォルトで追加された新しいトラッカーをブロックします"
-	},
 	"settings_show_purple_box": {
 		"message": "ブラウザの隅に総トラッカーを表示します"
 	},

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "사이트 소유자가 만든 트래커 허용 "
 	},
-	"settings_block_trackers": {
-		"message": "기본적으로 Ghostery에 추가된 새로운 트래커 차단 "
-	},
 	"settings_show_purple_box": {
 		"message": "브라우저 구석에 트래커 기록 표시"
 	},

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "Sta door website-eigenaren gemaakte trackers toe"
 	},
-	"settings_block_trackers": {
-		"message": "Blokkeer standaard nieuwe aan Ghostery toegevoegde trackers"
-	},
 	"settings_show_purple_box": {
 		"message": "De trackertelling in de hoek van mijn browser weergeven"
 	},

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "Zezwól działanie tropicieli utworzonych przez właścicieli strony"
 	},
-	"settings_block_trackers": {
-		"message": "Blokuj nowe tropiciele dodane domyślnie do Ghostery"
-	},
 	"settings_show_purple_box": {
 		"message": "Wyświetlaj licznik tropicieli w rogu wyszukiwarki"
 	},

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "Permitir rastreadores criados pelos criadores do site"
 	},
-	"settings_block_trackers": {
-		"message": "Bloquear novos rastreadores adicionados ao Ghostery por padrão"
-	},
 	"settings_show_purple_box": {
 		"message": "Mostrar a contagem de rastreamento no canto do meu navegador"
 	},

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "Разрешить трекеры, созданные владельцами сайтов"
 	},
-	"settings_block_trackers": {
-		"message": "Блокировать новые трекеры, добавленные в Ghostery по умолчанию"
-	},
 	"settings_show_purple_box": {
 		"message": "Показывать счетчик трекеров в углу браузера"
 	},

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "允许网站所有者创建的跟踪器"
 	},
-	"settings_block_trackers": {
-		"message": "默认拦截添加到 Ghostery 的新跟踪器"
-	},
 	"settings_show_purple_box": {
 		"message": "在浏览器一角显示跟踪器记录"
 	},

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "准許由網站擁有者所創造的網頁跟縱器"
 	},
-	"settings_block_trackers": {
-		"message": "默認封鎖被加入 Ghostery 的新網頁跟蹤器"
-	},
 	"settings_show_purple_box": {
 		"message": "在瀏覽器角落顯示追蹤器紀錄"
 	},

--- a/app/panel/components/Settings/GeneralSettings.jsx
+++ b/app/panel/components/Settings/GeneralSettings.jsx
@@ -166,14 +166,6 @@ class GeneralSettings extends React.Component {
 								</div>
 							</div>
 						</div>
-						<div className="s-option-group">
-							<div className="s-square-checkbox">
-								<input type="checkbox" id="settings-block-trackers" name="block_by_default" defaultChecked={settingsData.block_by_default} onClick={toggleCheckbox} />
-								<label htmlFor="settings-block-trackers">
-									{ t('settings_block_trackers') }
-								</label>
-							</div>
-						</div>
 					</div>
 				</div>
 			</div>
@@ -196,7 +188,6 @@ GeneralSettings.propTypes = {
 		enable_click2play_social: PropTypes.bool.isRequired,
 		toggle_individual_trackers: PropTypes.bool.isRequired,
 		ignore_first_party: PropTypes.bool.isRequired,
-		block_by_default: PropTypes.bool.isRequired,
 	}).isRequired,
 };
 

--- a/app/panel/components/Settings/__tests__/GeneralSettings.jsx
+++ b/app/panel/components/Settings/__tests__/GeneralSettings.jsx
@@ -30,7 +30,6 @@ describe('app/panel/Settings/GeneralSettings.jsx', () => {
 				enable_click2play_social: false,
 				toggle_individual_trackers: false,
 				ignore_first_party: false,
-				block_by_default: false,
 			};
 			const actions = {
 				updateDatabase: () => {},
@@ -57,7 +56,6 @@ describe('app/panel/Settings/GeneralSettings.jsx', () => {
 				enable_click2play_social: true,
 				toggle_individual_trackers: true,
 				ignore_first_party: true,
-				block_by_default: true,
 			};
 			const actions = {
 				updateDatabase: () => {},
@@ -85,7 +83,6 @@ describe('app/panel/Settings/GeneralSettings.jsx', () => {
 				enable_click2play_social: false,
 				toggle_individual_trackers: false,
 				ignore_first_party: false,
-				block_by_default: false,
 			};
 			const actions = {
 				updateDatabase: jest.fn(),

--- a/app/panel/components/Settings/__tests__/__snapshots__/GeneralSettings.jsx.snap
+++ b/app/panel/components/Settings/__tests__/__snapshots__/GeneralSettings.jsx.snap
@@ -205,26 +205,6 @@ exports[`app/panel/Settings/GeneralSettings.jsx Snapshot tests with react-test-r
           </div>
         </div>
       </div>
-      <div
-        className="s-option-group"
-      >
-        <div
-          className="s-square-checkbox"
-        >
-          <input
-            defaultChecked={false}
-            id="settings-block-trackers"
-            name="block_by_default"
-            onClick={[Function]}
-            type="checkbox"
-          />
-          <label
-            htmlFor="settings-block-trackers"
-          >
-            settings_block_trackers
-          </label>
-        </div>
-      </div>
     </div>
   </div>
 </div>
@@ -434,26 +414,6 @@ exports[`app/panel/Settings/GeneralSettings.jsx Snapshot tests with react-test-r
               src="../../app/images/panel/icon-information-tooltip.svg"
             />
           </div>
-        </div>
-      </div>
-      <div
-        className="s-option-group"
-      >
-        <div
-          className="s-square-checkbox"
-        >
-          <input
-            defaultChecked={true}
-            id="settings-block-trackers"
-            name="block_by_default"
-            onClick={[Function]}
-            type="checkbox"
-          />
-          <label
-            htmlFor="settings-block-trackers"
-          >
-            settings_block_trackers
-          </label>
         </div>
       </div>
     </div>

--- a/src/background.js
+++ b/src/background.js
@@ -167,17 +167,14 @@ function autoUpdateDBs(isAutoUpdateEnabled, bugsLastCheckedMsec) {
 	}
 }
 
-/**
- * Set Default Blocking: all apps in Advertising, Adult Advertising, and Site Analytics
- */
 function setGhosteryDefaultBlocking() {
-	const categoriesBlock = ['advertising', 'pornvertising', 'site_analytics'];
+	const categoriesBlock = globals.CATEGORIES_BLOCKED_BY_DEFAULT;
 	log('Blocking all trackers in categories:', ...categoriesBlock);
 	const selected_app_ids = {};
 	const app_ids = Object.keys(bugDb.db.apps);
 	app_ids.forEach((app_id) => {
 		const category = bugDb.db.apps[app_id].cat;
-		if (categoriesBlock.indexOf(category) >= 0 &&
+		if (categoriesBlock.includes(category) &&
 		!selected_app_ids.hasOwnProperty(app_id)) {
 			selected_app_ids[app_id] = 1;
 		}

--- a/src/classes/ConfData.js
+++ b/src/classes/ConfData.js
@@ -102,7 +102,6 @@ class ConfData {
 			_initProperty('alert_bubble_pos', 'br');
 			_initProperty('alert_bubble_timeout', 15);
 			_initProperty('alert_expanded', false);
-			_initProperty('block_by_default', false);
 			_initProperty('bugs_last_checked', 0);
 			_initProperty('bugs_last_updated', nowTime);
 			_initProperty('cliqz_adb_mode', 2); // 2 == Ads + Trackers + Annoyances

--- a/src/classes/Globals.js
+++ b/src/classes/Globals.js
@@ -98,7 +98,6 @@ class Globals {
 			'alert_bubble_pos',
 			'alert_bubble_timeout',
 			'alert_expanded',
-			'block_by_default',
 			'cliqz_adb_mode',
 			'cliqz_module_whitelist',
 			'current_theme',
@@ -130,6 +129,14 @@ class Globals {
 			'site_specific_unblocks',
 			'toggle_individual_trackers',
 			'trackers_banner_status',
+		];
+
+		// Relevant for a fresh installation: all trackers from the
+		// following categories will be blocked by default.
+		this.CATEGORIES_BLOCKED_BY_DEFAULT = [
+			'advertising',
+			'pornvertising',
+			'site_analytics',
 		];
 
 		this.SESSION = {

--- a/src/classes/PanelData.js
+++ b/src/classes/PanelData.js
@@ -469,7 +469,7 @@ class PanelData {
 	 */
 	static _getUserSettingsForSettingsView(userSettingsSource) {
 		const {
-			alert_bubble_pos, alert_bubble_timeout, block_by_default, cliqz_adb_mode, enable_autoupdate,
+			alert_bubble_pos, alert_bubble_timeout, cliqz_adb_mode, enable_autoupdate,
 			enable_click2play, enable_click2play_social, enable_human_web,
 			enable_metrics, enable_abtests, hide_alert_trusted, ignore_first_party, notify_library_updates,
 			notify_promotions, notify_upgrade_updates, selected_app_ids, show_alert, show_badge,
@@ -479,7 +479,6 @@ class PanelData {
 		return {
 			alert_bubble_pos,
 			alert_bubble_timeout,
-			block_by_default,
 			cliqz_adb_mode,
 			enable_autoupdate,
 			enable_click2play,


### PR DESCRIPTION
When a new tracker is added, it has to be decided whether it should be blocked.

Old behavior:
* If the flag "blocked_by_default" is set (can be changed in the UI), the new tracker will be blocked; otherwise, it will not be blocked
* Drawback: if a "site_analytic tracker and an "essential" tracker get released at the same time, it is either blocking both or none.

New behavior:
* Look at the other existing trackers of the same category; if most of them were blocked before, then also block the new one.
* If there is no majority (e.g., for a newly introduced categories), then fallback to the category's default setting for fresh installations.
* Removed the UI flag, as it is no longer used. The user controls the behavior indirectly by blocking or allowing certain categories.
