### PR TITLE
Never-Consent: make recommended option more visible

### DIFF
--- a/ui/src/modules/autoconsent/views/home.js
+++ b/ui/src/modules/autoconsent/views/home.js
@@ -67,7 +67,7 @@ export default define({
                 layout="margin:0"
                 style="accent-color: var(--ui-color-primary-700)"
               />
-              <ui-text>on all websites</ui-text>
+              <ui-text><strong>on all websites</strong></ui-text>
             </label>
           </div>
         </div>


### PR DESCRIPTION
We want Ghostery users opt-in to using Never-Consent consciously. That is why by default we made it run on a single page only. In some situation, users that encounter Never-Consent popup for the first time, do not realize the choosing `YES` is not enough to apply Never-Consent to all websites. To make it more obvious we make the text (`on all websites`) of the recommended option more visible by increasing its font weight.

It's a very subtle change, but we hope a one in a good direction.

<img width="452" alt="Screenshot 2022-10-26 at 20 43 20" src="https://user-images.githubusercontent.com/1228153/198109900-0b5ee69e-f848-4ca8-b95d-b8537186cabc.png">

