### PR TITLE
Add sync user settings after changing never-consent perfs

### DIFF
--- a/extension-manifest-v2/src/background.js
+++ b/extension-manifest-v2/src/background.js
@@ -567,6 +567,8 @@ function onMessageHandler(request, sender, callback) {
 				conf.autoconsent_interactions = 0;
 			}
 
+			account.saveUserSettings().catch(err => log('Background autoconsent', err));
+
 			return false;
 		}
 		if (name === 'disable') {
@@ -579,6 +581,8 @@ function onMessageHandler(request, sender, callback) {
 				conf.autoconsent_blacklist = [];
 				conf.autoconsent_interactions = 0;
 			}
+
+			account.saveUserSettings().catch(err => log('Background autoconsent', err));
 
 			return false;
 		}


### PR DESCRIPTION
It looks like settings are not automatically updated when changed (as I supposed that it does, as there is a Proxy, so it could do it easily). 

Added two sync triggers, when the never-consent popup changes its settings.