### PR TITLE
Fix cosmetics background feature

### DIFF
--- a/extension-manifest-v3/src/background/cosmetics.js
+++ b/extension-manifest-v3/src/background/cosmetics.js
@@ -281,7 +281,9 @@ chrome.webNavigation.onCommitted.addListener((details) => {
 
 chrome.runtime.onMessage.addListener((msg, sender) => {
   if (msg.action === 'getCosmeticsFilters') {
-    adblockerOnMessage(msg, sender);
+    adblockerOnMessage(msg, sender).catch((e) =>
+      console.error(`Error while processing cosmetics filters: ${e}`),
+    );
   }
 
   return false;

--- a/extension-manifest-v3/src/background/cosmetics.js
+++ b/extension-manifest-v3/src/background/cosmetics.js
@@ -66,11 +66,13 @@ function adblockerInjectStylesWebExtension(
     } else {
       target.allFrames = allFrames;
     }
-    chrome.scripting.insertCSS({
-      css: styles,
-      origin: 'USER',
-      target,
-    });
+    chrome.scripting
+      .insertCSS({
+        css: styles,
+        origin: 'USER',
+        target,
+      })
+      .catch((e) => console.error('Failed to inject CSS', e));
   } else {
     const details = {
       allFrames,
@@ -82,7 +84,9 @@ function adblockerInjectStylesWebExtension(
     if (frameId) {
       details.frameId = frameId;
     }
-    chrome.tabs.insertCSS(tabId, details);
+    chrome.tabs
+      .insertCSS(tabId, details)
+      .catch((e) => console.error('Failed to inject CSS', e));
   }
 }
 

--- a/extension-manifest-v3/src/background/cosmetics.js
+++ b/extension-manifest-v3/src/background/cosmetics.js
@@ -101,10 +101,7 @@ async function adblockerOnMessage(msg, sender) {
   let specificFrameId = null;
 
   Object.keys(adblockerEngines).forEach((engineName) => {
-    if (
-      adblockerEngines[engineName].isEnabled === false ||
-      engineName === 'annoyances' // Ensure Never-Consent has a chance to opt-out from tracking
-    ) {
+    if (adblockerEngines[engineName].isEnabled === false) {
       return;
     }
 

--- a/extension-manifest-v3/src/content_scripts/cosmetics.js
+++ b/extension-manifest-v3/src/content_scripts/cosmetics.js
@@ -10,4 +10,13 @@
  */
 import { injectCosmetics } from '@cliqz/adblocker-webextension-cosmetics';
 
-injectCosmetics(window);
+async function getCosmeticsFilters(args) {
+  const result = await chrome.runtime.sendMessage({
+    action: 'getCosmeticsFilters',
+    ...args,
+  });
+
+  return result || {};
+}
+
+injectCosmetics(window, true, getCosmeticsFilters);

--- a/extension-manifest-v3/src/content_scripts/cosmetics.js
+++ b/extension-manifest-v3/src/content_scripts/cosmetics.js
@@ -10,18 +10,13 @@
  */
 import { injectCosmetics } from '@cliqz/adblocker-webextension-cosmetics';
 
-async function getCosmeticsFilters(args) {
-  try {
-    const result = await chrome.runtime.sendMessage({
-      action: 'getCosmeticsFilters',
-      ...args,
-    });
+function getCosmeticsFilters(args) {
+  chrome.runtime.sendMessage({
+    action: 'getCosmeticsFilters',
+    ...args,
+  });
 
-    return result || {};
-  } catch (e) {
-    console.error('Error while getting cosmetic filters:', e);
-    return {};
-  }
+  return {};
 }
 
 injectCosmetics(window, true, getCosmeticsFilters);

--- a/extension-manifest-v3/src/content_scripts/cosmetics.js
+++ b/extension-manifest-v3/src/content_scripts/cosmetics.js
@@ -16,7 +16,7 @@ function getCosmeticsFilters(args) {
     ...args,
   });
 
-  return {};
+  return Promise.resolve({});
 }
 
 injectCosmetics(window, true, getCosmeticsFilters);

--- a/extension-manifest-v3/src/content_scripts/cosmetics.js
+++ b/extension-manifest-v3/src/content_scripts/cosmetics.js
@@ -11,12 +11,17 @@
 import { injectCosmetics } from '@cliqz/adblocker-webextension-cosmetics';
 
 async function getCosmeticsFilters(args) {
-  const result = await chrome.runtime.sendMessage({
-    action: 'getCosmeticsFilters',
-    ...args,
-  });
+  try {
+    const result = await chrome.runtime.sendMessage({
+      action: 'getCosmeticsFilters',
+      ...args,
+    });
 
-  return result || {};
+    return result || {};
+  } catch (e) {
+    console.error('Error while getting cosmetic filters:', e);
+    return {};
+  }
 }
 
 injectCosmetics(window, true, getCosmeticsFilters);


### PR DESCRIPTION
The `injectCosmetics` uses an MV2 hack to promisify the results, which is not required in MV3, and what is more important without the fix, we have thrown an error in each tab:

<img width="599" alt="Zrzut ekranu 2022-10-27 o 12 29 32" src="https://user-images.githubusercontent.com/1906677/198261514-25b3a977-807f-47dc-818e-f4b236bf8ffb.png">

Additionally, I have found, that `adblockerInjectStylesWebExtension` returns a promise, which is not consumed at all, so I cleaned it up.

The third thing.. the specific scripts were just omitted in the `sendResponse` callback. I assume this is a bug, so there is a fix. 