### PR TITLE
API: handle more kinds of errors

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -80,7 +80,7 @@ class Api {
 				} else {
 					resolve(data);
 				}
-			});
+			}).catch(err => reject(err));
 		});
 	}
 
@@ -97,7 +97,11 @@ class Api {
 								shouldRefresh = true;
 							}
 						});
+					} else {
+						reject(data);
+						return;
 					}
+
 					if (shouldRefresh) {
 						this.refreshToken()
 							.then((res) => {


### PR DESCRIPTION
Those changes handle potential errors which could lead to `account.migrate` hanging on some rare sever errors. 

Fix #500 
Fix #777
