### PR TITLE
Add option to skip redirect tracking dialogs

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1898,6 +1898,12 @@
   "settings_purple_box": {
     "message": "Tracker-Tally"
   },
+  "settings_show_redirect_tracking_dialogs": {
+    "message": "Ask me to confirm before visiting a site that redirects me through a tracker"
+  },
+  "settings_show_redirect_tracking_dialogs_tooltip": {
+    "message": "Redirect tracking means that instead of visiting a website directly, you are first redirected through another site that may try to track you (e.g. by placing a cookie). In contrast to normal tracking, you cannot block the request without breaking the functionality."
+  },
   "settings_replace_social": {
     "message": "Replace blocked social media buttons with a Ghostery icon"
   },

--- a/app/panel/components/Settings/GeneralSettings.jsx
+++ b/app/panel/components/Settings/GeneralSettings.jsx
@@ -91,7 +91,7 @@ class GeneralSettings extends React.Component {
 		const { dbLastUpdated } = this.state;
 
 		return (
-			<div className="s-tabs-panel">
+			<div id="general-settings-panel" className="s-tabs-panel">
 				<div className="row">
 					<div className="columns">
 						<h3>WhoTracks.Me</h3>
@@ -172,6 +172,17 @@ class GeneralSettings extends React.Component {
 									<span>{ t('settings_allow_trackers') }</span>
 								</label>
 								<div className="s-tooltip-up" data-g-tooltip={t('settings_allow_trackers_tooltip')}>
+									<img src="../../app/images/panel/icon-information-tooltip.svg" className="s-question" />
+								</div>
+							</div>
+						</div>
+						<div className="s-option-group">
+							<div className="s-square-checkbox">
+								<input type="checkbox" id="settings-show-redirect-tracking-dialogs" name="show_redirect_tracking_dialogs" defaultChecked={settingsData.show_redirect_tracking_dialogs} onClick={toggleCheckbox} />
+								<label htmlFor="settings-show-redirect-tracking-dialogs">
+									<span>{ t('settings_show_redirect_tracking_dialogs') }</span>
+								</label>
+								<div className="s-tooltip-up" data-g-tooltip={t('settings_show_redirect_tracking_dialogs_tooltip')}>
 									<img src="../../app/images/panel/icon-information-tooltip.svg" className="s-question" />
 								</div>
 							</div>

--- a/app/panel/components/Settings/__tests__/__snapshots__/GeneralSettings.jsx.snap
+++ b/app/panel/components/Settings/__tests__/__snapshots__/GeneralSettings.jsx.snap
@@ -3,6 +3,7 @@
 exports[`app/panel/Settings/GeneralSettings.jsx Snapshot tests with react-test-renderer GeneralSettings is rendered correctly with falsy props 1`] = `
 <div
   className="s-tabs-panel"
+  id="general-settings-panel"
 >
   <div
     className="row"
@@ -242,6 +243,36 @@ exports[`app/panel/Settings/GeneralSettings.jsx Snapshot tests with react-test-r
           </div>
         </div>
       </div>
+      <div
+        className="s-option-group"
+      >
+        <div
+          className="s-square-checkbox"
+        >
+          <input
+            id="settings-show-redirect-tracking-dialogs"
+            name="show_redirect_tracking_dialogs"
+            onClick={[Function]}
+            type="checkbox"
+          />
+          <label
+            htmlFor="settings-show-redirect-tracking-dialogs"
+          >
+            <span>
+              settings_show_redirect_tracking_dialogs
+            </span>
+          </label>
+          <div
+            className="s-tooltip-up"
+            data-g-tooltip="settings_show_redirect_tracking_dialogs_tooltip"
+          >
+            <img
+              className="s-question"
+              src="../../app/images/panel/icon-information-tooltip.svg"
+            />
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -250,6 +281,7 @@ exports[`app/panel/Settings/GeneralSettings.jsx Snapshot tests with react-test-r
 exports[`app/panel/Settings/GeneralSettings.jsx Snapshot tests with react-test-renderer GeneralSettings is rendered correctly with truthy props 1`] = `
 <div
   className="s-tabs-panel"
+  id="general-settings-panel"
 >
   <div
     className="row"
@@ -482,6 +514,36 @@ exports[`app/panel/Settings/GeneralSettings.jsx Snapshot tests with react-test-r
           <div
             className="s-tooltip-up"
             data-g-tooltip="settings_allow_trackers_tooltip"
+          >
+            <img
+              className="s-question"
+              src="../../app/images/panel/icon-information-tooltip.svg"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        className="s-option-group"
+      >
+        <div
+          className="s-square-checkbox"
+        >
+          <input
+            id="settings-show-redirect-tracking-dialogs"
+            name="show_redirect_tracking_dialogs"
+            onClick={[Function]}
+            type="checkbox"
+          />
+          <label
+            htmlFor="settings-show-redirect-tracking-dialogs"
+          >
+            <span>
+              settings_show_redirect_tracking_dialogs
+            </span>
+          </label>
+          <div
+            className="s-tooltip-up"
+            data-g-tooltip="settings_show_redirect_tracking_dialogs_tooltip"
           >
             <img
               className="s-question"

--- a/app/scss/partials/_settings.scss
+++ b/app/scss/partials/_settings.scss
@@ -28,7 +28,6 @@
 	padding: 0;
 	text-size-adjust: 100%;
 	box-sizing: content-box;
-	overflow: hidden;
 
 	@import './partials/_settings_menu';
 
@@ -288,6 +287,11 @@
 			height: 1px;
 		}
 	}
+
+	#general-settings-panel {
+	  overflow-y: scroll;
+	}
+
 	// TRUST / RESTRICT
 	$itemWrapper: 0 13px 0 13px;
 	$itemHeight: 32px;

--- a/src/classes/ConfData.js
+++ b/src/classes/ConfData.js
@@ -148,6 +148,7 @@ class ConfData {
 			_initProperty('setup_complete', false);
 			_initProperty('tutorial_complete', false);
 			_initProperty('enable_wtm_serp_report', true);
+			_initProperty('show_redirect_tracking_dialogs', true);
 
 			// Complex props
 			_initProperty('account', null);

--- a/src/classes/Globals.js
+++ b/src/classes/Globals.js
@@ -126,6 +126,7 @@ class Globals {
 			'show_alert',
 			'show_badge',
 			'show_cmp',
+			'show_redirect_tracking_dialogs',
 			'show_tracker_urls',
 			'site_specific_blocks',
 			'site_specific_unblocks',

--- a/src/classes/PanelData.js
+++ b/src/classes/PanelData.js
@@ -473,7 +473,8 @@ class PanelData {
 			enable_click2play, enable_click2play_social, enable_human_web,
 			enable_metrics, enable_abtests, hide_alert_trusted, ignore_first_party, notify_library_updates,
 			notify_promotions, notify_upgrade_updates, selected_app_ids, show_alert, show_badge,
-			show_cmp, show_tracker_urls, toggle_individual_trackers, enable_wtm_serp_report
+			show_cmp, show_tracker_urls, toggle_individual_trackers, enable_wtm_serp_report,
+			show_redirect_tracking_dialogs
 		} = userSettingsSource;
 
 		return {
@@ -496,6 +497,7 @@ class PanelData {
 			show_alert,
 			show_badge,
 			show_cmp,
+			show_redirect_tracking_dialogs,
 			show_tracker_urls,
 			toggle_individual_trackers
 		};


### PR DESCRIPTION
By default, Ghostery will ask for confirmation if you open a link that redirects through a tracker. This change adds an option to skip the confirmation dialog.

refs https://github.com/ghostery/ghostery-extension/issues/786
