### PR TITLE
Fix the WhoTracks.me links shown in the redirect-tracking notification dialog

### DIFF
--- a/src/utils/click2play.js
+++ b/src/utils/click2play.js
@@ -206,7 +206,7 @@ export function buildRedirectC2P(redirectUrls, app_id) {
 	const host_url = processUrl(redirectUrls.url).hostname;
 	const redirect_url = processUrl(redirectUrls.redirectUrl).hostname;
 	const { name, trackerID } = bugDb.db.apps[app_id];
-	const wtmURL = `${globals.WTM_BASE_URL}/trackers/${encodeURIComponent(trackerID).toLowerCase()}`;
+	const wtmURL = `${globals.WTM_BASE_URL}/trackers/${encodeURIComponent(trackerID).toLowerCase()}.html`;
 
 	globals.BLOCKED_REDIRECT_DATA = {};
 	globals.BLOCKED_REDIRECT_DATA.app_id = app_id;


### PR DESCRIPTION
It was missing the trailing .html:

`https://www.whotracks.me/trackers/dotomi.html`

instead of

`https://www.whotracks.me/trackers/dotomi`

(Test URL: `https://www.anrdoezrs.net/click-8900245-14009780?url=https://www.att.com/buy/phones/browse/apple&sid=tomsguide-us-4369692664335449600`)