### PR TITLE
Fix forced orientation of the on/off badge for japanese like languages

### DIFF
--- a/ui/src/modules/onboarding/views/main.js
+++ b/ui/src/modules/onboarding/views/main.js
@@ -88,7 +88,7 @@ export default define({
                 </section>
               </label>
               <div
-                layout="grid:max|1|min gap:2 items:center:start margin:2"
+                layout="grid:max|1|max gap:2 items:center:start margin:2"
                 layout@768px="margin:3"
               >
                 <ui-icon name="tracking" layout="size:3"></ui-icon>
@@ -98,7 +98,7 @@ export default define({
                 </ui-onboarding-badge>
               </div>
               <div
-                layout="grid:max|1|min gap:2 items:center:start margin:2"
+                layout="grid:max|1|max gap:2 items:center:start margin:2"
                 layout@768px="margin:3"
               >
                 <ui-icon name="ads" layout="size:3"></ui-icon>
@@ -108,7 +108,7 @@ export default define({
                 </ui-onboarding-badge>
               </div>
               <div
-                layout="grid:max|1|min gap:2 items:center:start margin:2"
+                layout="grid:max|1|max gap:2 items:center:start margin:2"
                 layout@768px="margin:3"
               >
                 <ui-icon name="autoconsent" layout="size:3"></ui-icon>

--- a/ui/src/modules/panel/components/switch.js
+++ b/ui/src/modules/panel/components/switch.js
@@ -34,7 +34,7 @@ export default {
     },
   },
   render: () => html`
-    <template layout="block relative margin:-2 padding:2">
+    <template layout="block relative overflow margin:-2 padding:2">
       <slot></slot>
     </template>
   `.css`


### PR DESCRIPTION
Fixes following issue:

<img width="300" alt="Zrzut ekranu 2023-01-25 o 13 23 19" src="https://user-images.githubusercontent.com/1906677/214562954-b872323c-68fe-4ad4-a3b7-2fa66e451ad9.png">

Into this:
<img width="300" alt="Zrzut ekranu 2023-01-25 o 13 23 33" src="https://user-images.githubusercontent.com/1906677/214562962-6df8d016-af68-4c99-ab98-f72ac598cdb4.png">

Additionally a small fix for the stats switch component on iOS.
