### PR TITLE
Fix autoconsent popup re-trigger action

### DIFF
--- a/extension-manifest-v2/src/background.js
+++ b/extension-manifest-v2/src/background.js
@@ -559,7 +559,8 @@ function onMessageHandler(request, sender, callback) {
 		if (name === 'enable') {
 			conf.enable_autoconsent = true;
 			if (message.url) {
-				conf.autoconsent_whitelist = conf.autoconsent_whitelist.concat(message.url);
+				conf.autoconsent_whitelist = (conf.autoconsent_whitelist || []).concat(message.url);
+				conf.autoconsent_blacklist = conf.autoconsent_blacklist || [];
 				conf.autoconsent_interactions += 1;
 			} else {
 				conf.autoconsent_whitelist = false;
@@ -573,7 +574,8 @@ function onMessageHandler(request, sender, callback) {
 		}
 		if (name === 'disable') {
 			if (message.url) {
-				conf.autoconsent_blacklist = conf.autoconsent_blacklist.concat(message.url);
+				conf.autoconsent_whitelist = conf.autoconsent_whitelist || [];
+				conf.autoconsent_blacklist = (conf.autoconsent_blacklist || []).concat(message.url);
 				conf.autoconsent_interactions += 1;
 			} else {
 				conf.enable_autoconsent = false;


### PR DESCRIPTION
Fixes #918.

The action happens when a user clicks "yes" or "no" on the first screen, and then goes back, so the values might not be as expected. 

The final solution would be to move triggering "an action" to the confirm screen, so it only sets the values once (and the user cannot "undo" the changes).

Currently, some of the information is lost - for example, if the user has black/white list with some items, but clicks yes on all websites and clicks then "go back", the list is gone, so changing the value to "only this site" will generate a new list with one item.