### PR TITLE
Pause feature to whitelist domains

### DIFF
--- a/extension-manifest-v3/src/background/cosmetics.js
+++ b/extension-manifest-v3/src/background/cosmetics.js
@@ -23,12 +23,17 @@ const adblockerEngines = DNR_RULES_LIST.reduce((map, name) => {
   };
   return map;
 }, {});
+let pausedDomains = [];
 
 let adblockerStartupPromise = (async function () {
   await observe('dnrRules', (dnrRules) => {
     DNR_RULES_LIST.forEach((key) => {
       adblockerEngines[key].isEnabled = dnrRules[key];
     });
+  });
+
+  await observe('paused', (paused) => {
+    pausedDomains = paused ? paused.map(String) : [];
   });
 
   await Promise.all(
@@ -43,7 +48,6 @@ let adblockerStartupPromise = (async function () {
       adblockerEngines[engineName].engine = engine;
     }),
   );
-
   adblockerStartupPromise = null;
 })();
 
@@ -91,7 +95,17 @@ function adblockerInjectStylesWebExtension(
 }
 
 // copied from https://github.com/cliqz-oss/adblocker/blob/0bdff8559f1c19effe278b8982fb8b6c33c9c0ab/packages/adblocker-webextension/adblocker.ts#L297
-async function adblockerOnMessage(msg, sender) {
+async function adblockerOnMessage(msg, sender, sendResponse) {
+  // Extract hostname from sender's URL
+  const { url = '', frameId } = sender;
+  const parsed = parse(url);
+  const hostname = parsed.hostname || '';
+  const domain = parsed.domain || '';
+
+  if (pausedDomains.includes(domain)) {
+    return;
+  }
+
   if (adblockerStartupPromise) {
     await adblockerStartupPromise;
   }
@@ -100,18 +114,10 @@ async function adblockerOnMessage(msg, sender) {
   const specificStyles = [];
   let specificFrameId = null;
 
-  Object.keys(adblockerEngines).forEach((engineName) => {
-    if (adblockerEngines[engineName].isEnabled === false) {
+  Object.values(adblockerEngines).forEach(([{ engine, isEnabled }]) => {
+    if (!isEnabled) {
       return;
     }
-
-    const { engine } = adblockerEngines[engineName];
-
-    // Extract hostname from sender's URL
-    const { url = '', frameId } = sender;
-    const parsed = parse(url);
-    const hostname = parsed.hostname || '';
-    const domain = parsed.domain || '';
 
     // Once per tab/page load we inject base stylesheets. These are always
     // the same for all frames of a given page because they do not depend on
@@ -247,18 +253,20 @@ ${scripts.join('\n\n')}}
   );
 }
 
-chrome.webNavigation.onCommitted.addListener((details) => {
+chrome.webNavigation.onCommitted.addListener(async (details) => {
   const { hostname, domain } = parse(details.url);
   if (!hostname) {
     return;
   }
 
-  Object.keys(adblockerEngines).forEach((engineName) => {
-    if (adblockerEngines[engineName].isEnabled === false) {
+  if (adblockerStartupPromise) {
+    await adblockerStartupPromise;
+  }
+
+  Object.values(adblockerEngines).forEach(({ isEnabled, engine }) => {
+    if (isEnabled === false) {
       return;
     }
-
-    const { engine } = adblockerEngines[engineName];
 
     const { active, scripts } = engine.getCosmeticsFilters({
       url: details.url,

--- a/extension-manifest-v3/src/background/cosmetics.js
+++ b/extension-manifest-v3/src/background/cosmetics.js
@@ -95,7 +95,7 @@ function adblockerInjectStylesWebExtension(
 }
 
 // copied from https://github.com/cliqz-oss/adblocker/blob/0bdff8559f1c19effe278b8982fb8b6c33c9c0ab/packages/adblocker-webextension/adblocker.ts#L297
-async function adblockerOnMessage(msg, sender, sendResponse) {
+async function adblockerOnMessage(msg, sender) {
   // Extract hostname from sender's URL
   const { url = '', frameId } = sender;
   const parsed = parse(url);

--- a/extension-manifest-v3/src/pages/options/devtools.js
+++ b/extension-manifest-v3/src/pages/options/devtools.js
@@ -9,7 +9,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import { define, html } from 'hybrids';
+import { define, html, store } from 'hybrids';
+import Options from '/store/options.js';
 
 const VERSION = chrome.runtime.getManifest().version;
 
@@ -35,7 +36,17 @@ async function asyncAction(event, fn, complete = '') {
 }
 
 function clearStorage(host, event) {
-  asyncAction(event, () => chrome.storage.local.clear(), 'Storage cleared');
+  asyncAction(
+    event,
+    async () => {
+      // Restore options to default values
+      await store.set(Options, null);
+
+      // Clear main local storage
+      chrome.storage.local.clear();
+    },
+    'Storage cleared',
+  );
 }
 
 export default define({

--- a/extension-manifest-v3/src/store/options.js
+++ b/extension-manifest-v3/src/store/options.js
@@ -53,6 +53,8 @@ const Options = {
       return options;
     },
     async set(_, options) {
+      if (options === null) options = {};
+
       await chrome.storage.local.set({ options });
 
       // Send update message to another contexts (background page / panel / options)
@@ -94,9 +96,84 @@ const Options = {
           disableRulesetIds,
         });
       }
+
+      // Ensure paused domains are reflected in dynamic rule
+      if (options.paused) {
+        const [rule] = await chrome.declarativeNetRequest.getDynamicRules();
+        const pausedDomains = options.paused.map(String);
+
+        const initiatorDomains = rule?.condition.initiatorDomains || [];
+        if (pausedDomains.length) {
+          if (
+            pausedDomains.some(
+              (domain, index) => initiatorDomains[index] !== domain,
+            )
+          ) {
+            chrome.declarativeNetRequest.updateDynamicRules({
+              addRules: [
+                {
+                  id: 1,
+                  priority: 10000,
+                  action: {
+                    type: 'allowAllRequests',
+                  },
+                  condition: {
+                    requestDomains: pausedDomains,
+                    resourceTypes: ['main_frame'],
+                  },
+                },
+              ],
+              removeRuleIds: rule ? [1] : undefined,
+            });
+          }
+        } else if (rule) {
+          chrome.declarativeNetRequest.updateDynamicRules({
+            removeRuleIds: [rule.id],
+          });
+        }
+
+        const alarms = await chrome.alarms.getAll();
+        const revokeDomains = options.paused.filter(({ revokeAt }) => revokeAt);
+
+        // Clear alarms for removed domains
+        alarms.forEach(({ name }) => {
+          if (!revokeDomains.find(({ id }) => name === `revoke:${id}`)) {
+            chrome.alarms.clear(name);
+          }
+        });
+
+        // Add alarms for new domains
+        if (revokeDomains.length) {
+          revokeDomains
+            .filter(({ id }) => !alarms.some(({ name }) => name === id))
+            .forEach(({ id, revokeAt }) => {
+              chrome.alarms.create(`revoke:${id}`, { when: revokeAt });
+            });
+        }
+      }
     },
   },
 };
+
+if (chrome.declarativeNetRequest.getDynamicRules) {
+  // Define `paused` property for keeping paused sites
+  Options.paused = [{ id: true, revokeAt: 0 }];
+
+  // Remove paused domains from dynamic rule when alarm is triggered
+  chrome.alarms.onAlarm.addListener((alarm) => {
+    if (alarm.name.startsWith('revoke:')) {
+      console.log('Revoke paused domain', alarm.name);
+
+      store.resolve(Options).then((options) => {
+        store.set(options, {
+          paused: options.paused.filter(
+            ({ id }) => `revoke:${id}` !== alarm.name,
+          ),
+        });
+      });
+    }
+  });
+}
 
 export default Options;
 
@@ -136,10 +213,10 @@ chrome.runtime.onMessage.addListener((msg) => {
       store.get(Options);
     }
 
+    const resolvedOptions = store.resolve(options);
+
     observers.forEach((fn) => {
-      fn(msg.options);
+      resolvedOptions.then(fn);
     });
   }
-
-  return false;
 });


### PR DESCRIPTION
Adds core logic for the pause feature. The UI has a pause button that whitelists a domain for a minute - blocks cosmetics and adds the 'allow' rule to the dynamic DNR list.

Additionally, I found a bug, which throws a lot of error messages in the console caused by to early closed messaging channel in the cosmetics content script.

We can merge the feature without showing it to the users - we just need to hardcode false condition here - https://github.com/ghostery/ghostery-extension/pull/883/files#diff-ab787eda050f8d097068bea78c9043e942c4480fdb99acf1f1c0213b0bbd859dR159
