### PR TITLE
Upgrade common (adblocker fixes)

### DIFF
--- a/extension-manifest-v2/package-lock.json
+++ b/extension-manifest-v2/package-lock.json
@@ -19,7 +19,7 @@
         "classnames": "^2.2.5",
         "d3": "^5.16.0",
         "foundation-sites": "^6.6.2",
-        "ghostery-common": "^1.2.39",
+        "ghostery-common": "^1.2.44",
         "history": "^4.10.1",
         "hybrids": "^8.1.1",
         "json-api-normalizer": "^1.0.4",
@@ -9082,9 +9082,9 @@
       }
     },
     "node_modules/ghostery-common": {
-      "version": "1.2.39",
-      "resolved": "https://registry.npmjs.org/ghostery-common/-/ghostery-common-1.2.39.tgz",
-      "integrity": "sha512-4IopbLs5b3g07XXeTMvT2eoU7b8IaDdhrlcK21pCh804CriLawwWUn/v2WPD3kjK+KgKPBVJsrK6gulbvTpJ5Q==",
+      "version": "1.2.44",
+      "resolved": "https://registry.npmjs.org/ghostery-common/-/ghostery-common-1.2.44.tgz",
+      "integrity": "sha512-rLWLcNV83DNBKQBzUpv1/u3C9DG2urG2roIfYqT+lMAyydpcRxuQTMNAQZUmeYBhoBSCvo2dwPT7hNMZah3KmA==",
       "dependencies": {
         "@cliqz-oss/dexie": "^2.0.4",
         "@cliqz/adblocker-webextension": "^1.25.0",
@@ -30111,9 +30111,9 @@
       }
     },
     "ghostery-common": {
-      "version": "1.2.39",
-      "resolved": "https://registry.npmjs.org/ghostery-common/-/ghostery-common-1.2.39.tgz",
-      "integrity": "sha512-4IopbLs5b3g07XXeTMvT2eoU7b8IaDdhrlcK21pCh804CriLawwWUn/v2WPD3kjK+KgKPBVJsrK6gulbvTpJ5Q==",
+      "version": "1.2.44",
+      "resolved": "https://registry.npmjs.org/ghostery-common/-/ghostery-common-1.2.44.tgz",
+      "integrity": "sha512-rLWLcNV83DNBKQBzUpv1/u3C9DG2urG2roIfYqT+lMAyydpcRxuQTMNAQZUmeYBhoBSCvo2dwPT7hNMZah3KmA==",
       "requires": {
         "@cliqz-oss/dexie": "^2.0.4",
         "@cliqz/adblocker-webextension": "^1.25.0",

--- a/extension-manifest-v2/package.json
+++ b/extension-manifest-v2/package.json
@@ -57,7 +57,7 @@
     "classnames": "^2.2.5",
     "d3": "^5.16.0",
     "foundation-sites": "^6.6.2",
-    "ghostery-common": "^1.2.39",
+    "ghostery-common": "^1.2.44",
     "history": "^4.10.1",
     "hybrids": "^8.1.1",
     "json-api-normalizer": "^1.0.4",


### PR DESCRIPTION
Most importantly, it contains a fix for the adblocker (https://github.com/ghostery/common/pull/66).
