### PR TITLE
Never-Consent: change default choice after two interactions

### DIFF
--- a/extension-manifest-v2/app/content-scripts/autoconsent.js
+++ b/extension-manifest-v2/app/content-scripts/autoconsent.js
@@ -23,7 +23,7 @@ chrome.runtime.onMessage.addListener((msg) => {
 			if (shownIframe) return false;
 
 			showIframe(chrome.runtime.getURL(
-				`app/templates/autoconsent.html?host=${encodeURIComponent(msg.domain)}`
+				`app/templates/autoconsent.html?host=${encodeURIComponent(msg.domain)}&default=${msg.defaultForAll ? 'all' : ''}`
 			));
 			shownIframe = true;
 

--- a/extension-manifest-v2/src/background.js
+++ b/extension-manifest-v2/src/background.js
@@ -560,7 +560,7 @@ function onMessageHandler(request, sender, callback) {
 			conf.enable_autoconsent = true;
 			if (message.url) {
 				conf.autoconsent_whitelist = conf.autoconsent_whitelist.concat(message.url);
-				conf.never_consent_interactions += 1;
+				conf.autoconsent_interactions += 1;
 			} else {
 				conf.autoconsent_whitelist = null;
 				conf.autoconsent_blacklist = null;
@@ -571,7 +571,7 @@ function onMessageHandler(request, sender, callback) {
 		if (name === 'disable') {
 			if (message.url) {
 				conf.autoconsent_blacklist = conf.autoconsent_blacklist.concat(message.url);
-				conf.never_consent_interactions += 1;
+				conf.autoconsent_interactions += 1;
 			} else {
 				conf.enable_autoconsent = false;
 				conf.autoconsent_whitelist = [];

--- a/extension-manifest-v2/src/background.js
+++ b/extension-manifest-v2/src/background.js
@@ -564,6 +564,7 @@ function onMessageHandler(request, sender, callback) {
 			} else {
 				conf.autoconsent_whitelist = null;
 				conf.autoconsent_blacklist = null;
+				conf.autoconsent_interactions = 0;
 			}
 
 			return false;
@@ -576,6 +577,7 @@ function onMessageHandler(request, sender, callback) {
 				conf.enable_autoconsent = false;
 				conf.autoconsent_whitelist = [];
 				conf.autoconsent_blacklist = [];
+				conf.autoconsent_interactions = 0;
 			}
 
 			return false;

--- a/extension-manifest-v2/src/background.js
+++ b/extension-manifest-v2/src/background.js
@@ -560,6 +560,7 @@ function onMessageHandler(request, sender, callback) {
 			conf.enable_autoconsent = true;
 			if (message.url) {
 				conf.autoconsent_whitelist = conf.autoconsent_whitelist.concat(message.url);
+				conf.never_consent_interactions += 1;
 			} else {
 				conf.autoconsent_whitelist = null;
 				conf.autoconsent_blacklist = null;
@@ -570,6 +571,7 @@ function onMessageHandler(request, sender, callback) {
 		if (name === 'disable') {
 			if (message.url) {
 				conf.autoconsent_blacklist = conf.autoconsent_blacklist.concat(message.url);
+				conf.never_consent_interactions += 1;
 			} else {
 				conf.enable_autoconsent = false;
 				conf.autoconsent_whitelist = [];

--- a/extension-manifest-v2/src/classes/ConfData.js
+++ b/extension-manifest-v2/src/classes/ConfData.js
@@ -135,7 +135,7 @@ class ConfData {
 			_initProperty('account', null);
 			_initProperty('autoconsent_whitelist', []);
 			_initProperty('autoconsent_blacklist', []);
-			_initProperty('never_consent_interactions', 0);
+			_initProperty('autoconsent_interactions', 0);
 			_initProperty('bugs', {});
 			_initProperty('click2play', {});
 			_initProperty('cmp_data', []);

--- a/extension-manifest-v2/src/classes/ConfData.js
+++ b/extension-manifest-v2/src/classes/ConfData.js
@@ -135,6 +135,7 @@ class ConfData {
 			_initProperty('account', null);
 			_initProperty('autoconsent_whitelist', []);
 			_initProperty('autoconsent_blacklist', []);
+			_initProperty('never_consent_interactions', 0);
 			_initProperty('bugs', {});
 			_initProperty('click2play', {});
 			_initProperty('cmp_data', []);

--- a/extension-manifest-v2/src/classes/PanelData.js
+++ b/extension-manifest-v2/src/classes/PanelData.js
@@ -600,7 +600,7 @@ class PanelData {
 		if (data.enable_autoconsent === false) {
 			conf.autoconsent_whitelist = [];
 			conf.autoconsent_blacklist = [];
-			conf.never_consent_interactions = 0;
+			conf.autoconsent_interactions = 0;
 			syncSetDataChanged = true;
 		}
 

--- a/extension-manifest-v2/src/classes/PanelData.js
+++ b/extension-manifest-v2/src/classes/PanelData.js
@@ -600,6 +600,7 @@ class PanelData {
 		if (data.enable_autoconsent === false) {
 			conf.autoconsent_whitelist = [];
 			conf.autoconsent_blacklist = [];
+			conf.never_consent_interactions = 0;
 			syncSetDataChanged = true;
 		}
 

--- a/extension-manifest-v2/src/classes/PanelData.js
+++ b/extension-manifest-v2/src/classes/PanelData.js
@@ -600,8 +600,11 @@ class PanelData {
 		if (data.enable_autoconsent === false) {
 			conf.autoconsent_whitelist = [];
 			conf.autoconsent_blacklist = [];
-			conf.autoconsent_interactions = 0;
 			syncSetDataChanged = true;
+		}
+
+		if (data.hasOwnProperty('enable_autoconsent')) {
+			conf.autoconsent_interactions = 0;
 		}
 
 		if (syncSetDataChanged) {

--- a/extension-manifest-v2/src/modules/autoconsent.js
+++ b/extension-manifest-v2/src/modules/autoconsent.js
@@ -89,7 +89,7 @@ async function evalCode(code, id, tabId, frameId) {
 }
 
 async function openIframe(msg, tabId) {
-	const { autoconsent_whitelist, never_consent_interactions } = conf;
+	const { autoconsent_whitelist, autoconsent_interactions } = conf;
 	if (!autoconsent_whitelist) return;
 
 	const domain = await getTabDomain(tabId);
@@ -104,7 +104,7 @@ async function openIframe(msg, tabId) {
 			action: 'autoconsent',
 			type: 'openIframe',
 			domain,
-			defaultForAll: never_consent_interactions >= 2,
+			defaultForAll: autoconsent_interactions >= 2,
 		},
 		{ frameId: 0 },
 	);

--- a/extension-manifest-v2/src/modules/autoconsent.js
+++ b/extension-manifest-v2/src/modules/autoconsent.js
@@ -89,7 +89,7 @@ async function evalCode(code, id, tabId, frameId) {
 }
 
 async function openIframe(msg, tabId) {
-	const { autoconsent_whitelist } = conf;
+	const { autoconsent_whitelist, never_consent_interactions } = conf;
 	if (!autoconsent_whitelist) return;
 
 	const domain = await getTabDomain(tabId);
@@ -100,7 +100,12 @@ async function openIframe(msg, tabId) {
 
 	chrome.tabs.sendMessage(
 		tabId,
-		{ action: 'autoconsent', type: 'openIframe', domain },
+		{
+			action: 'autoconsent',
+			type: 'openIframe',
+			domain,
+			defaultForAll: never_consent_interactions >= 2,
+		},
 		{ frameId: 0 },
 	);
 }

--- a/extension-manifest-v3/src/background/autoconsent.js
+++ b/extension-manifest-v3/src/background/autoconsent.js
@@ -91,7 +91,12 @@ async function openIframe(msg, tabId) {
 
   chrome.tabs.sendMessage(
     tabId,
-    { action: 'autoconsent', type: 'openIframe', domain },
+    {
+      action: 'autoconsent',
+      type: 'openIframe',
+      domain,
+      defaultForAll: autoconsent.interactions >= 2,
+    },
     { frameId: 0 },
   );
 }

--- a/extension-manifest-v3/src/content_scripts/autoconsent.js
+++ b/extension-manifest-v3/src/content_scripts/autoconsent.js
@@ -26,7 +26,9 @@ chrome.runtime.onMessage.addListener((msg) => {
 
       showIframe(
         chrome.runtime.getURL(
-          `pages/autoconsent/index.html?host=${encodeURIComponent(msg.domain)}`,
+          `pages/autoconsent/index.html?host=${encodeURIComponent(
+            msg.domain,
+          )}&default=${msg.defaultForAll ? 'all' : ''}`,
         ),
       );
       shownIframe = true;

--- a/extension-manifest-v3/src/pages/autoconsent/autoconsent.js
+++ b/extension-manifest-v3/src/pages/autoconsent/autoconsent.js
@@ -20,12 +20,13 @@ async function enable(_, event) {
   const options = await store.resolve(Options);
   const { all } = event.detail;
 
-  let { allowed, disallowed } = options.autoconsent;
+  let { allowed, disallowed, interactions } = options.autoconsent;
 
   if (all) {
     allowed = [];
     disallowed = [];
   } else {
+    interactions += 1;
     allowed = allowed.includes(hostname) ? allowed : allowed.concat(hostname);
   }
 
@@ -34,6 +35,7 @@ async function enable(_, event) {
       all,
       allowed,
       disallowed,
+      interactions,
     },
   });
 }
@@ -42,12 +44,14 @@ async function disable(_, event) {
   const options = await store.resolve(Options);
   const { all } = event.detail;
 
-  let { disallowed, allowed } = options.autoconsent;
+  let { disallowed, allowed, interactions } = options.autoconsent;
 
   if (all) {
     disallowed = [];
     allowed = [];
+    interactions = 0;
   } else {
+    interactions += 1;
     disallowed = disallowed.includes(hostname)
       ? disallowed
       : disallowed.concat(hostname);
@@ -55,7 +59,7 @@ async function disable(_, event) {
 
   store.set(Options, {
     dnrRules: { annoyances: !all },
-    autoconsent: { allowed, disallowed },
+    autoconsent: { allowed, disallowed, interactions },
   });
 }
 

--- a/extension-manifest-v3/src/store/options.js
+++ b/extension-manifest-v3/src/store/options.js
@@ -26,6 +26,7 @@ const Options = {
     all: false,
     allowed: [String],
     disallowed: [String],
+    interactions: 0,
   },
   trackerWheel: true,
   wtmSerpReport: true,

--- a/ui/src/modules/autoconsent/views/home.js
+++ b/ui/src/modules/autoconsent/views/home.js
@@ -13,7 +13,9 @@ import { define, html, router, dispatch } from 'hybrids';
 
 import Confirm from './confirm.js';
 
-const defaultChoice = new URLSearchParams(window.location.search).get('default');
+const defaultChoice = new URLSearchParams(window.location.search).get(
+  'default',
+);
 
 function onConfirm(type) {
   return (host) => {
@@ -27,7 +29,6 @@ function onConfirm(type) {
 export default define({
   tag: 'ui-autoconsent-home-view',
   scope: defaultChoice === 'all' ? 'all' : 'selected',
-  defaultAll: defaultChoice === 'all',
   content: ({ scope }) =>
     html`
       <template layout="column margin:3 gap:4">

--- a/ui/src/modules/autoconsent/views/home.js
+++ b/ui/src/modules/autoconsent/views/home.js
@@ -26,7 +26,7 @@ function onConfirm(type) {
 
 export default define({
   tag: 'ui-autoconsent-home-view',
-  scope: 'selected',
+  scope: defaultChoice === 'all' ? 'all' : 'selected',
   defaultAll: defaultChoice === 'all',
   content: ({ defaultAll }) =>
     html`

--- a/ui/src/modules/autoconsent/views/home.js
+++ b/ui/src/modules/autoconsent/views/home.js
@@ -29,7 +29,7 @@ function onConfirm(type) {
 export default define({
   tag: 'ui-autoconsent-home-view',
   scope: defaultChoice === 'all' ? 'all' : 'selected',
-  content: ({ scope }) =>
+  content: () =>
     html`
       <template layout="column margin:3 gap:4">
         <div layout="column items:center gap">
@@ -51,7 +51,7 @@ export default define({
                 name="scope"
                 value="selected"
                 onchange="${html.set('scope')}"
-                checked="${scope === 'selected'}"
+                checked="${defaultChoice !== 'all'}"
                 layout="margin:0"
                 style="accent-color: var(--ui-color-primary-700)"
               />
@@ -63,7 +63,7 @@ export default define({
                 name="scope"
                 value="all"
                 onchange="${html.set('scope')}"
-                checked="${scope === 'all'}"
+                checked="${defaultChoice === 'all'}"
                 layout="margin:0"
                 style="accent-color: var(--ui-color-primary-700)"
               />

--- a/ui/src/modules/autoconsent/views/home.js
+++ b/ui/src/modules/autoconsent/views/home.js
@@ -62,7 +62,7 @@ export default define({
                 name="scope"
                 value="all"
                 onchange="${html.set('scope')}"
-                checked="${defaultAll}"
+                checked="${scope === 'all'}"
                 layout="margin:0"
                 style="accent-color: var(--ui-color-primary-700)"
               />

--- a/ui/src/modules/autoconsent/views/home.js
+++ b/ui/src/modules/autoconsent/views/home.js
@@ -50,7 +50,7 @@ export default define({
                 name="scope"
                 value="selected"
                 onchange="${html.set('scope')}"
-                checked="${!defaultAll}"
+                checked="${scope === 'selected'}"
                 layout="margin:0"
                 style="accent-color: var(--ui-color-primary-700)"
               />

--- a/ui/src/modules/autoconsent/views/home.js
+++ b/ui/src/modules/autoconsent/views/home.js
@@ -13,6 +13,8 @@ import { define, html, router, dispatch } from 'hybrids';
 
 import Confirm from './confirm.js';
 
+const defaultChoice = new URLSearchParams(window.location.search).get('default');
+
 function onConfirm(type) {
   return (host) => {
     dispatch(host, type, {
@@ -25,7 +27,8 @@ function onConfirm(type) {
 export default define({
   tag: 'ui-autoconsent-home-view',
   scope: 'selected',
-  content: () =>
+  defaultAll: defaultChoice === 'all',
+  content: ({ defaultAll }) =>
     html`
       <template layout="column margin:3 gap:4">
         <div layout="column items:center gap">
@@ -47,7 +50,7 @@ export default define({
                 name="scope"
                 value="selected"
                 onchange="${html.set('scope')}"
-                checked
+                checked="${!defaultAll}"
                 layout="margin:0"
                 style="accent-color: var(--ui-color-primary-700)"
               />
@@ -59,6 +62,7 @@ export default define({
                 name="scope"
                 value="all"
                 onchange="${html.set('scope')}"
+                checked="${defaultAll}"
                 layout="margin:0"
                 style="accent-color: var(--ui-color-primary-700)"
               />

--- a/ui/src/modules/autoconsent/views/home.js
+++ b/ui/src/modules/autoconsent/views/home.js
@@ -28,7 +28,7 @@ export default define({
   tag: 'ui-autoconsent-home-view',
   scope: defaultChoice === 'all' ? 'all' : 'selected',
   defaultAll: defaultChoice === 'all',
-  content: ({ defaultAll }) =>
+  content: ({ scope }) =>
     html`
       <template layout="column margin:3 gap:4">
         <div layout="column items:center gap">

--- a/ui/src/modules/autoconsent/views/root.js
+++ b/ui/src/modules/autoconsent/views/root.js
@@ -21,7 +21,7 @@ export default define({
     get: (host, value = []) => value,
     set: (host, value) => value || [],
   },
-  content: ({ stack, categories, defaultChoice, }) => html`
+  content: ({ stack, categories }) => html`
     <template layout="grid::min|1|min">
       <ui-autoconsent-card>
         <ui-autoconsent-header></ui-autoconsent-header>

--- a/ui/src/modules/autoconsent/views/root.js
+++ b/ui/src/modules/autoconsent/views/root.js
@@ -21,7 +21,7 @@ export default define({
     get: (host, value = []) => value,
     set: (host, value) => value || [],
   },
-  content: ({ stack, categories }) => html`
+  content: ({ stack, categories, defaultChoice, }) => html`
     <template layout="grid::min|1|min">
       <ui-autoconsent-card>
         <ui-autoconsent-header></ui-autoconsent-header>


### PR DESCRIPTION
Since release of Never-Consent on Edge we've received a lot of very useful user feedback. Based on it we are changing the default choice of Never-Consent popup to "all websites" on 3rd user interaction with it.