### PR TITLE
Force localize before categories labels translation

### DIFF
--- a/extension-manifest-v3/src/pages/panel/index.html
+++ b/extension-manifest-v3/src/pages/panel/index.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <title>Ghostery panel</title>
-    <script type="module" src="@ghostery/ui/panel"></script>
     <script type="module" src="./index.js"></script>
   </head>
   <body tabindex="0">

--- a/extension-manifest-v3/src/pages/panel/index.js
+++ b/extension-manifest-v3/src/pages/panel/index.js
@@ -8,6 +8,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
+import '@ghostery/ui/panel';
 import { define } from 'hybrids';
 
 define.from(import.meta.glob('./**/*.js', { eager: true, import: 'default' }), {

--- a/extension-manifest-v3/src/pages/settings/index.html
+++ b/extension-manifest-v3/src/pages/settings/index.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <title>Ghostery settings</title>
-    <script type="module" src="@ghostery/ui/settings"></script>
     <script type="module" src="./index.js"></script>
   </head>
   <body>

--- a/ui/src/modules/global/index.js
+++ b/ui/src/modules/global/index.js
@@ -8,15 +8,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
-import { define, localize } from 'hybrids';
+import { define } from 'hybrids';
 
-// Localize wrapper for chrome.i18n
-if (typeof chrome === 'object' && chrome.i18n) {
-  localize(chrome.i18n.getMessage.bind(chrome.i18n), { format: 'chrome.i18n' });
-}
+import './localize.js';
 
 // Define components
-define.from(import.meta.glob('./**/*.js', { eager: true, import: 'default' }), {
-  prefix: 'ui',
-  root: 'components',
-});
+define.from(
+  import.meta.glob('./components/*.js', { eager: true, import: 'default' }),
+  {
+    prefix: 'ui',
+    root: 'components',
+  },
+);

--- a/ui/src/modules/global/localize.js
+++ b/ui/src/modules/global/localize.js
@@ -8,11 +8,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
+import { localize } from 'hybrids';
 
-import '@ghostery/ui/settings';
-import { define } from 'hybrids';
-
-define.from(import.meta.glob('./**/*.js', { eager: true, import: 'default' }), {
-  root: ['components', 'views'],
-  prefix: 'gh-settings',
-});
+// Localize wrapper for chrome.i18n
+if (typeof chrome === 'object' && chrome.i18n) {
+  localize(chrome.i18n.getMessage.bind(chrome.i18n), { format: 'chrome.i18n' });
+}

--- a/ui/src/utils/labels.js
+++ b/ui/src/utils/labels.js
@@ -10,6 +10,8 @@
  */
 
 import { msg } from 'hybrids';
+
+// Required to force loading localization module before using msg`...`
 import '../modules/global/localize.js';
 
 export const categories = {

--- a/ui/src/utils/labels.js
+++ b/ui/src/utils/labels.js
@@ -1,4 +1,16 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
 import { msg } from 'hybrids';
+import '../modules/global/localize.js';
 
 export const categories = {
   advertising: msg`Advertising | Tracker category name`,


### PR DESCRIPTION
Fixes #1001

The general solution is hard to achieve, as we use Vite in a very custom way. Even a fix for the import statement is not sufficient. After all, the HTML file generates a list of script tags, which can end with nondeterministic timing. 

This PR has some minor fixes and it adds a force import of the localize module in the categories labels file, so it ensures that localize is already set up before `msg` function is called.