### PR TITLE
Bugfix: cannot login to ghostery account in Firefox with same site isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### GHOSTERY 8.7.6 (July 11, 2022)
+
+* Fixed: Ghostery Account login problems on Firefox
+
 ### GHOSTERY 8.7.5 (June 9, 2022)
 
 * Fixed: WTM default setting for Ghostery Browsers

--- a/manifest.json
+++ b/manifest.json
@@ -3,8 +3,8 @@
 	"author": "Ghostery",
 	"name": "__MSG_name__",
 	"short_name": "Ghostery",
-	"version": "8.7.5",
-	"version_name": "8.7.5",
+	"version": "8.7.6",
+	"version_name": "8.7.6",
 	"default_locale": "en",
 	"description": "__MSG_short_description__",
 	"icons": {

--- a/src/classes/Account.js
+++ b/src/classes/Account.js
@@ -96,14 +96,18 @@ class Account {
 
 	async logout() {
 		try {
-			const cookie = await cookiesGet({ name: 'csrf_token' });
-			if (!cookie) {
+			const csrfCookie = await cookiesGet({ name: 'csrf_token' });
+			const accessTokenCookie = await cookiesGet({ name: 'access_token' });
+			if (!csrfCookie || !accessTokenCookie) {
 				throw new Error('no cookie');
 			}
 			const res = await fetch(`${AUTH_SERVER}/api/v2/logout`, {
 				method: 'POST',
-				credentials: 'include',
-				headers: { 'X-CSRF-Token': cookie.value },
+				credentials: 'omit',
+				headers: {
+					'X-CSRF-Token': csrfCookie.value,
+					Authorization: `Bearer ${accessTokenCookie.value}`,
+				},
 			});
 			if (res.status < 400) {
 				ghosteryDebugger.addAccountEvent('logout', 'cookie set by fetch POST');

--- a/src/classes/Account.js
+++ b/src/classes/Account.js
@@ -94,28 +94,6 @@ class Account {
 		});
 	}
 
-	register = (email, confirmEmail, password, firstName, lastName) => {
-		const data = `email=${window.encodeURIComponent(email)}&email_confirmation=${window.encodeURIComponent(confirmEmail)}&first_name=${window.encodeURIComponent(firstName)}&last_name=${window.encodeURIComponent(lastName)}&password=${window.encodeURIComponent(password)}`;
-		return fetch(`${AUTH_SERVER}/api/v2/register`, {
-			method: 'POST',
-			body: data,
-			headers: {
-				'Content-Type': 'application/x-www-form-urlencoded',
-				'Content-Length': Buffer.byteLength(data),
-			},
-			credentials: 'include',
-		}).then((res) => {
-			if (res.status >= 400) {
-				ghosteryDebugger.addAccountEvent('register', 'cookie set by fetch POST');
-				return res.json();
-			}
-			this._getUserIDFromCookie().then((userID) => {
-				this._setAccountInfo(userID);
-			});
-			return {};
-		});
-	}
-
 	async logout() {
 		try {
 			const cookie = await cookiesGet({ name: 'csrf_token' });

--- a/src/classes/Account.js
+++ b/src/classes/Account.js
@@ -437,6 +437,7 @@ class Account {
 				expirationDate,
 				secure: true,
 				httpOnly,
+				sameSite: 'None',
 			});
 			if (!cookie) {
 				throw new Error('no cookie');

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -42,15 +42,18 @@ class Api {
 	}
 
 	async _sendReq(method, path, body) {
-		const { value: access_token } = await cookiesGet({ name: 'access_token' });
-		const csrfToken = await this._getCsrfCookie();
+		const	accessTokenCookie = await cookiesGet({ name: 'access_token' });
+		const	csrfTokenCookie = await cookiesGet({ name: 'csrf_token' });
+		if (!accessTokenCookie || !csrfTokenCookie) {
+			throw new Error('no cookie');
+		}
 		return fetch(`${this.config.ACCOUNT_SERVER}${path}`, {
 			method,
 			headers: {
 				'Content-Type': Api.JSONAPI_CONTENT_TYPE,
 				'Content-Length': Buffer.byteLength(JSON.stringify(body)),
-				Authorization: `Bearer ${access_token}`,
-				'X-CSRF-Token': csrfToken,
+				Authorization: `Bearer ${accessTokenCookie.value}`,
+				'X-CSRF-Token': csrfTokenCookie.value,
 			},
 			credentials: 'omit',
 			body: JSON.stringify(body),
@@ -135,18 +138,6 @@ class Api {
 					}
 				});
 		});
-	}
-
-	_getCsrfCookie = async () => {
-		try {
-			const cookie = await cookiesGet({ name: 'csrf_token' });
-			if (!cookie) {
-				return '';
-			}
-			return cookie.value;
-		} catch (e) {
-			return '';
-		}
 	}
 
 	_errorHandler = errors => Promise.resolve(errors)

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -52,16 +52,21 @@ class Api {
 	}
 
 	async _sendReq(method, path, body) {
-		const	accessTokenCookie = await cookiesGet({ name: 'access_token' });
+		const headers = {
+			'Content-Type': Api.JSONAPI_CONTENT_TYPE,
+			'Content-Length': Buffer.byteLength(JSON.stringify(body)),
+		};
 		const	csrfTokenCookie = await cookiesGet({ name: 'csrf_token' });
+		if (csrfTokenCookie) {
+			headers['X-CSRF-Token'] = csrfTokenCookie.value;
+		}
+		const	accessTokenCookie = await cookiesGet({ name: 'access_token' });
+		if (accessTokenCookie) {
+			headers.Authorization = `Bearer ${accessTokenCookie.value}`;
+		}
 		return fetch(`${this.config.ACCOUNT_SERVER}${path}`, {
 			method,
-			headers: {
-				'Content-Type': Api.JSONAPI_CONTENT_TYPE,
-				'Content-Length': Buffer.byteLength(JSON.stringify(body)),
-				Authorization: `Bearer ${accessTokenCookie ? accessTokenCookie.value : ''}`,
-				'X-CSRF-Token': csrfTokenCookie ? csrfTokenCookie.value : '',
-			},
+			headers,
 			credentials: 'omit',
 			body: JSON.stringify(body),
 		});

--- a/src/utils/cookies.js
+++ b/src/utils/cookies.js
@@ -1,6 +1,6 @@
 import globals from '../classes/Globals';
 
-let IS_FIRST_PARTY_ISOLATION_SUPPORTED = false;
+let IS_FIRST_PARTY_ISOLATION_ENABLED = false;
 let IS_FIRST_PARTY_ISOLATION_TESTED = false;
 
 function testForFirstPartyIsolation() {
@@ -9,12 +9,10 @@ function testForFirstPartyIsolation() {
 	}
 	try {
 		chrome.cookies.getAll({
-			url: globals.COOKIE_URL,
-			firstPartyDomain: globals.GHOSTERY_ROOT_DOMAIN,
+			domain: '',
 		});
-		IS_FIRST_PARTY_ISOLATION_SUPPORTED = true;
 	} catch (e) {
-		// first party isolation is not supported
+		IS_FIRST_PARTY_ISOLATION_ENABLED = e.message.indexOf('firstPartyDomain') > -1;
 	} finally {
 		IS_FIRST_PARTY_ISOLATION_TESTED = true;
 	}
@@ -31,7 +29,7 @@ function wrapDetails(args) {
 		newArgs.url = globals.COOKIE_URL;
 	}
 
-	if (IS_FIRST_PARTY_ISOLATION_SUPPORTED) {
+	if (IS_FIRST_PARTY_ISOLATION_ENABLED) {
 		newArgs.firstPartyDomain = globals.GHOSTERY_ROOT_DOMAIN;
 	}
 

--- a/src/utils/cookies.js
+++ b/src/utils/cookies.js
@@ -1,26 +1,27 @@
 import globals from '../classes/Globals';
+import { decodeJwt } from './common';
 
 let IS_FIRST_PARTY_ISOLATION_ENABLED = false;
 let IS_FIRST_PARTY_ISOLATION_TESTED = false;
 
-function testForFirstPartyIsolation() {
+async function testForFirstPartyIsolation() {
 	if (IS_FIRST_PARTY_ISOLATION_TESTED) {
 		return;
 	}
-	try {
+	await new Promise((resolve) => {
 		chrome.cookies.getAll({
 			domain: '',
+		}, () => {
+			if (chrome.runtime.lastError) {
+				IS_FIRST_PARTY_ISOLATION_ENABLED = chrome.runtime.lastError.message.indexOf('firstPartyDomain') > -1;
+			}
+			IS_FIRST_PARTY_ISOLATION_TESTED = true;
+			resolve();
 		});
-	} catch (e) {
-		IS_FIRST_PARTY_ISOLATION_ENABLED = e.message.indexOf('firstPartyDomain') > -1;
-	} finally {
-		IS_FIRST_PARTY_ISOLATION_TESTED = true;
-	}
+	});
 }
 
 function wrapDetails(args) {
-	testForFirstPartyIsolation();
-
 	const newArgs = {
 		...args,
 	};
@@ -37,17 +38,17 @@ function wrapDetails(args) {
 }
 
 function wrapFunction(func) {
-	return details => (
-		new Promise((resolve, reject) => {
-			func(wrapDetails(details), (result) => {
+	return details => testForFirstPartyIsolation().then(() => {
+		const wrappedDetails = wrapDetails(details);
+		return new Promise((resolve, reject) => {
+			func(wrappedDetails, (result) => {
 				if (chrome.runtime.lastError) {
 					reject(chrome.runtime.lastError);
-					return;
 				}
 				resolve(result);
 			});
-		})
-	);
+		});
+	});
 }
 
 export const cookiesGet = wrapFunction(chrome.cookies.get.bind(chrome.cookies));
@@ -55,4 +56,74 @@ export const cookiesGetAll = wrapFunction(chrome.cookies.getAll.bind(chrome.cook
 export const cookiesRemove = wrapFunction(chrome.cookies.remove.bind(chrome.cookies));
 export const cookiesSet = wrapFunction(chrome.cookies.set.bind(chrome.cookies));
 
-window.cookiesGet = cookiesGet;
+const setLoginCookie = async (details) => {
+	const {
+		name, value, expirationDate, httpOnly
+	} = details;
+	if (!name || !value) {
+		throw new Error(`One or more required values missing: ${JSON.stringify({ name, value })}`);
+	}
+	try {
+		const cookie = await cookiesSet({
+			name,
+			value,
+			domain: globals.COOKIE_DOMAIN,
+			expirationDate,
+			secure: true,
+			httpOnly,
+			sameSite: 'no_restriction',
+		});
+		if (!cookie) {
+			throw new Error('no cookie');
+		}
+		return cookie;
+	} catch (e) {
+		throw new Error(`Error setting cookie ${JSON.stringify(details)}: ${e}`);
+	}
+};
+
+export const setAllLoginCookies = ({
+	accessToken,
+	csrfToken,
+	refreshToken,
+	userId,
+	expirationDate,
+} = {}) => {
+	let exp = expirationDate;
+
+	if (!exp) {
+		const decodedAccessToken = decodeJwt(accessToken);
+		exp = decodedAccessToken.payload.exp;
+	}
+
+	if (!accessToken || !csrfToken || !refreshToken || !userId || !exp) {
+		throw new Error('login response incomplete');
+	}
+
+	return Promise.all([
+		setLoginCookie({
+			name: 'refresh_token',
+			value: refreshToken,
+			expirationDate: exp + 604800, // + 7 days
+			httpOnly: true,
+		}),
+		setLoginCookie({
+			name: 'access_token',
+			value: accessToken,
+			expirationDate: exp,
+			httpOnly: true,
+		}),
+		setLoginCookie({
+			name: 'csrf_token',
+			value: csrfToken,
+			expirationDate: exp,
+			httpOnly: false,
+		}),
+		setLoginCookie({
+			name: 'user_id',
+			value: userId,
+			expirationDate: 1893456000, // Tue Jan 1 2030 00:00:00 GMT. @TODO is this the best way of hanlding this?
+			httpOnly: false,
+		})
+	]);
+};


### PR DESCRIPTION
Firefox privacy features like [Same Site Isolation](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#first-party_isolation) and [State partitioning](https://developer.mozilla.org/en-US/docs/Web/Privacy/State_Partitioning) change the way we are able to use cookies to maintain a persistent user session in the Ghostery Browser Extension.

This PR, moves away from setting the session cookies implicitly by `login` and `refresh_token` requests in favor of doing it explicitly. It also uses `Authorization Bearer` HTTP header instead of a cookie to authorize all API requests. 

We should test this in:
* [ ] Chrome - to ensure there is no breakage
* [ ] Firefox 
* [ ] Firefox with Strict mode privacy settings (in `about:preferences#privacy` select `Strict`)
* [ ] Firefox with first party isolation enabled (set `privacy.firstparty.isolate` to `true` in `about:config`)