### PR TITLE
TrackerDB: rename engine.bytes to engine.dat

### DIFF
--- a/extension-manifest-v2/.gitignore
+++ b/extension-manifest-v2/.gitignore
@@ -29,4 +29,4 @@ out/
 coverage/
 
 ## Assets
-databases/trackerdb.engine.bytes
+databases/trackerdb.engine.dat

--- a/extension-manifest-v2/src/classes/BugDb.js
+++ b/extension-manifest-v2/src/classes/BugDb.js
@@ -22,7 +22,7 @@ export function getPatternId(pattern) {
 
 async function getEngine() {
 	const response = await fetch(
-		chrome.runtime.getURL('databases/trackerdb.engine.bytes'),
+		chrome.runtime.getURL('databases/trackerdb.engine.dat'),
 	);
 	const rawTrackerDB = await response.arrayBuffer();
 	return FiltersEngine.deserialize(new Uint8Array(rawTrackerDB));

--- a/extension-manifest-v2/tools/download-trackerdb.js
+++ b/extension-manifest-v2/tools/download-trackerdb.js
@@ -36,7 +36,7 @@ const { ENGINE_VERSION } = require('@cliqz/adblocker');
 	const trackerDB = await trackerDBResponse.arrayBuffer();
 
 	writeFileSync(
-		path.join('databases', 'trackerdb.engine.bytes'),
+		path.join('databases', 'trackerdb.engine.dat'),
 		new Uint8Array(trackerDB),
 	);
 })();

--- a/extension-manifest-v3/scripts/build.js
+++ b/extension-manifest-v3/scripts/build.js
@@ -87,7 +87,7 @@ const engines = ['ads', 'tracking', 'annoyances'];
 const engineType = argv.target === 'firefox' ? '' : '-cosmetics';
 
 engines.forEach((engine) => {
-  const path = `engine-${engine}${engineType}.bytes`;
+  const path = `engine-${engine}${engineType}.dat`;
   shelljs.cp(
     resolve(options.srcDir, 'rule_resources', path),
     resolve(options.outDir, 'rule_resources'),
@@ -96,7 +96,7 @@ engines.forEach((engine) => {
 
 // copy trackerdb engine
 shelljs.cp(
-  resolve(options.srcDir, 'rule_resources', 'engine-trackerdb.bytes'),
+  resolve(options.srcDir, 'rule_resources', 'engine-trackerdb.dat'),
   resolve(options.outDir, 'rule_resources'),
 );
 

--- a/extension-manifest-v3/scripts/download-engines/index.js
+++ b/extension-manifest-v3/scripts/download-engines/index.js
@@ -68,7 +68,7 @@ for (const [name, target] of Object.entries(ENGINES)) {
     return res.arrayBuffer();
   });
 
-  writeFileSync(`${TARGET_PATH}/engine-${target}.bytes`, new Uint8Array(rules));
+  writeFileSync(`${TARGET_PATH}/engine-${target}.dat`, new Uint8Array(rules));
 
   /* DNR rules */
 

--- a/extension-manifest-v3/src/background/utils/trackerdb.js
+++ b/extension-manifest-v3/src/background/utils/trackerdb.js
@@ -14,7 +14,7 @@ import { FiltersEngine } from '@cliqz/adblocker';
 let engine;
 let trackerDBStartupPromise = (async () => {
   const response = await fetch(
-    chrome.runtime.getURL('rule_resources/engine-trackerdb.bytes'),
+    chrome.runtime.getURL('rule_resources/engine-trackerdb.dat'),
   );
   const rawTrackerDB = await response.arrayBuffer();
   engine = FiltersEngine.deserialize(new Uint8Array(rawTrackerDB));


### PR DESCRIPTION
Opera does not allow files with `.bytes` extension. 