### PR TITLE
TrackersDB: fix caching

### DIFF
--- a/extension-manifest-v2/src/background.js
+++ b/extension-manifest-v2/src/background.js
@@ -45,7 +45,7 @@ import ErrorReporter from './classes/ErrorReporter';
 // utilities
 import { allowAllwaysC2P } from './utils/click2play';
 import {
-	log, alwaysLog, hashCode, prefsSet, prefsGet
+	log, alwaysLog, hashCode, prefsSet, prefsGet, getISODate
 } from './utils/common';
 import * as utils from './utils/utils';
 import { injectNotifications } from './utils/inject';
@@ -88,7 +88,7 @@ const { onHeadersReceived } = Events;
 function updateDBs() {
 	return new Promise(((resolve, reject) => {
 		const failed = { success: false, updated: false };
-		utils.getJson(VERSION_CHECK_URL).then((data) => {
+		utils.getJson(`${VERSION_CHECK_URL}?d=${getISODate()}`).then((data) => {
 			log('Database version retrieval succeeded', data);
 
 			c2pDb.update(data.click2play);
@@ -1320,11 +1320,7 @@ function initializeGhosteryModules() {
 		conf.metrics.install_complete_all = Date.now();
 	} else if (globals.JUST_INSTALLED) {
 		log('JUST INSTALLED');
-		const date = new Date();
-		const year = date.getFullYear().toString();
-		const month = (`0${date.getMonth() + 1}`).slice(-2).toString();
-		const day = (`0${date.getDate()}`).slice(-2).toString();
-		const dateString = `${year}-${month}-${day}`;
+		const dateString = getISODate();
 		const randomNumber = (Math.floor(Math.random() * 100) + 1);
 
 		conf.install_random_number = randomNumber;

--- a/extension-manifest-v2/src/classes/Updatable.js
+++ b/extension-manifest-v2/src/classes/Updatable.js
@@ -15,7 +15,7 @@ import { bind, isFunction } from 'underscore';
 import globals from './Globals';
 import conf from './Conf';
 import { getJson, fetchLocalJSONResource } from '../utils/utils';
-import { log } from '../utils/common';
+import { getISODate, log } from '../utils/common';
 
 const { CDN_BASE_URL } = globals;
 /**
@@ -130,7 +130,7 @@ class Updatable {
 	 */
 	_remoteFetcher(callback) {
 		log(`fetching ${this.type} from remote`);
-		const UPDATE_URL = `${CDN_BASE_URL}/update/v4.1/${this.type}.json`;
+		const UPDATE_URL = `${CDN_BASE_URL}/update/v4.1/${this.type}.json?d=${getISODate()}`;
 
 		getJson(UPDATE_URL).then((list) => {
 			callback(true, list);

--- a/extension-manifest-v2/src/utils/common.js
+++ b/extension-manifest-v2/src/utils/common.js
@@ -240,3 +240,7 @@ export function decodeJwt(token) {
 		signature: signatureSeg
 	};
 }
+
+export function getISODate() {
+	return new Date().toISOString().split('T')[0];
+}


### PR DESCRIPTION
Caching headers on the CDN are set to 1 year. That means, the tracker db could only update once every 365 years. With this change the caching headers with hold only for 1 day, which is a behavior we want.