### PR TITLE
Only run Never Consent on HTML pages (not XML).

### DIFF
--- a/extension-manifest-v2/app/content-scripts/autoconsent.js
+++ b/extension-manifest-v2/app/content-scripts/autoconsent.js
@@ -12,26 +12,28 @@
 import AutoConsent from '@duckduckgo/autoconsent';
 import { showIframe } from '@ghostery/ui/autoconsent/iframe';
 
-const consent = new AutoConsent(msg => chrome.runtime.sendMessage(
-	{ ...msg, action: 'autoconsent' },
-));
+if (document.contentType === 'text/html') {
+	const consent = new AutoConsent(msg => chrome.runtime.sendMessage(
+		{ ...msg, action: 'autoconsent' },
+	));
 
-let shownIframe = false;
-chrome.runtime.onMessage.addListener((msg) => {
-	if (msg.action === 'autoconsent') {
-		if (msg.type === 'openIframe') {
-			if (shownIframe) return false;
+	let shownIframe = false;
+	chrome.runtime.onMessage.addListener((msg) => {
+		if (msg.action === 'autoconsent') {
+			if (msg.type === 'openIframe') {
+				if (shownIframe) return false;
 
-			showIframe(chrome.runtime.getURL(
-				`app/templates/autoconsent.html?host=${encodeURIComponent(msg.domain)}&default=${msg.defaultForAll ? 'all' : ''}`
-			));
-			shownIframe = true;
+				showIframe(chrome.runtime.getURL(
+					`app/templates/autoconsent.html?host=${encodeURIComponent(msg.domain)}&default=${msg.defaultForAll ? 'all' : ''}`
+				));
+				shownIframe = true;
 
-			return false;
+				return false;
+			}
+
+			return Promise.resolve(consent.receiveMessageCallback(msg));
 		}
 
-		return Promise.resolve(consent.receiveMessageCallback(msg));
-	}
-
-	return false;
-});
+		return false;
+	});
+}

--- a/extension-manifest-v3/src/content_scripts/autoconsent.js
+++ b/extension-manifest-v3/src/content_scripts/autoconsent.js
@@ -12,32 +12,34 @@
 import AutoConsent from '@duckduckgo/autoconsent';
 import { showIframe } from '@ghostery/ui/autoconsent/iframe';
 
-const consent = new AutoConsent((msg) => {
-  return chrome.runtime.sendMessage(
-    Object.assign({}, msg, { action: 'autoconsent' }),
-  );
-});
+if (document.contentType === 'text/html') {
+  const consent = new AutoConsent((msg) => {
+    return chrome.runtime.sendMessage(
+      Object.assign({}, msg, { action: 'autoconsent' }),
+    );
+  });
 
-let shownIframe = false;
-chrome.runtime.onMessage.addListener((msg) => {
-  if (msg.action === 'autoconsent') {
-    if (msg.type === 'openIframe') {
-      if (shownIframe) return false;
+  let shownIframe = false;
+  chrome.runtime.onMessage.addListener((msg) => {
+    if (msg.action === 'autoconsent') {
+      if (msg.type === 'openIframe') {
+        if (shownIframe) return false;
 
-      showIframe(
-        chrome.runtime.getURL(
-          `pages/autoconsent/index.html?host=${encodeURIComponent(
-            msg.domain,
-          )}&default=${msg.defaultForAll ? 'all' : ''}`,
-        ),
-      );
-      shownIframe = true;
+        showIframe(
+          chrome.runtime.getURL(
+            `pages/autoconsent/index.html?host=${encodeURIComponent(
+              msg.domain,
+            )}&default=${msg.defaultForAll ? 'all' : ''}`,
+          ),
+        );
+        shownIframe = true;
 
-      return false;
+        return false;
+      }
+
+      return Promise.resolve(consent.receiveMessageCallback(msg));
     }
 
-    return Promise.resolve(consent.receiveMessageCallback(msg));
-  }
-
-  return false;
-});
+    return false;
+  });
+}


### PR DESCRIPTION
Never Consent mistakenly tries to inject its popup in non-HTML pages.

This patch adds a guard to the injection in the content-script:
```
if (document.contentType === 'text/html') {
  ...
}
 ```

fixes #983
