### PR TITLE
Edge: fix for wasm evaluation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -63,7 +63,7 @@
 			"run_at": "document_start"
 		}
 	],
-	"content_security_policy": "script-src 'self'; object-src 'self'",
+	"content_security_policy": "script-src 'self' 'wasm-eval'; object-src 'self'",
 	"permissions": [
 		"webNavigation",
 		"webRequest",


### PR DESCRIPTION
Edge 97 prevent running wasm without an explicit CSP
