### PR TITLE
Fixed: AdBlocking engine started with the wrong block mode

### DIFF
--- a/src/classes/Cliqz.js
+++ b/src/classes/Cliqz.js
@@ -22,6 +22,7 @@ export const HPN_MODULE = IS_ANDROID ? 'hpn-lite' : 'hpnv2';
 // Override the default prefs based on the platform
 CLIQZ.config.default_prefs = {
 	...CLIQZ.config.default_prefs,
+	cliqz_adb_mode: globals.DEFAULT_ADBLOCKER_MODE,
 	// the following are enabled by default on non-android platforms
 	'modules.human-web.enabled': !IS_ANDROID,
 	'modules.hpnv2.enabled': !IS_ANDROID,

--- a/src/classes/ConfData.js
+++ b/src/classes/ConfData.js
@@ -104,7 +104,7 @@ class ConfData {
 			_initProperty('alert_expanded', false);
 			_initProperty('bugs_last_checked', 0);
 			_initProperty('bugs_last_updated', nowTime);
-			_initProperty('cliqz_adb_mode', 2); // 2 == Ads + Trackers + Annoyances
+			_initProperty('cliqz_adb_mode', globals.DEFAULT_ADBLOCKER_SETTING);
 			_initProperty('cliqz_legacy_opt_in', false);
 			_initProperty('cliqz_import_state', 0);
 			_initProperty('cmp_version', 0);

--- a/src/classes/Globals.js
+++ b/src/classes/Globals.js
@@ -139,6 +139,7 @@ class Globals {
 			'pornvertising',
 			'site_analytics',
 		];
+		this.DEFAULT_ADBLOCKER_MODE = 2; // 2 == Ads + Trackers + Annoyances
 
 		this.SESSION = {
 			paused_blocking: false,


### PR DESCRIPTION
During first installation, the value of the AdBlocker engine was not initialized early enough. Fixed by propagating the default.
