### PR TITLE
TrackersPreview: hide details view

### DIFF
--- a/ui/src/modules/panel/components/stats.js
+++ b/ui/src/modules/panel/components/stats.js
@@ -83,6 +83,7 @@ export default {
           </ui-tooltip>
         `}
         ${trackers &&
+        trackers.length > 0 &&
         html`
           <ui-panel-action-group>
             <ui-tooltip>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1228153/235194950-6326a800-a1d2-4ea6-b63e-e71ba96b4964.png)

fixes ui problem introduced by https://github.com/ghostery/ghostery-extension/pull/1141

Trackers Preview should not show Simple/Detailed View switcher