### PR TITLE
Upgrade adblocker library: improves blocking of YouTube ads on Chrome & support bfcache optimizations

### DIFF
--- a/extension-manifest-v2/package-lock.json
+++ b/extension-manifest-v2/package-lock.json
@@ -18,7 +18,7 @@
         "classnames": "^2.2.5",
         "d3": "^5.16.0",
         "foundation-sites": "^6.6.2",
-        "ghostery-common": "^1.2.17",
+        "ghostery-common": "^1.2.31",
         "history": "^4.10.1",
         "hybrids": "^8.0.10",
         "json-api-normalizer": "^1.0.4",
@@ -957,51 +957,51 @@
       }
     },
     "node_modules/@cliqz/adblocker": {
-      "version": "1.23.8",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker/-/adblocker-1.23.8.tgz",
-      "integrity": "sha512-xM1JYTv5dA+pPP4x4IVZdjkM9aAsakTnShFLuHLzMxMHd20eUB91NXm4kK6acw9nHwG6rCyat6+u7TvAqSmR6g==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker/-/adblocker-1.25.0.tgz",
+      "integrity": "sha512-hRcPyiZsU6KccHi7OdEmYxTjjE/TGPPLEjVVfnvlRXCwBSvVnBTXhx31BhUi7BHXXS+OvmNxJOb+cue1nu5YGw==",
       "dependencies": {
-        "@cliqz/adblocker-content": "^1.23.8",
-        "@cliqz/adblocker-extended-selectors": "^1.23.8",
+        "@cliqz/adblocker-content": "^1.25.0",
+        "@cliqz/adblocker-extended-selectors": "^1.25.0",
         "@remusao/guess-url-type": "^1.1.2",
         "@remusao/small": "^1.1.2",
         "@remusao/smaz": "^1.7.1",
-        "@types/chrome": "^0.0.183",
+        "@types/chrome": "^0.0.195",
         "@types/firefox-webext-browser": "^94.0.0",
         "tldts-experimental": "^5.6.21"
       }
     },
     "node_modules/@cliqz/adblocker-content": {
-      "version": "1.23.8",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-content/-/adblocker-content-1.23.8.tgz",
-      "integrity": "sha512-5Wm/OSA6H8AUVFi8SDff6xJ4zT/1VCrNoUnevFEi3e0MCmdQUvn+cJc03Saky7Ch5oLSJKTXNNMyPaODZLz24A==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-content/-/adblocker-content-1.25.0.tgz",
+      "integrity": "sha512-P3DenzNpd0WRpZAwCZHpOMiMs+o4e0lbHOLJSmOl09bVtwgvPV5PNqJeTQ0GNBgclTbrDzfXDbAEjm+NBm3vcA==",
       "dependencies": {
-        "@cliqz/adblocker-extended-selectors": "^1.23.8"
+        "@cliqz/adblocker-extended-selectors": "^1.25.0"
       }
     },
     "node_modules/@cliqz/adblocker-extended-selectors": {
-      "version": "1.23.8",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-extended-selectors/-/adblocker-extended-selectors-1.23.8.tgz",
-      "integrity": "sha512-5xx47oT2Q9E3vkfEm/EzSs7cAPi8WNWtu7kJcGa/urVkDchJwdkdelvQ2Dof+k5icI5AqZorZSsk9Q7w2bLxrA=="
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-extended-selectors/-/adblocker-extended-selectors-1.25.0.tgz",
+      "integrity": "sha512-8gUGPj1bnTqRVi414ouBlyRB9Y/orhlBBFhMAjjlmFNmcJNDLI0t3wFBjpxe/R95c2wGnTLxk5Fsahy1RamKRQ=="
     },
     "node_modules/@cliqz/adblocker-webextension": {
-      "version": "1.23.8",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-webextension/-/adblocker-webextension-1.23.8.tgz",
-      "integrity": "sha512-vl4PyA4we6BRU2SRIPNn+JwBABIJ9zhR9fnBLfz+q1wAAiCFLd9x9GRFwpETs/3A8OUkpcppJ9YzSea8qaAM0w==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-webextension/-/adblocker-webextension-1.25.0.tgz",
+      "integrity": "sha512-PGEPXsmjhHftKEvXiJGyCz1JeSvUYplR13EBhqPMypdVGTuKfnoE5JjZvrbIB+VHx9hppYXeY6lwrjSDGeMAww==",
       "dependencies": {
-        "@cliqz/adblocker": "^1.23.8",
-        "@cliqz/adblocker-content": "^1.23.8",
+        "@cliqz/adblocker": "^1.25.0",
+        "@cliqz/adblocker-content": "^1.25.0",
         "tldts-experimental": "^5.6.21",
         "webextension-polyfill-ts": "^0.26.0"
       }
     },
     "node_modules/@cliqz/adblocker-webextension-cosmetics": {
-      "version": "1.23.8",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-webextension-cosmetics/-/adblocker-webextension-cosmetics-1.23.8.tgz",
-      "integrity": "sha512-uF66OGqQ/dg/1BgfpmA9tPSCJn20sumqtok319CwBNXNvwtoMhOHxiNbcJ9Op/H4Q9uclPJu4Sk78acAHNb7hg==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-webextension-cosmetics/-/adblocker-webextension-cosmetics-1.25.0.tgz",
+      "integrity": "sha512-UNnJkK2/7D4TsFWZTMq8PAFFbjgKn/N6QvBJn0mLqMcAxBVePfyT+u3zk2ZRV69+QcfZfRByVy5i5fA/YlwMCA==",
       "dependencies": {
-        "@cliqz/adblocker-content": "^1.23.8",
-        "@cliqz/adblocker-extended-selectors": "^1.23.8"
+        "@cliqz/adblocker-content": "^1.25.0",
+        "@cliqz/adblocker-extended-selectors": "^1.25.0"
       }
     },
     "node_modules/@cliqz/url-parser": {
@@ -1058,15 +1058,6 @@
       "dev": true,
       "engines": {
         "node": "^12.20.0 || >=14"
-      }
-    },
-    "node_modules/@devicefarmer/adbkit/node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6.13.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -2314,9 +2305,9 @@
       }
     },
     "node_modules/@types/chrome": {
-      "version": "0.0.183",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.183.tgz",
-      "integrity": "sha512-sYI1qGY2oB6U5GFyuoSsVJsi2ytuEe92QrQTXQRwkISN8yn1gPY5qRq1XSwKN17yjvZTgxxeHw2ZoSHMti6qYg==",
+      "version": "0.0.195",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.195.tgz",
+      "integrity": "sha512-kmFh1xx7ehXoOVl6OjEBxmiYaquhxCaILjFGwPbW6xwbqzwDKCte+Mzl99aNWg3EP1B4rKVUuRm1vBsiRYks5g==",
       "dependencies": {
         "@types/filesystem": "*",
         "@types/har-format": "*"
@@ -9079,13 +9070,13 @@
       }
     },
     "node_modules/ghostery-common": {
-      "version": "1.2.23",
-      "resolved": "https://registry.npmjs.org/ghostery-common/-/ghostery-common-1.2.23.tgz",
-      "integrity": "sha512-faxp6A62ShahkaWLhtNy3rnRdD9Yy9uBY7UB/SuHTAL+6ez2buqZy86T7FuaztFjb+dnILevkKX+ElTrmM4cdg==",
+      "version": "1.2.31",
+      "resolved": "https://registry.npmjs.org/ghostery-common/-/ghostery-common-1.2.31.tgz",
+      "integrity": "sha512-7WOfXZIJMCQulB8X+qtKXPKl8DulVO6Wt6S2oTv2tiwe7ApGC4wWQYNKX0AOmQpHo8cauV8Moo1lR2c5Xq0X/g==",
       "dependencies": {
         "@cliqz-oss/dexie": "^2.0.4",
-        "@cliqz/adblocker-webextension": "^1.20.0",
-        "@cliqz/adblocker-webextension-cosmetics": "^1.20.0",
+        "@cliqz/adblocker-webextension": "^1.25.0",
+        "@cliqz/adblocker-webextension-cosmetics": "^1.25.0",
         "@cliqz/url-parser": "^1.1.4",
         "abortcontroller-polyfill": "^1.5.0",
         "anonymous-credentials": "https://github.com/whotracksme/anonymous-credentials/releases/download/1.0.0/anonymous-credentials-1.0.0.tgz",
@@ -9093,9 +9084,9 @@
         "jsonschema": "^1.4.0",
         "linkedom": "^0.14.5",
         "math-expression-evaluator": "^1.3.8",
-        "moment": "^2.29.1",
+        "moment": "^2.29.4",
         "node-fetch": "^2.6.1",
-        "node-forge": "^0.10.0",
+        "node-forge": "^1.3.1",
         "pako": "^2.0.4",
         "punycode": "^2.1.1",
         "rusha": "^0.8.14",
@@ -14981,11 +14972,11 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-gyp": {
@@ -23550,51 +23541,51 @@
       "integrity": "sha512-HxMbBQfdy0CehThTFierXbRPI+PHDEucUUriCCzViAKbCWWQIlL6uZcyDaaPRMPWy45v78lezPB4457kfjS72g=="
     },
     "@cliqz/adblocker": {
-      "version": "1.23.8",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker/-/adblocker-1.23.8.tgz",
-      "integrity": "sha512-xM1JYTv5dA+pPP4x4IVZdjkM9aAsakTnShFLuHLzMxMHd20eUB91NXm4kK6acw9nHwG6rCyat6+u7TvAqSmR6g==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker/-/adblocker-1.25.0.tgz",
+      "integrity": "sha512-hRcPyiZsU6KccHi7OdEmYxTjjE/TGPPLEjVVfnvlRXCwBSvVnBTXhx31BhUi7BHXXS+OvmNxJOb+cue1nu5YGw==",
       "requires": {
-        "@cliqz/adblocker-content": "^1.23.8",
-        "@cliqz/adblocker-extended-selectors": "^1.23.8",
+        "@cliqz/adblocker-content": "^1.25.0",
+        "@cliqz/adblocker-extended-selectors": "^1.25.0",
         "@remusao/guess-url-type": "^1.1.2",
         "@remusao/small": "^1.1.2",
         "@remusao/smaz": "^1.7.1",
-        "@types/chrome": "^0.0.183",
+        "@types/chrome": "^0.0.195",
         "@types/firefox-webext-browser": "^94.0.0",
         "tldts-experimental": "^5.6.21"
       }
     },
     "@cliqz/adblocker-content": {
-      "version": "1.23.8",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-content/-/adblocker-content-1.23.8.tgz",
-      "integrity": "sha512-5Wm/OSA6H8AUVFi8SDff6xJ4zT/1VCrNoUnevFEi3e0MCmdQUvn+cJc03Saky7Ch5oLSJKTXNNMyPaODZLz24A==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-content/-/adblocker-content-1.25.0.tgz",
+      "integrity": "sha512-P3DenzNpd0WRpZAwCZHpOMiMs+o4e0lbHOLJSmOl09bVtwgvPV5PNqJeTQ0GNBgclTbrDzfXDbAEjm+NBm3vcA==",
       "requires": {
-        "@cliqz/adblocker-extended-selectors": "^1.23.8"
+        "@cliqz/adblocker-extended-selectors": "^1.25.0"
       }
     },
     "@cliqz/adblocker-extended-selectors": {
-      "version": "1.23.8",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-extended-selectors/-/adblocker-extended-selectors-1.23.8.tgz",
-      "integrity": "sha512-5xx47oT2Q9E3vkfEm/EzSs7cAPi8WNWtu7kJcGa/urVkDchJwdkdelvQ2Dof+k5icI5AqZorZSsk9Q7w2bLxrA=="
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-extended-selectors/-/adblocker-extended-selectors-1.25.0.tgz",
+      "integrity": "sha512-8gUGPj1bnTqRVi414ouBlyRB9Y/orhlBBFhMAjjlmFNmcJNDLI0t3wFBjpxe/R95c2wGnTLxk5Fsahy1RamKRQ=="
     },
     "@cliqz/adblocker-webextension": {
-      "version": "1.23.8",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-webextension/-/adblocker-webextension-1.23.8.tgz",
-      "integrity": "sha512-vl4PyA4we6BRU2SRIPNn+JwBABIJ9zhR9fnBLfz+q1wAAiCFLd9x9GRFwpETs/3A8OUkpcppJ9YzSea8qaAM0w==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-webextension/-/adblocker-webextension-1.25.0.tgz",
+      "integrity": "sha512-PGEPXsmjhHftKEvXiJGyCz1JeSvUYplR13EBhqPMypdVGTuKfnoE5JjZvrbIB+VHx9hppYXeY6lwrjSDGeMAww==",
       "requires": {
-        "@cliqz/adblocker": "^1.23.8",
-        "@cliqz/adblocker-content": "^1.23.8",
+        "@cliqz/adblocker": "^1.25.0",
+        "@cliqz/adblocker-content": "^1.25.0",
         "tldts-experimental": "^5.6.21",
         "webextension-polyfill-ts": "^0.26.0"
       }
     },
     "@cliqz/adblocker-webextension-cosmetics": {
-      "version": "1.23.8",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-webextension-cosmetics/-/adblocker-webextension-cosmetics-1.23.8.tgz",
-      "integrity": "sha512-uF66OGqQ/dg/1BgfpmA9tPSCJn20sumqtok319CwBNXNvwtoMhOHxiNbcJ9Op/H4Q9uclPJu4Sk78acAHNb7hg==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-webextension-cosmetics/-/adblocker-webextension-cosmetics-1.25.0.tgz",
+      "integrity": "sha512-UNnJkK2/7D4TsFWZTMq8PAFFbjgKn/N6QvBJn0mLqMcAxBVePfyT+u3zk2ZRV69+QcfZfRByVy5i5fA/YlwMCA==",
       "requires": {
-        "@cliqz/adblocker-content": "^1.23.8",
-        "@cliqz/adblocker-extended-selectors": "^1.23.8"
+        "@cliqz/adblocker-content": "^1.25.0",
+        "@cliqz/adblocker-extended-selectors": "^1.25.0"
       }
     },
     "@cliqz/url-parser": {
@@ -23624,12 +23615,6 @@
           "version": "9.4.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
           "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
-          "dev": true
-        },
-        "node-forge": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-          "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
           "dev": true
         }
       }
