### PR TITLE
Build: force postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "glossary-converter": "node tools/glossary-converter.js",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package && npm run postinstall --ws --if-present"
   },
   "devDependencies": {
     "csv": "^6.2.5",


### PR DESCRIPTION
npm workspaces does not trigger workspace specific lifecycle hooks like postinstall