### PR TITLE
MV2: indicate dormant state with browser action

### DIFF
--- a/extension-manifest-v2/src/background.js
+++ b/extension-manifest-v2/src/background.js
@@ -527,6 +527,7 @@ function onMessageHandler(request, sender, callback) {
 			globals.ONBOARDED_FEATURES.forEach((confName) => {
 				conf[confName] = true;
 			});
+			button.update();
 		}
 		if (name === 'setup_skip') {
 			conf.setup_skip = true;

--- a/extension-manifest-v2/src/classes/BrowserButton.js
+++ b/extension-manifest-v2/src/classes/BrowserButton.js
@@ -132,6 +132,11 @@ class BrowserButton {
 		let	trackerCount = '';
 		let alert = false;
 
+		if (!conf.setup_complete) {
+			this._setIcon(false, tabId, '!', true);
+			return;
+		}
+
 		// Get tracker count for badgeText
 		if (foundBugs.getBugs(tabId) === false) {
 			// if no cached bug discovery data then:


### PR DESCRIPTION
Accepting privacy policy is a mandatory to enable content blocking features. To help users realise their extension may not be fully active, we update the browser action icon:
<img width="38" alt="Screenshot 2023-03-07 at 20 29 20" src="https://user-images.githubusercontent.com/1228153/223534667-06bbc0b2-0985-4619-a803-e9cd21cce6ca.png">