@@ -24644,9 +24629,9 @@
       }
     },
     "@types/chrome": {
-      "version": "0.0.183",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.183.tgz",
-      "integrity": "sha512-sYI1qGY2oB6U5GFyuoSsVJsi2ytuEe92QrQTXQRwkISN8yn1gPY5qRq1XSwKN17yjvZTgxxeHw2ZoSHMti6qYg==",
+      "version": "0.0.195",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.195.tgz",
+      "integrity": "sha512-kmFh1xx7ehXoOVl6OjEBxmiYaquhxCaILjFGwPbW6xwbqzwDKCte+Mzl99aNWg3EP1B4rKVUuRm1vBsiRYks5g==",
       "requires": {
         "@types/filesystem": "*",
         "@types/har-format": "*"
@@ -30081,13 +30066,13 @@
       }
     },
     "ghostery-common": {
-      "version": "1.2.23",
-      "resolved": "https://registry.npmjs.org/ghostery-common/-/ghostery-common-1.2.23.tgz",
-      "integrity": "sha512-faxp6A62ShahkaWLhtNy3rnRdD9Yy9uBY7UB/SuHTAL+6ez2buqZy86T7FuaztFjb+dnILevkKX+ElTrmM4cdg==",
+      "version": "1.2.31",
+      "resolved": "https://registry.npmjs.org/ghostery-common/-/ghostery-common-1.2.31.tgz",
+      "integrity": "sha512-7WOfXZIJMCQulB8X+qtKXPKl8DulVO6Wt6S2oTv2tiwe7ApGC4wWQYNKX0AOmQpHo8cauV8Moo1lR2c5Xq0X/g==",
       "requires": {
         "@cliqz-oss/dexie": "^2.0.4",
-        "@cliqz/adblocker-webextension": "^1.20.0",
-        "@cliqz/adblocker-webextension-cosmetics": "^1.20.0",
+        "@cliqz/adblocker-webextension": "^1.25.0",
+        "@cliqz/adblocker-webextension-cosmetics": "^1.25.0",
         "@cliqz/url-parser": "^1.1.4",
         "abortcontroller-polyfill": "^1.5.0",
         "anonymous-credentials": "https://github.com/whotracksme/anonymous-credentials/releases/download/1.0.0/anonymous-credentials-1.0.0.tgz",
@@ -30095,9 +30080,9 @@
         "jsonschema": "^1.4.0",
         "linkedom": "^0.14.5",
         "math-expression-evaluator": "^1.3.8",
-        "moment": "^2.29.1",
+        "moment": "^2.29.4",
         "node-fetch": "^2.6.1",
-        "node-forge": "^0.10.0",
+        "node-forge": "^1.3.1",
         "pako": "^2.0.4",
         "punycode": "^2.1.1",
         "rusha": "^0.8.14",
@@ -34530,9 +34515,9 @@
       }
     },
     "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
     "node-gyp": {
       "version": "8.4.1",

--- a/extension-manifest-v2/package.json
+++ b/extension-manifest-v2/package.json
@@ -56,7 +56,7 @@
     "classnames": "^2.2.5",
     "d3": "^5.16.0",
     "foundation-sites": "^6.6.2",
-    "ghostery-common": "^1.2.17",
+    "ghostery-common": "^1.2.31",
     "history": "^4.10.1",
     "hybrids": "^8.0.10",
     "json-api-normalizer": "^1.0.4",

--- a/extension-manifest-v2/src/background.js
+++ b/extension-manifest-v2/src/background.js
@@ -941,9 +941,6 @@ function initializeDispatcher() {
 		// update content script state when blocking is paused/unpaused
 		common.modules.core.action('refreshAppState');
 	});
