### PR TITLE
Fix dnr rules options field name

### DIFF
--- a/extension-manifest-v3/src/background/telemetry.js
+++ b/extension-manifest-v3/src/background/telemetry.js
@@ -45,7 +45,7 @@ const getConf = async () => {
     .toISOString()
     .split('T')[0];
   return {
-    enable_ad_block: Object.values(options.dnr).some((enabled) => enabled),
+    enable_ad_block: Object.values(options.dnrRules).some((enabled) => enabled),
     enable_human_web: options.terms,
     install_date,
   };


### PR DESCRIPTION
Fixes `dnr` -> `dnrRules`. For now, it throws:

<img width="891" alt="Zrzut ekranu 2022-08-17 o 11 22 20" src="https://user-images.githubusercontent.com/1906677/185084438-46f4645f-4f05-40e4-840e-79f1e0e98e24.png">
<img width="807" alt="Zrzut ekranu 2022-08-17 o 11 20 13" src="https://user-images.githubusercontent.com/1906677/185084554-3bfcd2c1-0ba3-4955-b650-d117f5c04b75.png">

