### PR TITLE
Use HistoryStateUpdated in supported platforms

### DIFF
--- a/extension-manifest-v3/src/background/reporting.js
+++ b/extension-manifest-v3/src/background/reporting.js
@@ -281,7 +281,10 @@ function onLocationChange(details) {
 }
 
 chrome.webNavigation.onCommitted.addListener(onLocationChange);
-chrome.webNavigation.onHistoryStateUpdated.addListener(onLocationChange);
+
+if (__PLATFORM__ !== 'safari') {
+  chrome.webNavigation.onHistoryStateUpdated.addListener(onLocationChange);
+}
 
 // for debugging service-workers (TODO: provide a way to control logging)
 globalThis.ghostery = globalThis.ghostery || {};


### PR DESCRIPTION
Fixes https://github.com/ghostery/ghostery-extension/pull/1093

Safari does not support https://developer.apple.com/documentation/safariservices/safari_web_extensions/assessing_your_safari_web_extension_s_browser_compatibility#:~:text=onHistoryStateUpdated%20not%20supported