### PR TITLE
UI tweak: the scrollbar in the settings UI is not needed in English

### DIFF
--- a/extension-manifest-v2/app/scss/partials/_settings.scss
+++ b/extension-manifest-v2/app/scss/partials/_settings.scss
@@ -289,7 +289,7 @@
 	}
 
 	#general-settings-panel {
-	  overflow-y: scroll;
+	  overflow-y: auto;
 	}
 
 	// TRUST / RESTRICT


### PR DESCRIPTION
In some languages like English, the scrollbar in the general settings are not needed. Before:

![image](https://user-images.githubusercontent.com/1616509/197601843-7c542acc-59f7-4ea6-b599-f6dc1c8c38ed.png)

After (English):
![after](https://user-images.githubusercontent.com/1616509/197602103-98f47a6e-79cc-421e-92bc-4ddadddbc67a.png)

After (German):
![after-with-scrollbar](https://user-images.githubusercontent.com/1616509/197602698-4a4eefd4-a11c-4c8c-a59a-b421a1eb6282.png)