### PR TITLE
MV2: don't list non-blockable trackers

### DIFF
--- a/extension-manifest-v2/src/classes/BugDb.js
+++ b/extension-manifest-v2/src/classes/BugDb.js
@@ -81,6 +81,10 @@ export class BugDb {
 		patterns.forEach((pattern) => {
 			const id = getPatternId(pattern);
 
+			if (pattern.filters.length === 0) {
+				return;
+			}
+
 			categoriesMeta[pattern.category].trackers.push({
 				id,
 				name: pattern.name,
@@ -147,7 +151,7 @@ export class BugDb {
 			num_total: categoriesMeta[category].trackers.length,
 			num_blocked: categoriesMeta[category].blockedTrackersCount,
 			trackers: categoriesMeta[category].trackers,
-		}));
+		})).filter(category => category.num_total > 0);
 
 		this.conf.bugs = this.db;
 		this.loadingPromiseResolver();

--- a/extension-manifest-v2/test/src/BugDb.test.js
+++ b/extension-manifest-v2/test/src/BugDb.test.js
@@ -23,7 +23,7 @@ describe('src/classes/BugDb.js', () => {
 
 	describe('init', () => {
 		describe('on every run', () => {
-			test('adds categories', async () => {
+			test('does not add empty category', async () => {
 				bugDb.engine = createEngineMock({
 					categories: [{
 						key: 'advertising'
@@ -31,15 +31,7 @@ describe('src/classes/BugDb.js', () => {
 				});
 				expect(bugDb.db.categories).toHaveLength(0);
 				await bugDb.init();
-				expect(bugDb.db.categories).toEqual([{
-					description: 'category_advertising_desc',
-					id: 'advertising',
-					img_name: 'adv',
-					name: 'category_advertising',
-					num_blocked: 0,
-					num_total: 0,
-					trackers: [],
-				}]);
+				expect(bugDb.db.categories).toEqual([]);
 			});
 
 			describe('with patterns', () => {
@@ -53,6 +45,7 @@ describe('src/classes/BugDb.js', () => {
 							ghostery_id: '1',
 							name: 'Google Ads',
 							key: 'google_ads',
+							filters: ['test']
 						}],
 					});
 				});
@@ -144,16 +137,19 @@ describe('src/classes/BugDb.js', () => {
 						ghostery_id: '1',
 						name: 'Google Ads',
 						key: 'google_ads',
+						filters: ['test']
 					}, {
 						category: 'advertising',
 						ghostery_id: '2',
 						name: 'Facebook Ads',
 						key: 'facebook_ads',
+						filters: ['test']
 					}, {
 						category: 'essential',
 						ghostery_id: '3',
 						name: 'Google Tag Manager',
 						key: 'google_tag_manager',
+						filters: ['test']
 					}],
 				});
 			});
@@ -203,6 +199,7 @@ describe('src/classes/BugDb.js', () => {
 						ghostery_id: '1',
 						name: 'Google Ads',
 						key: 'google_ads',
+						filters: ['test']
 					}],
 				});
 
@@ -241,6 +238,7 @@ describe('src/classes/BugDb.js', () => {
 						ghostery_id: '1',
 						name: 'Google Ads',
 						key: 'google_ads',
+						filters: ['test']
 					}],
 				});
 


### PR DESCRIPTION
In the new TrackerDB there are over 700 patterns without network filters. Those cannot be blocked so for now we wont list them.