### PR TITLE
fixed regression: set default categories only once after installation

### DIFF
--- a/extension-manifest-v2/src/background.js
+++ b/extension-manifest-v2/src/background.js
@@ -1515,7 +1515,9 @@ async function initializeAccount() {
 
 		if (!conf.account) {
 			ghosteryDebugger.addAccountEvent('app started', 'not signed in');
-			setGhosteryDefaultBlocking();
+			if (globals.JUST_INSTALLED) {
+				setGhosteryDefaultBlocking();
+			}
 			return;
 		}
 


### PR DESCRIPTION
Enforcing default blocking categories must not be done on each startup, but only when the extension is first installed.
Otherwise, it becomes impossible to disable a tracker in the default category because it will be selected again after an extension restart.

refs #853
