### PR TITLE
Trim the email entered in the "login" and "forget password" dialog

### DIFF
--- a/extension-manifest-v2/app/panel/components/Login.jsx
+++ b/extension-manifest-v2/app/panel/components/Login.jsx
@@ -52,7 +52,8 @@ class Login extends React.Component {
 	handleSubmit = (e) => {
 		const { actions, is_expert } = this.props;
 		e.preventDefault();
-		const { email, password } = this.state;
+		const { email: emailRaw, password } = this.state;
+		const email = emailRaw?.trim();
 		const emailIsValid = email && validateEmail(email);
 
 		this.setState({

--- a/extension-manifest-v2/app/shared-components/ForgotPassword/ForgotPassword.jsx
+++ b/extension-manifest-v2/app/shared-components/ForgotPassword/ForgotPassword.jsx
@@ -45,7 +45,7 @@ class ForgotPassword extends React.Component {
 	handleSubmit = (e) => {
 		e.preventDefault();
 		this.setState({ loading: true }, () => {
-			const { email } = this.state;
+			const email = this.state.email?.trim();
 
 			// validate the email and password
 			if (!validateEmail(email)) {


### PR DESCRIPTION
Ignore leading and trailing whitespaces in emails in the login/forgot password forms.

refs #813
