### PR TITLE
MV2: handle chrome.storage.local.set exceptions

### DIFF
--- a/extension-manifest-v2/src/utils/common.js
+++ b/extension-manifest-v2/src/utils/common.js
@@ -132,14 +132,19 @@ export function prefsSet(prefs) {
 		throw new Error('Bad argument');
 	}
 	return new Promise(((resolve, reject) => {
-		chrome.storage.local.set(prefs, () => {
-			if (chrome.runtime.lastError) {
-				alwaysLog('prefsSet ERROR', chrome.runtime.lastError);
-				reject(chrome.runtime.lastError);
-			} else {
-				resolve(prefs);
-			}
-		});
+		try {
+			chrome.storage.local.set(prefs, () => {
+				if (chrome.runtime.lastError) {
+					alwaysLog('prefsSet ERROR', chrome.runtime.lastError);
+					reject(chrome.runtime.lastError);
+				} else {
+					resolve(prefs);
+				}
+			});
+		} catch (e) {
+			alwaysLog('prefsSet ERROR', e);
+			reject(e);
+		}
 	}));
 }
 


### PR DESCRIPTION
fix #980

This wont fix the actual problem but will help us understand what actually is happening as the exception should now be reported to Sentry.
