### PR TITLE
Fallback when trackerDB misses pattern's organization

### DIFF
--- a/extension-manifest-v3/src/background/utils/trackerdb.js
+++ b/extension-manifest-v3/src/background/utils/trackerdb.js
@@ -43,14 +43,20 @@ export async function getMetadata(url, sourceUrl) {
   return {
     name: pattern.name,
     category: category.key,
-    company: {
-      id: organization.key,
-      name: organization.name,
-      description: organization.description,
-      website: organization.website_url,
-      contact: organization.privacy_contact,
-      privacyPolicy: organization.privacy_policy_url,
-    },
+    company: organization
+      ? {
+          id: pattern.key,
+          name: organization.name,
+          description: organization.description,
+          website: organization.website_url || pattern.website_url,
+          contact: organization.privacy_contact,
+          privacyPolicy: organization.privacy_policy_url,
+        }
+      : {
+          id: pattern.key,
+          name: pattern.name,
+          website: pattern.website_url,
+        },
     url,
   };
 }

--- a/extension-manifest-v3/src/pages/panel/views/company.js
+++ b/extension-manifest-v3/src/pages/panel/views/company.js
@@ -62,21 +62,21 @@ export default {
           <ui-text slot="header" type="body-s" color="gray-600">
             <span>trackers detected</span>: ${trackers.length}
           </ui-text>
-          ${company.description &&
-          html`
-            <div layout="column gap:0.5">
-              <ui-text type="body-s">${cleanUp(company.description)}</ui-text>
-              ${wtmUrl &&
-              html`
-                <ui-text type="label-xs" color="primary-700" underline>
-                  <a href="${wtmUrl}" target="_blank">
-                    Read more on WhoTracks.Me
-                  </a>
-                </ui-text>
-              `}
-            </div>
-            <ui-line></ui-line>
-          `}
+          <div layout="column gap:0.5">
+            ${company.description &&
+            html`<ui-text type="body-s"
+              >${cleanUp(company.description)}</ui-text
+            >`}
+            ${wtmUrl &&
+            html`
+              <ui-text type="label-xs" color="primary-700" underline>
+                <a href="${wtmUrl}" target="_blank">
+                  Read more on WhoTracks.Me
+                </a>
+              </ui-text>
+            `}
+          </div>
+          <ui-line></ui-line>
           <section
             layout="
               grid:max|1 items:start:stretch content:start gap:1:2.5


### PR DESCRIPTION
The previous bugs.js implementation includes a case when an organization (company) was missing - as it is required in the panel to show the dialog with a list of requests.

Test case: `https://onet.pl` - trackers from 'onet' have pattern, but it does not contain organization