### PR TITLE
Downgrade linkedom to version 0.14.12 to fix a build error with webpack:

### DIFF
--- a/extension-manifest-v2/package-lock.json
+++ b/extension-manifest-v2/package-lock.json
@@ -23,7 +23,7 @@
         "history": "^4.10.1",
         "hybrids": "^8.1.1",
         "json-api-normalizer": "^1.0.4",
-        "linkedom": "^0.14.5",
+        "linkedom": "0.14.12",
         "moment": "^2.29.1",
         "prop-types": "^15.6.2",
         "query-string": "^6.13.1",
@@ -2901,9 +2901,26 @@
       "dependencies": {
         "@cliqz/url-parser": "^1.1.4",
         "@ghostery/ui": "^0.3.2",
-        "linkedom": "^0.14.20",
+        "linkedom": "0.14.12",
         "pako": "^2.0.4",
         "tldts-experimental": "^5.7.74"
+      }
+    },
+    "node_modules/@whotracksme/webextension-packages/node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="
+    },
+    "node_modules/@whotracksme/webextension-packages/node_modules/linkedom": {
+      "version": "0.14.12",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.14.12.tgz",
+      "integrity": "sha512-8uw8LZifCwyWeVWr80T79sQTMmNXt4Da7oN5yH5gTXRqQM+TuZWJyBqRMcIp32zx/f8anHNHyil9Avw9y76ziQ==",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^8.0.1",
+        "uhyphen": "^0.1.0"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -9325,7 +9342,7 @@
         "anonymous-credentials": "https://github.com/whotracksme/anonymous-credentials/releases/download/1.0.0/anonymous-credentials-1.0.0.tgz",
         "fast-deep-equal": "^3.1.3",
         "jsonschema": "^1.4.0",
-        "linkedom": "^0.14.5",
+        "linkedom": "0.14.12",
         "math-expression-evaluator": "^1.3.8",
         "moment": "^2.29.4",
         "node-fetch": "^2.6.1",
@@ -13634,9 +13651,9 @@
       "dev": true
     },
     "node_modules/linkedom": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.14.20.tgz",
-      "integrity": "sha512-H7BX22kn4Ul4Mfr5/Jz039TgfsYce/YCvQ6272LEIlIJ1sYmU3R6yFNSYZU6iDX2aoF76wX+qjcSZEaLwumcAw==",
+      "version": "0.14.12",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.14.12.tgz",
+      "integrity": "sha512-8uw8LZifCwyWeVWr80T79sQTMmNXt4Da7oN5yH5gTXRqQM+TuZWJyBqRMcIp32zx/f8anHNHyil9Avw9y76ziQ==",
       "dependencies": {
         "css-select": "^5.1.0",
         "cssom": "^0.5.0",
@@ -25627,9 +25644,28 @@
       "requires": {
         "@cliqz/url-parser": "^1.1.4",
         "@ghostery/ui": "^0.3.2",
-        "linkedom": "^0.14.20",
+        "linkedom": "0.14.12",
         "pako": "^2.0.4",
         "tldts-experimental": "^5.7.74"
+      },
+      "dependencies": {
+        "html-escaper": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+          "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="
+        },
+        "linkedom": {
+          "version": "0.14.12",
+          "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.14.12.tgz",
+	        "integrity": "sha512-8uw8LZifCwyWeVWr80T79sQTMmNXt4Da7oN5yH5gTXRqQM+TuZWJyBqRMcIp32zx/f8anHNHyil9Avw9y76ziQ==",
+	        "dependencies": {
+	          "css-select": "^5.1.0",
+	          "cssom": "^0.5.0",
+	          "html-escaper": "^3.0.3",
+	          "htmlparser2": "^8.0.1",
+	          "uhyphen": "^0.1.0"
+	        }
+        }
       }
     },
     "@xtuc/ieee754": {
@@ -30659,7 +30695,7 @@
         "anonymous-credentials": "https://github.com/whotracksme/anonymous-credentials/releases/download/1.0.0/anonymous-credentials-1.0.0.tgz",
         "fast-deep-equal": "^3.1.3",
         "jsonschema": "^1.4.0",
-        "linkedom": "^0.14.5",
+        "linkedom": "0.14.12",
         "math-expression-evaluator": "^1.3.8",
         "moment": "^2.29.4",
         "node-fetch": "^2.6.1",
@@ -33949,9 +33985,9 @@
       "dev": true
     },
     "linkedom": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.14.20.tgz",
-      "integrity": "sha512-H7BX22kn4Ul4Mfr5/Jz039TgfsYce/YCvQ6272LEIlIJ1sYmU3R6yFNSYZU6iDX2aoF76wX+qjcSZEaLwumcAw==",
+      "version": "0.14.12",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.14.12.tgz",
+      "integrity": "sha512-8uw8LZifCwyWeVWr80T79sQTMmNXt4Da7oN5yH5gTXRqQM+TuZWJyBqRMcIp32zx/f8anHNHyil9Avw9y76ziQ==",
       "requires": {
         "css-select": "^5.1.0",
         "cssom": "^0.5.0",

--- a/extension-manifest-v2/package.json
+++ b/extension-manifest-v2/package.json
@@ -61,7 +61,7 @@
     "history": "^4.10.1",
     "hybrids": "^8.1.1",
     "json-api-normalizer": "^1.0.4",
-    "linkedom": "^0.14.5",
+    "linkedom": "0.14.12",
     "moment": "^2.29.1",
     "prop-types": "^15.6.2",
     "query-string": "^6.13.1",


### PR DESCRIPTION
linkedom 0.14.20 breaks the build, so downgrade to 0.14.12 

```
ERROR in ./node_modules/linkedom/cjs/html/option-element.js 23:38 Module parse failed: Unexpected token (23:38)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|   get selected() { return booleanAttribute.get(this, 'selected'); }
|   set selected(value) {
>     const option = this.parentElement?.querySelector('option[selected]');
|     if (option && option !== this)
|       option.selected = false;
 @ ./node_modules/linkedom/cjs/shared/html-classes.js 32:28-64
 @ ./node_modules/linkedom/cjs/index.js
 @ ./src/classes/Common.js
 @ ./src/background.js
 @ multi ./src/background.js
```

Note: this is not a good long-term solution, since it involved manually editing `package-json.lock` to fix everything to linkedom 0.14.12, which is the last stable version that we had. It is intended as a temporary fix to make the build pass.