### PR TITLE
fixed regression: do not hide the UI element for toggling categories of trackers

### DIFF
--- a/extension-manifest-v2/app/panel/components/Blocking/BlockingHeader.jsx
+++ b/extension-manifest-v2/app/panel/components/Blocking/BlockingHeader.jsx
@@ -269,7 +269,7 @@ class BlockingHeader extends React.Component {
 	}
 
 	/**
-	* Render appropriate Blocking Header to be part of Blocking or Global Blblocking view.
+	* Render appropriate Blocking Header to be part of Blocking or Global Blocking view.
 	* @return {ReactComponent}   ReactComponent instance
 	*/
 	render() {

--- a/extension-manifest-v2/app/panel/components/Settings.jsx
+++ b/extension-manifest-v2/app/panel/components/Settings.jsx
@@ -78,7 +78,7 @@ class Settings extends React.Component {
 	}
 
 	GlobalBlockingComponent = () => {
-		const { actions, language } = this.props;
+		const { actions, language, setup_complete } = this.props;
 		return (
 			<GlobalBlocking
 				toggleCheckbox={this.toggleCheckbox}
@@ -86,6 +86,7 @@ class Settings extends React.Component {
 				actions={actions}
 				showToast={this.showToast}
 				language={language}
+				setup_complete={setup_complete}
 			/>
 		);
 	}
@@ -103,12 +104,13 @@ class Settings extends React.Component {
 	}
 
 	GeneralSettingsComponent = () => {
-		const { actions } = this.props;
+		const { actions, setup_complete } = this.props;
 		return (
 			<GeneralSettings
 				toggleCheckbox={this.toggleCheckbox}
 				settingsData={this.props}
 				actions={actions}
+				setup_complete={setup_complete}
 			/>
 		);
 	}

--- a/extension-manifest-v2/app/panel/components/Settings/GlobalBlocking.jsx
+++ b/extension-manifest-v2/app/panel/components/Settings/GlobalBlocking.jsx
@@ -46,6 +46,7 @@ class GlobalBlocking extends React.Component {
 			showToast,
 			filtered,
 			language,
+			setup_complete,
 		} = this.props;
 		const categories = settingsData ? settingsData.categories : [];
 		const filterText = settingsData ? settingsData.filterText : t('settings_filter_all_label');
@@ -66,6 +67,7 @@ class GlobalBlocking extends React.Component {
 					paused_blocking={settingsData.paused_blocking}
 					selected_app_ids={settingsData.selected_app_ids}
 					globalBlocking
+					setup_complete={setup_complete}
 				/>
 				<div className="blocking-trackers">
 					{ categories && categories.length > 0 && (
@@ -77,6 +79,7 @@ class GlobalBlocking extends React.Component {
 							showToast={showToast}
 							language={language}
 							globalBlocking
+							setup_complete={setup_complete}
 						/>
 					)}
 				</div>

--- a/extension-manifest-v2/app/panel/containers/SettingsContainer.js
+++ b/extension-manifest-v2/app/panel/containers/SettingsContainer.js
@@ -37,7 +37,8 @@ const mapStateToProps = state => ({
 	site_blacklist: state.summary.site_blacklist,
 	site_whitelist: state.summary.site_whitelist,
 	trackers_banner_status: state.panel.trackers_banner_status,
-	trackerCounts: state.summary.trackerCounts
+	trackerCounts: state.summary.trackerCounts,
+	setup_complete: state.panel.setup_complete,
 });
 /**
  * Bind Settings view component action creators using Redux's bindActionCreators


### PR DESCRIPTION
The option to toggle categories of trackers was hidden because the "setup_complete" property was not always passed through.

refs #853
