### PR TITLE
Add asyncSetup utility

### DIFF
--- a/extension-manifest-v3/src/background/utils/setup.js
+++ b/extension-manifest-v3/src/background/utils/setup.js
@@ -1,0 +1,32 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+export default function asyncSetup(promises, threshold = 5000) {
+  let timeoutId;
+
+  const result = {
+    pending: Promise.race([
+      Promise.all(promises),
+      new Promise((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(Error('Initial setup threshold exceeded'));
+        }, threshold);
+      }),
+    ]).then((...args) => {
+      result.pending = false;
+      clearTimeout(timeoutId);
+
+      return args;
+    }),
+  };
+
+  return result;
+}

--- a/extension-manifest-v3/src/store/options.js
+++ b/extension-manifest-v3/src/store/options.js
@@ -169,8 +169,6 @@ export async function observe(property, fn) {
     }
   };
 
-  observers.add(wrapper);
-
   try {
     const options = await store.resolve(Options);
     // let observer know of the option value
@@ -180,6 +178,8 @@ export async function observe(property, fn) {
   } catch (e) {
     console.error(e);
   }
+
+  observers.add(wrapper);
 
   // Return unobserve function
   return () => {


### PR DESCRIPTION
I know that it is a third attempt at the same subject, but I think it is worth considering this solution. It is very short, covers all of the edge cases, supports race conditions, and takes only 20 lines of code. 

To use it, simply:

```js
const setup = asynsSetup([promise1, promise2]);

// consume in async function
setup.pending && (await setup.pending);
```