### PR TITLE
Improve internal error handling and cleanup obsolete keys

### DIFF
--- a/app/content-scripts/notifications.js
+++ b/app/content-scripts/notifications.js
@@ -701,55 +701,56 @@ const NotificationsContentScript = (function(win, doc) {
 	 */
 	const _initialize = function() {
 		onMessage.addListener((request, sender, sendResponse) => {
-			if (request.source === 'cliqz-content-script') {
-				return false;
-			}
+			try {
+				if (request.source !== 'cliqz-content-script') {
+					const alertMessages = [
+						'showUpgradeAlert',
+						'showLibraryUpdateAlert',
+						'showCMPMessage',
+						'showBrowseWindow'
+					];
+					const { name, message } = request;
 
-			const alertMessages = [
-				'showUpgradeAlert',
-				'showLibraryUpdateAlert',
-				'showCMPMessage',
-				'showBrowseWindow'
-			];
-			const { name, message } = request;
+					log('notifications.js received message', name);
 
-			log('notifications.js received message', name);
+					if (alertMessages.includes(name)) {
+						if (!CSS_INJECTED) {
+							CSS_INJECTED = true;
+							injectCSS();
+						}
+					}
 
-			if (alertMessages.includes(name)) {
-				if (!CSS_INJECTED) {
-					CSS_INJECTED = true;
-					injectCSS();
+					if (name === 'showCMPMessage') {
+						CMP_DATA = message.data;
+						showAlert('showCMPMessage', {
+							campaign: CMP_DATA
+						});
+						ALERT_SHOWN = true;
+					} else if (name === 'showUpgradeAlert') {
+						NOTIFICATION_TRANSLATIONS = message.translations;
+						showAlert('showUpgradeAlert', message.major_upgrade);
+						ALERT_SHOWN = true;
+					} else if (name === 'showLibraryUpdateAlert') {
+						NOTIFICATION_TRANSLATIONS = message.translations;
+						showAlert('showLibraryUpdateAlert');
+						ALERT_SHOWN = true;
+					// Import/Export related messages
+					} else if (name === 'showBrowseWindow') {
+						showBrowseWindow(message.translations);
+						ALERT_SHOWN = true;
+					} else if (name === 'onFileImported') {
+						updateBrowseWindow(message);
+					} else if (name === 'exportFile') {
+						const { content, type } = message;
+						exportFile(content, type);
+					}
 				}
+			} catch (e) {
+				sendResponse(e);
+				return;
 			}
 
-			if (name === 'showCMPMessage') {
-				CMP_DATA = message.data;
-				showAlert('showCMPMessage', {
-					campaign: CMP_DATA
-				});
-				ALERT_SHOWN = true;
-			} else if (name === 'showUpgradeAlert') {
-				NOTIFICATION_TRANSLATIONS = message.translations;
-				showAlert('showUpgradeAlert', message.major_upgrade);
-				ALERT_SHOWN = true;
-			} else if (name === 'showLibraryUpdateAlert') {
-				NOTIFICATION_TRANSLATIONS = message.translations;
-				showAlert('showLibraryUpdateAlert');
-				ALERT_SHOWN = true;
-			// Import/Export related messages
-			} else if (name === 'showBrowseWindow') {
-				showBrowseWindow(message.translations);
-				ALERT_SHOWN = true;
-			} else if (name === 'onFileImported') {
-				updateBrowseWindow(message);
-			} else if (name === 'exportFile') {
-				const { content, type } = message;
-				exportFile(content, type);
-			}
-
-			// trigger a response callback to src/background so that we can handle errors properly
 			sendResponse();
-			return true;
 		});
 	};
 

--- a/src/classes/PanelData.js
+++ b/src/classes/PanelData.js
@@ -597,8 +597,10 @@ class PanelData {
 		}
 
 		if (syncSetDataChanged) {
-			// Push conf changes to the server
-			account.saveUserSettings().catch(err => log('PanelData saveUserSettings', err));
+			// TODO: skip it if the user is not logged in (to avoid errors in the debug logs)
+			account.saveUserSettings().catch((err) => {
+				log('Unable to sync settings (note: this is expected if the user is not logged it)', err);
+			});
 		}
 	}
 

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -128,20 +128,18 @@ export function prefsGet(...args) {
  * @return {Promise} 		prefs object which has been set, or error
  */
 export function prefsSet(prefs) {
+	if (prefs === undefined || prefs === null) {
+		throw new Error('Bad argument');
+	}
 	return new Promise(((resolve, reject) => {
-		if (typeof prefs !== 'undefined') {
-			chrome.storage.local.set(prefs, () => {
-				if (chrome.runtime.lastError) {
-					log('prefsSet ERROR', chrome.runtime.lastError);
-					reject(new Error(chrome.runtime.lastError));
-				} else {
-					resolve(prefs);
-				}
-			});
-		} else {
-			log('prefsSet ERROR', chrome.runtime.lastError);
-			reject(new Error(chrome.runtime.lastError));
-		}
+		chrome.storage.local.set(prefs, () => {
+			if (chrome.runtime.lastError) {
+				alwaysLog('prefsSet ERROR', chrome.runtime.lastError);
+				reject(new Error(chrome.runtime.lastError));
+			} else {
+				resolve(prefs);
+			}
+		});
 	}));
 }
 
@@ -157,13 +155,9 @@ export function prefsSet(prefs) {
  */
 export function pref(key, value) {
 	if (typeof value === 'undefined') {
-		// call getter
 		return prefsGet(key);
 	}
-	// convert params to object and call setter
-	const valueObj = {};
-	valueObj[key] = value;
-	return prefsSet(valueObj);
+	return prefsSet({ [key]: value });
 }
 
 /**


### PR DESCRIPTION
Make the internal error handling more robust and ensure critical errors in prefSet are logged (refs #500).
Also, free up space in chrome.storage.local by deleting obsolete keys (fixes #747).
