### PR TITLE
Update iOS/macOS app copy

### DIFF
--- a/extension-manifest-v3/xcode/Shared (App)/Resources/Main.html
+++ b/extension-manifest-v3/xcode/Shared (App)/Resources/Main.html
@@ -59,7 +59,7 @@
           <span data-i18n>Enjoying Ghostery?</span> <br />
           <span class="small" data-i18n>Support what we do</span>
         </h2>
-        <button id="button-subscribe" data-i18n>Subscribe now</button>
+        <button id="button-subscribe" data-i18n>Become a contributor</button>
       </section>
 
       <section>

--- a/extension-manifest-v3/xcode/Shared (App)/StoreHelper/Products.storekit
+++ b/extension-manifest-v3/xcode/Shared (App)/StoreHelper/Products.storekit
@@ -21,6 +21,9 @@
           "adHocOffers" : [
 
           ],
+          "codeOffers" : [
+
+          ],
           "displayPrice" : "47.99",
           "familyShareable" : false,
           "groupNumber" : 1,
@@ -29,7 +32,7 @@
           "localizations" : [
             {
               "description" : "$3.99/month - Cancel anytime",
-              "displayName" : "Yearly subscription",
+              "displayName" : "Yearly donation",
               "locale" : "en_US"
             }
           ],
@@ -43,6 +46,9 @@
           "adHocOffers" : [
 
           ],
+          "codeOffers" : [
+
+          ],
           "displayPrice" : "4.99",
           "familyShareable" : false,
           "groupNumber" : 1,
@@ -50,8 +56,8 @@
           "introductoryOffer" : null,
           "localizations" : [
             {
-              "description" : "Cancel anytime",
-              "displayName" : "Monthly subscription",
+              "description" : "$4.99/month",
+              "displayName" : "Monthly donation",
               "locale" : "en_US"
             }
           ],
@@ -65,7 +71,7 @@
     }
   ],
   "version" : {
-    "major" : 1,
-    "minor" : 1
+    "major" : 2,
+    "minor" : 0
   }
 }

--- a/extension-manifest-v3/xcode/Shared (App)/views/screens/Subscriptions.swift
+++ b/extension-manifest-v3/xcode/Shared (App)/views/screens/Subscriptions.swift
@@ -28,7 +28,7 @@ struct Subscriptions: View {
                 Spacer()
                 Button(action: restorePurchases) {
                     HStack {
-                        Text("Restore subscription")
+                        Text("Restore donation")
                     }
                 }
             }
@@ -38,10 +38,10 @@ struct Subscriptions: View {
                 .frame(maxWidth: .infinity, alignment: .topLeading)
 
 
-            Text("Support our mission for a clean, fast, and free internet.")
+            Text("Contribute to Ghostery and support a clean, fast, and open web.")
                 .multilineTextAlignment(.center)
                 .padding()
-            Text("Choose a subscription plan:")
+            Text("Choose how to support Ghostery:")
                 .font(.headline)
                 .padding()
 
@@ -51,20 +51,20 @@ struct Subscriptions: View {
                         SubscriptionListViewRow(products: subscriptions)
                     }
                 } else {
-                    Text("No Subscriptions available")
+                    Text("No donations available")
                         .font(.title)
                         .foregroundColor(.red)
                 }
             }
 
             Text("""
-            • By subscribing to Ghostery, you are supporting our mission. Thank you for believing in us!
+            • By donating to Ghostery, you are supporting our mission. Thank you for believing in us!
 
-            • For now the subscription does not unlock any additional features but it helps us.
+            • For now donating does not unlock any additional features, but it does help us.
 
-            • We are working on implementing more premium features for you on the Apple platform.
+            • We are working on implementing more privacy features and benefits on the Apple platform.
 
-            • You will be soon able to link your Apple subscription to your Ghostery account for unlocking premium features on further platforms.
+            • You will soon be able to link your Apple subscription to your Ghostery account and unlock additional features on other platforms.
             """)
                 .font(.footnote)
                 .lineLimit(nil)


### PR DESCRIPTION
Fixes #1021.

I've got only a problem with updating the price on the confirm buttons (those blue ones). The price label is passed from the `StoreKit` product model, which has built-in localization. We don't control the label directly. I think it will display the price according to the local settings.

It's the `product.displayPrice` passed here: https://github.com/ghostery/ghostery-extension/blob/94f2af9553de66aded6a180313b2eae0636fbeaa/extension-manifest-v3/xcode/Shared%20(App)/views/screens/Subscriptions/SubscriptionListViewRow.swift#L25
