### PR TITLE
Use local implementation for delaying icon update

### DIFF
--- a/extension-manifest-v3/package.json
+++ b/extension-manifest-v3/package.json
@@ -43,7 +43,6 @@
     "@whotracksme/webextension-packages": "^2.1.5",
     "idb": "^7.1.1",
     "jwt-decode": "^3.1.2",
-    "lodash-es": "^4.17.21",
     "tldts-experimental": "^5.7.66"
   },
   "webExt": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,6 @@
         "@whotracksme/webextension-packages": "^2.1.5",
         "idb": "^7.1.1",
         "jwt-decode": "^3.1.2",
-        "lodash-es": "^4.17.21",
         "tldts-experimental": "^5.7.66"
       },
       "devDependencies": {
@@ -14863,11 +14862,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "node_modules/lodash.escape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
@@ -22269,7 +22263,6 @@
         "eslint-plugin-prettier": "^4.0.0",
         "idb": "^7.1.1",
         "jwt-decode": "^3.1.2",
-        "lodash-es": "^4.17.21",
         "node-fetch": "^3.2.3",
         "prettier": "^2.6.1",
         "shelljs": "^0.8.5",
@@ -32803,11 +32796,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
-    },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.escape": {
       "version": "4.0.1",


### PR DESCRIPTION
Fixes #977 

Hits update on both edges (to be fast but also to update changes during the delay).

It looks like it is even better in another context, before the change, the background process cleared updates of the icon in not the "newest" tab - as we used only one throttle for all tabs.