### PR TITLE
Fixed: access tokens should also be refreshed on 10020 errors

### DIFF
--- a/extension-manifest-v2/src/utils/api.js
+++ b/extension-manifest-v2/src/utils/api.js
@@ -130,7 +130,13 @@ class Api {
 					let shouldRefresh = false;
 					if (data && data.errors) {
 						data.errors.forEach((e) => {
-							if (e.code === '10021' || e.code === '10022') { // token is expired or missing
+							if (e.code === '10020' || e.code === '10021' || e.code === '10022') {
+								// The access_token was rejected, but we can get a new one because it is
+								// one of the retryable cases (not valid, expired, or missing).
+								//
+								// Note: "not valid" ('10020') is somewhat misleading: it does not
+								// necessarily mean that the access_token is ill-formed; the server
+								// will also return that code in situations where the token expired.
 								shouldRefresh = true;
 							}
 						});


### PR DESCRIPTION
Fixed another bug where the user gets logged out: the server may return a 10020 ("token is not valid") if the token has expired. That case was not detected and thus the user gets logged out as a consequence.

refs https://github.com/ghostery/ghostery-extension/issues/43
