### PR TITLE
Use whotracksme with ES module exports

### DIFF
--- a/hybrids.js
+++ b/hybrids.js
@@ -10,4 +10,4 @@
  */
 
 // shorthand module for nicer imports until importmaps will be supported
-export * from '/vendor/hybrids/index.js';
+export * from '/vendor/hybrids/src/index.js';

--- a/manifest.json
+++ b/manifest.json
@@ -64,11 +64,10 @@
 		},
 		{
 			"js": [
-				"/vendor/@whotracksme/tracker-wheel/src/index.js",
-				"/vendor/@whotracksme/serp-report/src/content_scripts/index.js"
+				"/vendor/@whotracksme/serp-report/src/content_scripts/serp-report.js"
 			],
 			"css": [
-				"/vendor/@whotracksme/serp-report/src/content_scripts/index.css"
+				"/vendor/@whotracksme/serp-report/src/content_scripts/serp-report.css"
 			],
 			"matches": [
 				"*://*.google.com/*",
@@ -284,8 +283,6 @@
 	],
 	"background": {
 		"scripts": [
-			"/vendor/@whotracksme/serp-report/src/background/data.js",
-			"/vendor/@whotracksme/serp-report/src/background/index.js",
 			"dist/background.js"
 		],
 		"persistent": true
@@ -301,6 +298,7 @@
 	"minimum_opera_version": "56",
 	"web_accessible_resources": [
 		"app/images/*",
-		"/vendor/@whotracksme/serp-report/src/assets/iframe/index.html"
+		"vendor/@whotracksme/serp-report/src/pages/iframe/index.html",
+		"vendor/@whotracksme/ui/src/tracker-wheel.js"
 	]
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "vendorCopy": [
     {
       "from": "node_modules/hybrids/src",
-      "to": "vendor/hybrids"
+      "to": "vendor/hybrids/src"
     },
     {
       "from": "node_modules/ghostery-common/build/gbe/assets",
@@ -43,10 +43,6 @@
     {
       "from": "node_modules/@whotracksme/webextension-packages/packages/ui/src",
       "to": "vendor/@whotracksme/ui/src"
-    },
-    {
-      "from": "node_modules/@whotracksme/webextension-packages/packages/tracker-wheel/src",
-      "to": "vendor/@whotracksme/tracker-wheel/src"
     }
   ],
   "repository": {
@@ -60,7 +56,7 @@
   "homepage": "https://github.com/ghostery/ghostery-extension#readme",
   "dependencies": {
     "@cliqz/url-parser": "^1.1.4",
-    "@whotracksme/webextension-packages": "0.0.2",
+    "@whotracksme/webextension-packages": "whotracksme/webextension-packages#feat-refactor",
     "classnames": "^2.2.5",
     "d3": "^5.16.0",
     "foundation-sites": "^6.6.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "homepage": "https://github.com/ghostery/ghostery-extension#readme",
   "dependencies": {
     "@cliqz/url-parser": "^1.1.4",
-    "@whotracksme/webextension-packages": "whotracksme/webextension-packages#feat-refactor",
+    "@whotracksme/webextension-packages": "^0.1.0",
     "classnames": "^2.2.5",
     "d3": "^5.16.0",
     "foundation-sites": "^6.6.2",

--- a/src/background.js
+++ b/src/background.js
@@ -47,7 +47,11 @@ import * as utils from './utils/utils';
 import { _getJSONAPIErrorsObject } from './utils/api';
 import importCliqzSettings from './utils/cliqzSettingImport';
 import { sendCliqzModuleCounts } from './utils/cliqzModulesData';
-import { tryWTMReportOnMessageHandler } from './whotracksme/index';
+
+// @whotracksme/serp-report
+
+import './whotracksme/globals'; // loads tldts into the global scope
+import tryWTMReportOnMessageHandler from '../vendor/@whotracksme/serp-report/src/background/serp-report';
 
 // For debug purposes, provide Access to the internals of `ghostery-common`
 // module from Developer Tools Console.

--- a/src/whotracksme/index.js
+++ b/src/whotracksme/index.js
@@ -1,7 +1,0 @@
-import './globals';
-
-// eslint-disable-next-line no-undef
-const { tryWTMReportOnMessageHandler } = globalThis;
-
-// eslint-disable-next-line import/prefer-default-export
-export { tryWTMReportOnMessageHandler };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1281,10 +1281,9 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@whotracksme/webextension-packages@0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@whotracksme/webextension-packages/-/webextension-packages-0.0.2.tgz#2d6f23397ad091afbe9b8cf8ab9cb798b2b5ff80"
-  integrity sha512-iJIkqQ56i8q+ibqP54IrWwZSdLCslW5cYTziSZiBCjSAyTXR59I6TT8ZOG3pm0PE+9yA1wp/alduSgXl+7rkJw==
+"@whotracksme/webextension-packages@whotracksme/webextension-packages#feat-refactor":
+  version "0.0.3"
+  resolved "https://codeload.github.com/whotracksme/webextension-packages/tar.gz/53855b3148184308b0117b34f853f2accf24a213"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1281,9 +1281,10 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@whotracksme/webextension-packages@whotracksme/webextension-packages#feat-refactor":
-  version "0.0.3"
-  resolved "https://codeload.github.com/whotracksme/webextension-packages/tar.gz/53855b3148184308b0117b34f853f2accf24a213"
+"@whotracksme/webextension-packages@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@whotracksme/webextension-packages/-/webextension-packages-0.1.0.tgz#914b97734509a9e6f95908687e4d507f5bfc9abf"
+  integrity sha512-xJPEje/iUXHsoSbNsetYgc8DxUPD3GjDbrdLWhCN3phfvDQyDaXlJs69zkLxDbPPNWC3e06GBlmZT91L+B5VPA==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"


### PR DESCRIPTION
Updates (for now, from the GitHub directly - DO NOT MERGE before updating to the npm version) `webextension-packages` with the ES module exports for the `serp-report`.
