### PR TITLE
Fix Safari release

### DIFF
--- a/extension-manifest-v3/.eslintrc
+++ b/extension-manifest-v3/.eslintrc
@@ -4,7 +4,7 @@
     "browser": true,
     "node": true,
     "serviceworker": true,
-    "webextensions": true 
+    "webextensions": true
   },
   "extends": [
     "eslint:recommended",
@@ -12,5 +12,8 @@
   ],
   "parserOptions": {
     "sourceType": "module"
+  },
+  "globals": {
+    "__PLATFORM__": "readonly"
   }
 }

--- a/extension-manifest-v3/scripts/build.js
+++ b/extension-manifest-v3/scripts/build.js
@@ -20,13 +20,11 @@ const argv = process.argv.slice(2).reduce((acc, arg, index, arr) => {
   }
   return acc;
 }, {});
+const target = argv.target || 'chromium';
 
 const pkg = JSON.parse(readFileSync(resolve(pwd, 'package.json'), 'utf8'));
 const manifest = JSON.parse(
-  readFileSync(
-    resolve(options.srcDir, `manifest.${argv.target || 'chromium'}.json`),
-    'utf8',
-  ),
+  readFileSync(resolve(options.srcDir, `manifest.${target}.json`), 'utf8'),
 );
 
 const config = {
@@ -35,6 +33,7 @@ const config = {
   resolve: {
     preserveSymlinks: true,
   },
+  define: { __PLATFORM__: JSON.stringify(target) },
   build: {
     outDir: options.outDir,
     assetsDir: '',

--- a/extension-manifest-v3/src/pages/panel/index.js
+++ b/extension-manifest-v3/src/pages/panel/index.js
@@ -19,13 +19,15 @@ define.from(import.meta.glob('./**/*.js', { eager: true, import: 'default' }), {
   Safari extension popup has a bug, which focuses visibly the first element on the page
   when the popup is opened. This is a workaround to remove the focus.
 */
-window.addEventListener('DOMContentLoaded', () => {
-  document.body.focus();
-  document.body.addEventListener(
-    'focus',
-    () => {
-      document.body.removeAttribute('tabIndex');
-    },
-    { once: true },
-  );
+window.addEventListener('load', () => {
+  setTimeout(() => {
+    document.body.focus();
+    document.body.addEventListener(
+      'focus',
+      () => {
+        document.body.removeAttribute('tabIndex');
+      },
+      { once: true },
+    );
+  }, 100);
 });

--- a/extension-manifest-v3/src/pages/panel/views/home.js
+++ b/extension-manifest-v3/src/pages/panel/views/home.js
@@ -26,12 +26,14 @@ const NOTIFICATIONS = [
     url: 'https://www.ghostery.com/support?utm_source=gbe',
     action: 'Get help',
   },
-  {
-    icon: 'heart',
-    text: 'Hey, do you enjoy Ghostery and want to support our work?',
-    url: 'https://www.ghostery.com/become-a-contributor?utm_source=gbe',
-    action: 'Become a Contributor',
-  },
+  __PLATFORM__ !== 'safari'
+    ? {
+        icon: 'heart',
+        text: 'Hey, do you enjoy Ghostery and want to support our work?',
+        url: 'https://www.ghostery.com/become-a-contributor?utm_source=gbe',
+        action: 'Become a Contributor',
+      }
+    : null,
 ];
 
 const SETTINGS_URL = chrome.runtime.getURL('/pages/settings/index.html');

--- a/extension-manifest-v3/src/pages/panel/views/navigation.js
+++ b/extension-manifest-v3/src/pages/panel/views/navigation.js
@@ -14,11 +14,6 @@ import { html, msg, router, store } from 'hybrids';
 import Account from '/store/account.js';
 
 const MENU = [
-  {
-    icon: 'heart',
-    label: msg`Become a Contributor`,
-    href: 'https://www.ghostery.com/become-a-contributor',
-  },
   {},
   {
     icon: 'alert',
@@ -48,10 +43,18 @@ const MENU = [
   },
 ];
 
+if (__PLATFORM__ !== 'safari') {
+  MENU.unshift({
+    icon: 'heart',
+    label: msg`Become a Contributor`,
+    href: 'https://www.ghostery.com/become-a-contributor',
+  });
+}
+
 export default {
   account: store(Account),
   content: ({ account }) => html`
-    <template layout="grid height:600px">
+    <template layout="grid">
       <ui-panel-header layout="fixed top left width:full">
         Menu
         <ui-action slot="actions">

--- a/libs/package.json
+++ b/libs/package.json
@@ -5,6 +5,7 @@
   "description": "",
   "license": "MPL-2.0",
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": "./src/index.js"
   },


### PR DESCRIPTION
Minor fixes for upcoming Safari release:

* introduce the global `__PLATFORM__` env for detecting the target - used here for removing a notification about contributions from Safari release (it actually removes it from the code)
* Minor fix for the focus workaround on macOS
* Tree-shaking flag for libs
