### PR TITLE
Fixes a potential race during reporting startup

### DIFF
--- a/extension-manifest-v3/src/background/reporting.js
+++ b/extension-manifest-v3/src/background/reporting.js
@@ -218,23 +218,20 @@ const reporting = new Reporting({
 
 let pendingStartup = (async function () {
   await observe('terms', async (terms) => {
-    try {
-      if (terms) {
-        try {
-          await reporting.init();
-        } catch (e) {
-          console.warn(
-            'Failed to initialize reporting. Leaving the module disabled and continue.',
-            e,
-          );
-        }
-      } else {
-        reporting.unload();
+    if (terms) {
+      try {
+        await reporting.init();
+      } catch (e) {
+        console.warn(
+          'Failed to initialize reporting. Leaving the module disabled and continue.',
+          e,
+        );
       }
-    } finally {
-      pendingStartup = null;
+    } else {
+      reporting.unload();
     }
   });
+  pendingStartup = null;
 })();
 
 function delay(timeInMs) {

--- a/extension-manifest-v3/src/store/options.js
+++ b/extension-manifest-v3/src/store/options.js
@@ -161,14 +161,12 @@ export async function observe(property, fn) {
       value = options[property];
 
       try {
-        return await fn(value, prevValue);
+        await fn(value, prevValue);
       } catch (e) {
         console.error(`Error while observing options: `, e);
       }
     }
   };
-
-  observers.add(wrapper);
 
   try {
     const options = await store.resolve(Options);
@@ -179,6 +177,7 @@ export async function observe(property, fn) {
   } catch (e) {
     console.error(e);
   }
+  observers.add(wrapper);
 
   // Return unobserve function
   return () => {


### PR DESCRIPTION
Fixes a potential race in the reporting initialization. When the service worker wakes up and immediately runs the listener callback, the first event may get lost.

Also, include a fix for a race that is documented here: https://github.com/ghostery/ghostery-extension/pull/1129
But fixed by postponing the observer registration (not as in #1129, which is more elaborate).