### PR TITLE
Fix: uninstall survey not triggering in Firefox

### DIFF
--- a/extension-manifest-v2/src/background.js
+++ b/extension-manifest-v2/src/background.js
@@ -1379,6 +1379,8 @@ function initializeVersioning() {
  * @return {Promise}
  */
 function initializeGhosteryModules() {
+	metrics.setUninstallUrl();
+
 	if (globals.JUST_UPGRADED) {
 		log('JUST UPGRADED');
 		metrics.ping('upgrade');
@@ -1397,8 +1399,6 @@ function initializeGhosteryModules() {
 		if (BROWSER_INFO.name === 'ghostery_desktop') {
 			conf.site_whitelist.push('bing.com', 'search.yahoo.com', 'startpage.com');
 		}
-
-		metrics.setUninstallUrl();
 
 		metrics.ping('install');
 

--- a/extension-manifest-v2/src/classes/Conf.js
+++ b/extension-manifest-v2/src/classes/Conf.js
@@ -72,9 +72,7 @@ const handler = {
 		// notify specific key subscribers
 		dispatcher.trigger(`conf.save.${key}`, value);
 		// notify catch all settings subscribers
-		if (confMutable.SYNC_SET.has(key) || key === 'bugs_last_checked') {
-			dispatcher.trigger('conf.changed.settings', key);
-		}
+		dispatcher.trigger('conf.changed.settings', key);
 
 		return true;
 	},


### PR DESCRIPTION
https://github.com/ghostery/ghostery-extension/pull/820 introduced a regression by which `chrome.runtime.setUninstallUrl` was not called as often.

