### PR TITLE
Trackers preview: follow build system structure

### DIFF
--- a/app/content-scripts/trackers-preview.js
+++ b/app/content-scripts/trackers-preview.js
@@ -1,6 +1,5 @@
 import setupTrackersPreview from '@whotracksme/webextension-packages/packages/trackers-preview/src/content_scripts';
-import './content_script.scss';
 
 setupTrackersPreview(
-	chrome.runtime.getURL('/app/trackers-preview/popup.html'),
+	chrome.runtime.getURL('/app/templates/trackers-preview.html'),
 );

--- a/app/scss/trackers-preview_content_script.scss
+++ b/app/scss/trackers-preview_content_script.scss
@@ -1,0 +1,1 @@
+@import "@whotracksme/webextension-packages/packages/trackers-preview/src/content_scripts/styles.css";

--- a/app/scss/trackers-preview_popup.scss
+++ b/app/scss/trackers-preview_popup.scss
@@ -1,0 +1,1 @@
+@import "@ghostery/ui/src/index.css";

--- a/app/templates/trackers-preview.html
+++ b/app/templates/trackers-preview.html
@@ -9,7 +9,7 @@
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
     <meta content="utf-8" http-equiv="encoding" />
     <script src="../../dist/trackers_preview_popup.js" type="module" async></script>
-    <link rel="stylesheet" href="../../dist/css/trackers_preview_popup.css" />
+    <link rel="stylesheet" href="../../dist/css/trackers_preview_popup_styles.css" />
   </head>
   <body>
     <wtm-trackers-preview></wtm-trackers-preview>

--- a/app/trackers-preview/content_script.scss
+++ b/app/trackers-preview/content_script.scss
@@ -1,1 +1,0 @@
-@import "../../node_modules/@whotracksme/webextension-packages/packages/trackers-preview/src/content_scripts/styles.css";

--- a/app/trackers-preview/popup.scss
+++ b/app/trackers-preview/popup.scss
@@ -1,1 +1,0 @@
-@import "../../node_modules/@ghostery/ui/src/index.css";

--- a/manifest.json
+++ b/manifest.json
@@ -67,7 +67,7 @@
 				"/dist/trackers_preview_content_script.js"
 			],
 			"css": [
-				"/dist/css/trackers_preview_content_script.css"
+				"/dist/css/trackers_preview_content_script_styles.css"
 			],
 			"matches": [
 				"*://*.google.com/*",
@@ -298,6 +298,6 @@
 	"minimum_opera_version": "56",
 	"web_accessible_resources": [
 		"app/images/*",
-		"app/trackers-preview/popup.html"
+		"app/templates/trackers-preview.html"
 	]
 }

--- a/src/trackers-preview/popup.js
+++ b/src/trackers-preview/popup.js
@@ -1,2 +1,1 @@
 import '@whotracksme/webextension-packages/packages/trackers-preview/src/components';
-import './popup.scss';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,6 @@ const HUB_DIR = path.resolve(__dirname, 'app/hub');
 const LICENSES_DIR = path.resolve(__dirname, 'app/licenses');
 const SASS_DIR = path.resolve(__dirname, 'app/scss');
 const CONTENT_SCRIPTS_DIR = path.resolve(__dirname, 'app/content-scripts');
-const TRACKERS_PREVIEW_DIR = path.resolve(__dirname, 'app/trackers-preview');
 const RM = (process.platform === 'win32') ? 'powershell remove-item' : 'rm';
 
 module.exports = {
@@ -62,8 +61,8 @@ module.exports = {
 		panel_react: [`${PANEL_DIR}/index.jsx`],
 		purplebox: [`${CONTENT_SCRIPTS_DIR}/purplebox.js`],
 		shared_comp_react: [`${SHARED_COMP_DIR}/index.js`],
-		trackers_preview_popup: [`${TRACKERS_PREVIEW_DIR}/popup.js`],
-		trackers_preview_content_script: [`${TRACKERS_PREVIEW_DIR}/content_script.js`],
+		trackers_preview_popup: [`${SRC_DIR}/trackers-preview/popup.js`],
+		trackers_preview_content_script: [`${CONTENT_SCRIPTS_DIR}/trackers-preview.js`],
 
 		// Sass
 		foundation: [`${SASS_DIR}/vendor/foundation.scss`],
@@ -73,6 +72,8 @@ module.exports = {
 		panel: [`${SASS_DIR}/panel.scss`],
 		panel_android: [`${SASS_DIR}/panel_android.scss`],
 		purplebox_styles: [`${SASS_DIR}/purplebox.scss`],
+		trackers_preview_popup_styles: [`${SASS_DIR}/trackers-preview_popup.scss`],
+		trackers_preview_content_script_styles: [`${SASS_DIR}/trackers-preview_content_script.scss`],
 	},
 	output: {
 		filename: '[name].js',


### PR DESCRIPTION
Trackers Preview having own folder in the `app` was not supported by the build system, which was resulting in source files being present in the production builds. 

This PR changes trackers-preview file structure to follow established conventions. 
