### PR TITLE
MV3: prevent starup races with Options

### DIFF
--- a/extension-manifest-v3/src/background/adblocker.js
+++ b/extension-manifest-v3/src/background/adblocker.js
@@ -10,7 +10,6 @@
  */
 
 import { FiltersEngine } from '@cliqz/adblocker';
-import { store } from 'hybrids';
 import { parse } from 'tldts-experimental';
 
 import Options, { observe } from '/store/options.js';
@@ -27,10 +26,6 @@ const adblockerEngines = Object.keys(Options.engines).reduce((map, name) => {
 let pausedDomains = [];
 
 let adblockerStartupPromise = (async function () {
-  await store.resolve(Options);
-  Object.keys(Options.engines).forEach((engineName) => {
-    adblockerEngines[engineName].isEnabled = Options.engines[engineName];
-  });
   observe('engines', (engines) => {
     Object.entries(engines).forEach(([key, value]) => {
       adblockerEngines[key].isEnabled = value;

--- a/extension-manifest-v3/src/background/adblocker.js
+++ b/extension-manifest-v3/src/background/adblocker.js
@@ -26,12 +26,12 @@ const adblockerEngines = Object.keys(Options.engines).reduce((map, name) => {
 let pausedDomains = [];
 
 let adblockerStartupPromise = (async function () {
-  observe('engines', (engines) => {
+  await observe('engines', (engines) => {
     Object.entries(engines).forEach(([key, value]) => {
       adblockerEngines[key].isEnabled = value;
     });
   });
-  observe('paused', (paused) => {
+  await observe('paused', (paused) => {
     pausedDomains = paused ? paused.map(String) : [];
   });
 

--- a/extension-manifest-v3/src/store/options.js
+++ b/extension-manifest-v3/src/store/options.js
@@ -156,7 +156,7 @@ export async function observe(property, fn) {
       value = options[property];
 
       try {
-        return fn(value, prevValue);
+        return await fn(value, prevValue);
       } catch (e) {
         console.error(`Error while observing options: `, e);
       }

--- a/extension-manifest-v3/src/store/options.js
+++ b/extension-manifest-v3/src/store/options.js
@@ -85,17 +85,10 @@ const Options = {
           e,
         );
       }
-
       return options;
     },
     observe: (_, options, prevOptions) => {
-      observers.forEach((fn) => {
-        try {
-          fn(options, prevOptions);
-        } catch (e) {
-          console.error(`Error while observing options: `, e);
-        }
-      });
+      observers.forEach((fn) => fn(options, prevOptions));
     },
   },
 };
@@ -162,13 +155,19 @@ export function observe(property, fn) {
       const prevValue = value;
       value = options[property];
 
-      fn(value, prevValue);
+      try {
+        fn(value, prevValue);
+      } catch (e) {
+        console.error(`Error while observing options: `, e);
+      }
     }
   };
 
   observers.add(wrapper);
 
-  store.resolve(Options);
+  // let observer know of the option value
+  // in case when registered after the store.connect
+  store.resolve(Options).then(wrapper).catch(console.error);
 
   // Return unobserve function
   return () => {


### PR DESCRIPTION
On physical iOS devices store of Options model was connected before all observers got registered. This broke those modules that relied on the `observe` callback. 

Breakage was introduced here https://github.com/ghostery/ghostery-extension/pull/1023/files#diff-ab787eda050f8d097068bea78c9043e942c4480fdb99acf1f1c0213b0bbd859dL270

Workaround for the adblocker startup https://github.com/ghostery/ghostery-extension/pull/1035/files#diff-df2e21bb6266c3df460f6af7886b15496d496b3bd46182750a55addf0a1a7a89R31 is no longer needed.