### PR TITLE
MV3: Panel UI broken layout

### DIFF
--- a/extension-manifest-v2/package-lock.json
+++ b/extension-manifest-v2/package-lock.json
@@ -9787,9 +9787,9 @@
       }
     },
     "node_modules/hybrids": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/hybrids/-/hybrids-8.1.3.tgz",
-      "integrity": "sha512-jkVTz2Uyqn3PTy2ILCuGJyuUtv1FzGSzG3HZBC11hfRNZhLkIL8L1RkP0PdIWb+apHCfNC/VOdgxBXfMbUDnJQ==",
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/hybrids/-/hybrids-8.1.4.tgz",
+      "integrity": "sha512-TtXSXubVCZjhyowVkp7yb5wn9mz8NQ6V74du3FDqgGnAMDvSFIWE8lzZ355j3zbv4astf/Kd9rjVDbwUOrwc7Q==",
       "bin": {
         "hybrids": "scripts/cli.js"
       }
@@ -30664,9 +30664,9 @@
       }
     },
     "hybrids": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/hybrids/-/hybrids-8.1.3.tgz",
-      "integrity": "sha512-jkVTz2Uyqn3PTy2ILCuGJyuUtv1FzGSzG3HZBC11hfRNZhLkIL8L1RkP0PdIWb+apHCfNC/VOdgxBXfMbUDnJQ=="
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/hybrids/-/hybrids-8.1.4.tgz",
+      "integrity": "sha512-TtXSXubVCZjhyowVkp7yb5wn9mz8NQ6V74du3FDqgGnAMDvSFIWE8lzZ355j3zbv4astf/Kd9rjVDbwUOrwc7Q=="
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/extension-manifest-v3/package-lock.json
+++ b/extension-manifest-v3/package-lock.json
@@ -3082,9 +3082,9 @@
       }
     },
     "node_modules/hybrids": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/hybrids/-/hybrids-8.1.3.tgz",
-      "integrity": "sha512-jkVTz2Uyqn3PTy2ILCuGJyuUtv1FzGSzG3HZBC11hfRNZhLkIL8L1RkP0PdIWb+apHCfNC/VOdgxBXfMbUDnJQ==",
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/hybrids/-/hybrids-8.1.4.tgz",
+      "integrity": "sha512-TtXSXubVCZjhyowVkp7yb5wn9mz8NQ6V74du3FDqgGnAMDvSFIWE8lzZ355j3zbv4astf/Kd9rjVDbwUOrwc7Q==",
       "bin": {
         "hybrids": "scripts/cli.js"
       }
@@ -8485,9 +8485,9 @@
       "dev": true
     },
     "hybrids": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/hybrids/-/hybrids-8.1.3.tgz",
-      "integrity": "sha512-jkVTz2Uyqn3PTy2ILCuGJyuUtv1FzGSzG3HZBC11hfRNZhLkIL8L1RkP0PdIWb+apHCfNC/VOdgxBXfMbUDnJQ=="
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/hybrids/-/hybrids-8.1.4.tgz",
+      "integrity": "sha512-TtXSXubVCZjhyowVkp7yb5wn9mz8NQ6V74du3FDqgGnAMDvSFIWE8lzZ355j3zbv4astf/Kd9rjVDbwUOrwc7Q=="
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/extension-manifest-v3/src/pages/panel/components/category-with-trackers.js
+++ b/extension-manifest-v3/src/pages/panel/components/category-with-trackers.js
@@ -35,7 +35,7 @@ export default define({
   },
   render: ({ category, stats, shouldShowMore, trackerCounts }) => html`
     <main onclick="${toggleShowMore}">
-      <label><ui-category name="${category}" bullet="12"></ui-category></label>
+      <ui-category name="${category}" bullet="12"></ui-category>
       <strong class="count">
         <!-- Number of trackers detected by Ghostery -->
         ${stats.byCategory[category].count} Detected
@@ -95,13 +95,10 @@ export default define({
     main button svg {
       height: 18px;
     }
-    main label {
+    ui-category {
       cursor: pointer;
-    }
-    label {
       margin: 0 7px;
       font-size: 14px;
-      font-family: inherit;
       line-height: 20px;
       color: var(--ui-black);
     }
@@ -129,6 +126,7 @@ export default define({
     }
     li label {
       margin: 0 5px;
+      color: var(--ui-black);
       font-size: 13px;
       line-height: 16px;
     }

--- a/ui/src/components/category.js
+++ b/ui/src/components/category.js
@@ -68,11 +68,11 @@ export default define({
   },
   bullet: 0,
   count: 0,
-  content: ({ name, bullet, count }) => {
+  render: ({ name, bullet, count }) => {
     const sizePx = `${bullet}px`;
 
     return html`
-      <template layout="row items:center gap">
+      <template layout="row items:center gap shrink:0">
         ${!!bullet &&
         html`<div
           layout="shrink:0"
@@ -83,9 +83,21 @@ export default define({
             borderRadius: sizePx,
           }}
         ></div>`}
-        <div layout="grow">${labels[name]}</div>
-        ${!!count && html`<div><strong>${count}</strong></div>`}
+        <div layout="grow">
+          ${labels[name]} ${!!count && html`<strong>${count}</strong>`}
+        </div>
       </template>
+    `.css`
+      :host {
+        font-size: 13px;
+        line-height: 16px;
+        white-space: nowrap;
+      }
+
+      strong {
+        color: var(--ui-black);
+        font-weight: 500;
+      }
     `;
   },
 });

--- a/ui/src/components/stats.js
+++ b/ui/src/components/stats.js
@@ -27,56 +27,21 @@ export default define({
       ),
     ).sort(sortCategories((a) => a[0]));
   },
-  render: ({ categories, entries }) => html`
-    <ui-tracker-wheel categories="${categories}"></ui-tracker-wheel>
+  content: ({ categories, entries }) => html`
+    <template layout="row items:center gap margin:2:0">
+      <ui-tracker-wheel categories="${categories}"></ui-tracker-wheel>
 
-    <ul>
-      ${entries.map(
-        ([category, value]) => html`
-          <li class="category">
+      <section layout="grow column gap:0.5 items:start">
+        ${entries.map(
+          ([category, value]) => html`
             <ui-category
               name="${category}"
               bullet="7"
               count="${value}"
             ></ui-category>
-          </li>
-        `,
-      )}
-    </ul>
-  `.css`
-     :host {
-       display: grid;
-       grid-template-columns: 1fr 1fr;
-       column-gap: 10px;
-       padding: 10px 0px;
-     }
-
-     ul {
-       display: flex;
-       flex-direction: column;
-       justify-content: center;
-       margin: 0;
-       padding: 0;
-       list-style-type: none;
-       list-style: none none inside;
-       white-space: nowrap;
-     }
-
-     .category {
-       display: grid;
-       grid-template-columns: min-content max-content 1fr;
-       grid-gap: 5px;
-       margin-bottom: 5px;
-     }
-
-     .category {
-       font-size: 13px;
-       line-height: 16px;
-     }
-
-     .category strong {
-       color: var(--ui-black);
-       font-weight: 500;
-     }
-    `,
+          `,
+        )}
+      </section>
+    </template>
+  `,
 });


### PR DESCRIPTION
Fixes #874.

The core issue is related to the bug in the layout engine of the hybrids about how to style elements are cleared when removed from the DOM. To reproduce the error you must open the panel in Safari, go to details and go back to the main view. Otherwise, the layout is fine. 

When looking for errors in our code, I made some clean up of the styles in `ui-category` and `ui-stats` components. It looks that updating hybrids could solve the issue, but I think the changes are worth to be included.
