### PR TITLE
[v3] Fix offscreen wheel drawing

### DIFF
--- a/ui/src/utils/wheel.js
+++ b/ui/src/utils/wheel.js
@@ -16,8 +16,8 @@ function degToRad(degree) {
   return degree * factor;
 }
 
-export function drawWheel(ctx, size, categories) {
-  if (typeof window !== 'undefined') {
+export function drawWheel(ctx, size, categories, useScale = true) {
+  if (useScale && typeof window !== 'undefined') {
     const { canvas } = ctx;
 
     canvas.style.width = size + 'px';
@@ -86,7 +86,7 @@ export function getOffscreenImageData(size, categories) {
     canvas.height = size;
   }
   const ctx = canvas.getContext('2d');
-  drawWheel(ctx, size, categories);
+  drawWheel(ctx, size, categories, false);
 
   return ctx.getImageData(0, 0, size, size);
 }


### PR DESCRIPTION
Safari background process uses background pages, which have `window` in the context. As a result, a wheel icon on Safari is broken.

The pr fixes the issue.