### PR TITLE
Never-Consent: Use bool instead of null to avoid reset value of autoconsent lists

### DIFF
--- a/extension-manifest-v2/src/background.js
+++ b/extension-manifest-v2/src/background.js
@@ -562,8 +562,8 @@ function onMessageHandler(request, sender, callback) {
 				conf.autoconsent_whitelist = conf.autoconsent_whitelist.concat(message.url);
 				conf.autoconsent_interactions += 1;
 			} else {
-				conf.autoconsent_whitelist = null;
-				conf.autoconsent_blacklist = null;
+				conf.autoconsent_whitelist = false;
+				conf.autoconsent_blacklist = false;
 				conf.autoconsent_interactions = 0;
 			}
 

--- a/extension-manifest-v2/src/modules/autoconsent.js
+++ b/extension-manifest-v2/src/modules/autoconsent.js
@@ -34,7 +34,7 @@ async function initialize(msg, tabId, frameId) {
 
 	const domain = await getTabDomain(tabId);
 
-	if (autoconsent_blacklist?.includes(domain) || site_whitelist.some(s => s.includes(domain))) {
+	if ((autoconsent_blacklist && autoconsent_blacklist.includes(domain)) || site_whitelist.some(s => s.includes(domain))) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #908.