-	dispatcher.on('conf.save.enable_ad_block', (enableAdBlock) => {
-		setAdblockerState(enableAdBlock);
-	});
 }
 
 /**

--- a/extension-manifest-v2/src/background.js
+++ b/extension-manifest-v2/src/background.js
@@ -18,7 +18,9 @@ import { debounce, every, size } from 'underscore';
 import moment from 'moment/min/moment-with-locales.min';
 import { tryWTMReportOnMessageHandler, isDisableWTMReportMessage } from '@whotracksme/webextension-packages/packages/trackers-preview/src/background/index';
 
-import common, { setAdblockerState, setAntitrackingState, setWhotracksmeState } from './classes/Common';
+import common, {
+	syncTrustedSites, setAdblockerState, setAntitrackingState, setWhotracksmeState
+} from './classes/Common';
 import ghosteryDebugger from './classes/Debugger';
 // object classes
 import Events from './classes/EventHandlers';
@@ -902,6 +904,7 @@ function initializeDispatcher() {
 		// TODO debounce with below
 		button.update();
 		utils.flushChromeMemoryCache();
+		syncTrustedSites();
 		common.modules.core.action('refreshAppState');
 	});
 	dispatcher.on('conf.save.site_blacklist', () => {
@@ -937,6 +940,9 @@ function initializeDispatcher() {
 	dispatcher.on('globals.save.paused_blocking', () => {
 		// update content script state when blocking is paused/unpaused
 		common.modules.core.action('refreshAppState');
+	});
+	dispatcher.on('conf.save.enable_ad_block', (enableAdBlock) => {
+		setAdblockerState(enableAdBlock);
 	});
 }
 

--- a/extension-manifest-v2/src/classes/Common.js
+++ b/extension-manifest-v2/src/classes/Common.js
@@ -50,6 +50,10 @@ const setPref = (pref, value) => {
 	common.prefs.set(pref, value);
 };
 
+export const syncTrustedSites = () => {
+	setPref('adb-trusted-sites', conf.site_whitelist || []);
+};
+
 const start = common.start.bind(common);
 common.start = async () => {
 	// ensures that prefs.set is present
@@ -76,6 +80,8 @@ common.start = async () => {
 	}
 
 	setPref('cliqz_adb_mode', DEFAULT_ADBLOCKER_MODE);
+	syncTrustedSites();
+
 	setPref('modules.adblocker.enabled', conf.enable_ad_block);
 	setPref('modules.antitracking.enabled', conf.enable_anti_tracking);
 	setPref('modules.human-web.enabled', conf.enable_human_web);


### PR DESCRIPTION
Integrates the latest version of the adblocker engine, which fixes a problem in Chrome: YouTube ads were being shown in certain scenarios, for instance, when reloading the page.

This pull request notifies the adblocker about trusted sites (together with https://github.com/ghostery/common/pull/52), but most of the changes are in the adblocker library itself (https://github.com/ghostery/adblocker/pull/2750).

Another improvement in the library is that "unload" listeners will be replaced by "pagehide" listeners, which will no longer break bfcache (see https://github.com/ghostery/ghostery-extension/issues/836, https://github.com/ghostery/adblocker/pull/2782, https://github.com/ghostery/common/pull/53).