### PR TITLE
Add applinks support for contribution link

### DIFF
--- a/extension-manifest-v3/src/pages/panel/views/home.js
+++ b/extension-manifest-v3/src/pages/panel/views/home.js
@@ -33,15 +33,13 @@ const NOTIFICATIONS = [
         : 'https://www.ghostery.com/support?utm_source=gbe',
     action: 'Get help',
   },
-  __PLATFORM__ !== 'safari'
-    ? {
-        icon: 'heart',
-        type: '',
-        text: 'Hey, do you enjoy Ghostery and want to support our work?',
-        url: 'https://www.ghostery.com/become-a-contributor?utm_source=gbe',
-        action: 'Become a Contributor',
-      }
-    : null,
+  {
+    icon: 'heart',
+    type: '',
+    text: 'Hey, do you enjoy Ghostery and want to support our work?',
+    url: 'https://www.ghostery.com/become-a-contributor?utm_source=gbe',
+    action: 'Become a Contributor',
+  },
 ];
 
 const SETTINGS_URL = chrome.runtime.getURL('/pages/settings/index.html');

--- a/extension-manifest-v3/src/pages/panel/views/navigation.js
+++ b/extension-manifest-v3/src/pages/panel/views/navigation.js
@@ -16,6 +16,11 @@ import { SIGNON_PAGE_URL } from '/utils/api.js';
 import { openTabWithUrl } from '/utils/tabs.js';
 
 const MENU = [
+  {
+    icon: 'heart',
+    label: msg`Become a Contributor`,
+    href: 'https://www.ghostery.com/become-a-contributor?utm_source=gbe',
+  },
   {},
   {
     icon: 'alert',
@@ -44,14 +49,6 @@ const MENU = [
     href: 'https://www.ghostery.com/?utm_source=gbe',
   },
 ];
-
-if (__PLATFORM__ !== 'safari') {
-  MENU.unshift({
-    icon: 'heart',
-    label: msg`Become a Contributor`,
-    href: 'https://www.ghostery.com/become-a-contributor?utm_source=gbe',
-  });
-}
 
 export default {
   session: store(Session),

--- a/extension-manifest-v3/xcode/Ghostery.xcodeproj/project.pbxproj
+++ b/extension-manifest-v3/xcode/Ghostery.xcodeproj/project.pbxproj
@@ -223,6 +223,8 @@
 		B469CA8827BE924D00408C43 /* _locales */ = {isa = PBXFileReference; lastKnownFileType = folder; name = _locales; path = ../../dist/_locales; sourceTree = "<group>"; };
 		B469CA9A27BE949000408C43 /* manifest.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = manifest.json; path = ../../dist/manifest.json; sourceTree = "<group>"; };
 		B479A073299266F300A25D8F /* utils */ = {isa = PBXFileReference; lastKnownFileType = folder; name = utils; path = ../../dist/utils; sourceTree = "<group>"; };
+		B49948CB2AB2F01700264E8A /* Ghostery – Privacy Ad Blocker (iOS) - Debug.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = "Ghostery – Privacy Ad Blocker (iOS) - Debug.entitlements"; sourceTree = "<group>"; };
+		B49948CC2AB2F02800264E8A /* Ghostery – Privacy Ad Blocker (iOS) - Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = "Ghostery – Privacy Ad Blocker (iOS) - Release.entitlements"; sourceTree = "<group>"; };
 		B4D49C6F28045EFC00277CCA /* store */ = {isa = PBXFileReference; lastKnownFileType = folder; name = store; path = ../../dist/store; sourceTree = "<group>"; };
 		B4DA09B5283CEBAE0052F343 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B4EBAD7E2A1DFA6C006A7D73 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -422,6 +424,8 @@
 		468E428D2701F84A008B5792 /* iOS (App) */ = {
 			isa = PBXGroup;
 			children = (
+				B49948CC2AB2F02800264E8A /* Ghostery – Privacy Ad Blocker (iOS) - Release.entitlements */,
+				B49948CB2AB2F01700264E8A /* Ghostery – Privacy Ad Blocker (iOS) - Debug.entitlements */,
 				465E356127551D600032B8D2 /* GhosteryApp.swift */,
 				468E42982701F84A008B5792 /* Info.plist */,
 				468E42922701F84A008B5792 /* LaunchScreen.storyboard */,
@@ -989,6 +993,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "iOS (App)/Ghostery – Privacy Ad Blocker (iOS) - Debug.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
 				DEVELOPMENT_TEAM = HPY23A294X;
@@ -1026,6 +1031,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "iOS (App)/Ghostery – Privacy Ad Blocker (iOS) - Release.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
 				DEVELOPMENT_TEAM = HPY23A294X;

--- a/extension-manifest-v3/xcode/iOS (App)/Ghostery – Privacy Ad Blocker (iOS) - Debug.entitlements
+++ b/extension-manifest-v3/xcode/iOS (App)/Ghostery – Privacy Ad Blocker (iOS) - Debug.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:www.ghostery.com</string>
+	</array>
+</dict>
+</plist>

--- a/extension-manifest-v3/xcode/iOS (App)/Ghostery – Privacy Ad Blocker (iOS) - Release.entitlements
+++ b/extension-manifest-v3/xcode/iOS (App)/Ghostery – Privacy Ad Blocker (iOS) - Release.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:www.ghostery.com</string>
+	</array>
+</dict>
+</plist>

--- a/extension-manifest-v3/xcode/iOS (App)/GhosteryApp.swift
+++ b/extension-manifest-v3/xcode/iOS (App)/GhosteryApp.swift
@@ -51,6 +51,16 @@ struct GhosteryApp: App {
                     .sheet(isPresented: $showSheet) {
                             SafariView(url: $url)
                     }
+                    .onOpenURL { url in
+                        handleIncomingURL(url)
+                    }
+        }
+    }
+
+    func handleIncomingURL(_ url: URL) {
+        // check path of the url
+        if url.pathComponents.contains("become-a-contributor") {
+            // run toggleSubscriptions from ContentView
         }
     }
 


### PR DESCRIPTION
Fixes #1020

* Followed [Apple documentation](https://developer.apple.com/documentation/Xcode/supporting-associated-domains?language=objc) to setup associated domain on ghostery.com
* Configured entitlements in XCode 

It looks like everything is configured correctly, but I can't make it work. The domain can be verified here: https://app-site-association.cdn-apple.com/a/v1/www.ghostery.com

To open URL on iOS simulator you can use command:
```
xcrun simctl openurl booted https://www.ghostery.com/become-a-contributor
```