### PR TITLE
Minor fixes for Firefox/Ghostery Browser 

### DIFF
--- a/extension-manifest-v2/package.json
+++ b/extension-manifest-v2/package.json
@@ -109,7 +109,7 @@
     "underscore-template-loader": "^1.2.0",
     "url-loader": "^4.1.1",
     "vendor-copy": "^3.0.1",
-    "web-ext": "^7.4.0",
+    "web-ext": "^7.6.2",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",
     "webpack-shell-plugin-next": "^2.3.1"

--- a/extension-manifest-v2/webpack.config.js
+++ b/extension-manifest-v2/webpack.config.js
@@ -110,8 +110,6 @@ module.exports = {
 			onBuildEnd: {
 				scripts: [
 					`${RM} ./dist/foundation.js`,
-					`${RM} ./dist/panel.js`,
-					`${RM} ./dist/panel_android.js`,
 					`${RM} ./dist/purplebox_styles.js`,
 					'npm run licenses',
 				],

--- a/extension-manifest-v3/package.json
+++ b/extension-manifest-v3/package.json
@@ -31,7 +31,7 @@
     "prettier": "^2.6.1",
     "shelljs": "^0.8.5",
     "vite": "^4.0.2",
-    "web-ext": "^7.3.1"
+    "web-ext": "^7.6.2"
   },
   "dependencies": {
     "@cliqz/adblocker": "^1.26.6",

--- a/extension-manifest-v3/src/background/adblocker.js
+++ b/extension-manifest-v3/src/background/adblocker.js
@@ -351,7 +351,7 @@ if (__PLATFORM__ === 'firefox') {
         );
       }
 
-      if (details.frameAncestors.length > 0) {
+      if (details.frameAncestors?.length > 0) {
         for (const { url } of details.frameAncestors) {
           const { domain, hostname } = parse(url);
           if (pausedDomains.includes(domain || hostname)) {
@@ -402,7 +402,7 @@ if (__PLATFORM__ === 'firefox') {
     (details) => {
       const request = Request.fromRequestDetails(details);
 
-      if (details.frameAncestors.length > 0) {
+      if (details.frameAncestors?.length > 0) {
         for (const { url } of details.frameAncestors) {
           const { domain, hostname } = parse(url);
           if (pausedDomains.includes(domain || hostname)) {

--- a/extension-manifest-v3/src/background/adblocker.js
+++ b/extension-manifest-v3/src/background/adblocker.js
@@ -351,6 +351,15 @@ if (__PLATFORM__ === 'firefox') {
         );
       }
 
+      if (details.frameAncestors.length > 0) {
+        for (const { url } of details.frameAncestors) {
+          const { domain, hostname } = parse(url);
+          if (pausedDomains.includes(domain || hostname)) {
+            return;
+          }
+        }
+      }
+
       if (
         pausedDomains.includes(request.sourceDomain || request.sourceHostname)
       ) {
@@ -392,6 +401,15 @@ if (__PLATFORM__ === 'firefox') {
   chrome.webRequest.onHeadersReceived.addListener(
     (details) => {
       const request = Request.fromRequestDetails(details);
+
+      if (details.frameAncestors.length > 0) {
+        for (const { url } of details.frameAncestors) {
+          const { domain, hostname } = parse(url);
+          if (pausedDomains.includes(domain || hostname)) {
+            return;
+          }
+        }
+      }
 
       if (pausedDomains.includes(request.sourceDomain)) {
         return {};

--- a/extension-manifest-v3/src/background/adblocker.js
+++ b/extension-manifest-v3/src/background/adblocker.js
@@ -328,6 +328,23 @@ if (__PLATFORM__ === 'safari') {
   });
 }
 
+function isPaused(details, request) {
+  if (details.frameAncestors?.length > 0) {
+    for (const { url } of details.frameAncestors) {
+      const { domain, hostname } = parse(url);
+      if (pausedDomains.includes(domain || hostname)) {
+        return true;
+      }
+    }
+  }
+
+  if (pausedDomains.includes(request.sourceDomain || request.sourceHostname)) {
+    return true;
+  }
+
+  return false;
+}
+
 if (__PLATFORM__ === 'firefox') {
   chrome.webRequest.onBeforeRequest.addListener(
     (details) => {
@@ -349,47 +366,34 @@ if (__PLATFORM__ === 'firefox') {
                 )
             : () => updateTabStats(tabId, [request]),
         );
-      }
 
-      if (details.frameAncestors?.length > 0) {
-        for (const { url } of details.frameAncestors) {
-          const { domain, hostname } = parse(url);
-          if (pausedDomains.includes(domain || hostname)) {
-            return;
+        if (isPaused(details, request)) return;
+
+        for (const { engine, isEnabled } of adblockerEngines) {
+          if (!engine || isEnabled === false) {
+            continue;
           }
-        }
-      }
 
-      if (
-        pausedDomains.includes(request.sourceDomain || request.sourceHostname)
-      ) {
-        return;
-      }
+          if (request.isMainFrame()) {
+            const htmlFilters = engine.getHtmlFilters(request);
+            if (htmlFilters.length !== 0) {
+              filterRequestHTML(
+                chrome.webRequest.filterResponseData,
+                request,
+                htmlFilters,
+              );
+              return;
+            }
+          } else {
+            const { redirect, match } = engine.match(request);
 
-      for (const { engine, isEnabled } of adblockerEngines) {
-        if (!engine || isEnabled === false) {
-          continue;
-        }
-
-        if (request.isMainFrame()) {
-          const htmlFilters = engine.getHtmlFilters(request);
-          if (htmlFilters.length !== 0) {
-            filterRequestHTML(
-              chrome.webRequest.filterResponseData,
-              request,
-              htmlFilters,
-            );
-            return;
-          }
-        } else {
-          const { redirect, match } = engine.match(request);
-
-          if (redirect !== undefined) {
-            request.blocked = true;
-            return { redirectUrl: redirect.dataUrl };
-          } else if (match === true) {
-            request.blocked = true;
-            return { cancel: true };
+            if (redirect !== undefined) {
+              request.blocked = true;
+              return { redirectUrl: redirect.dataUrl };
+            } else if (match === true) {
+              request.blocked = true;
+              return { cancel: true };
+            }
           }
         }
       }
@@ -401,19 +405,7 @@ if (__PLATFORM__ === 'firefox') {
   chrome.webRequest.onHeadersReceived.addListener(
     (details) => {
       const request = Request.fromRequestDetails(details);
-
-      if (details.frameAncestors?.length > 0) {
-        for (const { url } of details.frameAncestors) {
-          const { domain, hostname } = parse(url);
-          if (pausedDomains.includes(domain || hostname)) {
-            return;
-          }
-        }
-      }
-
-      if (pausedDomains.includes(request.sourceDomain)) {
-        return {};
-      }
+      if (isPaused(details, request)) return;
 
       let policies;
       for (const { engine, isEnabled } of adblockerEngines) {

--- a/extension-manifest-v3/src/background/helpers.js
+++ b/extension-manifest-v3/src/background/helpers.js
@@ -9,20 +9,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import '../utils/shims.js';
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  switch (msg.action) {
+    case 'getCurrentTab':
+      chrome.tabs.query({ active: true, currentWindow: true }).then(([tab]) => {
+        sendResponse(tab);
+      });
+      return true;
+  }
 
-import './onboarding.js';
-
-import './autoconsent.js';
-import './adblocker.js';
-import './stats.js';
-import './trackers-preview.js';
-
-import './alarms.js';
-import './dnr.js';
-import './helpers.js';
-
-import './telemetry.js';
-import './reporting.js';
-import './external.js';
-import './devtools.js';
+  return false;
+});

--- a/extension-manifest-v3/src/pages/panel/components/notification.js
+++ b/extension-manifest-v3/src/pages/panel/components/notification.js
@@ -13,6 +13,8 @@ import { html } from 'hybrids';
 
 function close(host, event) {
   event.preventDefault();
+  event.stopPropagation();
+
   host.parentNode.removeChild(host);
 }
 

--- a/extension-manifest-v3/src/pages/panel/components/notification.js
+++ b/extension-manifest-v3/src/pages/panel/components/notification.js
@@ -10,6 +10,7 @@
  */
 
 import { html } from 'hybrids';
+import { openTabWithUrl } from '/utils/tabs.js';
 
 function close(host, event) {
   event.preventDefault();
@@ -27,7 +28,7 @@ export default {
       <ui-action>
         <a
           href="${href}"
-          target="_blank"
+          onclick="${openTabWithUrl}"
           layout="row gap:2 items:stretch padding:1.5"
         >
           ${icon &&

--- a/extension-manifest-v3/src/pages/panel/index.js
+++ b/extension-manifest-v3/src/pages/panel/index.js
@@ -66,6 +66,7 @@ if (__PLATFORM__ === 'firefox') {
     let el = event.target;
     while (el && !el.href) el = el.parentElement;
 
+    // Timeout is required to prevent from closing the window before the anchor is opened
     if (el?.target) setTimeout(window.close, 100);
   });
 }

--- a/extension-manifest-v3/src/pages/panel/index.js
+++ b/extension-manifest-v3/src/pages/panel/index.js
@@ -66,6 +66,6 @@ if (__PLATFORM__ === 'firefox') {
     let el = event.target;
     while (el && !el.href) el = el.parentElement;
 
-    if (el?.target) requestIdleCallback(window.close);
+    if (el?.target) setTimeout(window.close, 100);
   });
 }

--- a/extension-manifest-v3/src/pages/panel/views/home.js
+++ b/extension-manifest-v3/src/pages/panel/views/home.js
@@ -114,7 +114,6 @@ export default {
                 <ui-action slot="icon">
                   <a
                     href="https://www.ghostery.com"
-                    target="_blank"
                     onclick="${openTabWithUrl}"
                   >
                     <ui-icon name="logo"></ui-icon>
@@ -134,7 +133,7 @@ export default {
                 layout="absolute inset bottom:auto margin"
               >
                 Additional Permissions Required <br />
-                <a href="${ONBOARDING_URL}" target="_blank">
+                <a href="${ONBOARDING_URL}" onclick="${openTabWithUrl}">
                   Enable Ghostery
                 </a>
               </gh-panel-alert>
@@ -149,7 +148,6 @@ export default {
             <gh-panel-button>
               <a
                 href="${chrome.runtime.getURL('/pages/onboarding/index.html')}"
-                target="_blank"
                 layout="row center gap:0.5"
                 onclick="${openTabWithUrl}"
               >
@@ -199,7 +197,7 @@ export default {
             <ui-text color="gray-900">
               <a
                 href="${options.terms ? SETTINGS_URL : ONBOARDING_URL}"
-                target="_blank"
+                onclick="${openTabWithUrl}"
                 layout="block"
               >
                 <gh-panel-options-item

--- a/extension-manifest-v3/src/pages/panel/views/home.js
+++ b/extension-manifest-v3/src/pages/panel/views/home.js
@@ -15,6 +15,8 @@ import Options from '/store/options.js';
 import Session from '/store/session.js';
 import TabStats from '/store/tab-stats.js';
 
+import { openTabWithUrl } from '/utils/tabs.js';
+
 import sleep from '../assets/sleep.svg';
 
 import Navigation from './navigation.js';
@@ -110,7 +112,11 @@ export default {
               <ui-panel-header layout="fixed top left width:full">
                 ${store.ready(stats) && stats.domain}
                 <ui-action slot="icon">
-                  <a href="https://www.ghostery.com" target="_blank">
+                  <a
+                    href="https://www.ghostery.com"
+                    target="_blank"
+                    onclick="${openTabWithUrl}"
+                  >
                     <ui-icon name="logo"></ui-icon>
                   </a>
                 </ui-action>
@@ -145,6 +151,7 @@ export default {
                 href="${chrome.runtime.getURL('/pages/onboarding/index.html')}"
                 target="_blank"
                 layout="row center gap:0.5"
+                onclick="${openTabWithUrl}"
               >
                 <ui-icon name="pause"></ui-icon>
                 Enable Ghostery
@@ -226,6 +233,7 @@ export default {
                 icon="${notification.icon}"
                 href="${notification.url}"
                 type="${notification.type}"
+                onclick="${openTabWithUrl}"
               >
                 ${notification.text}
                 <span slot="action">${notification.action}</span>

--- a/extension-manifest-v3/src/pages/panel/views/navigation.js
+++ b/extension-manifest-v3/src/pages/panel/views/navigation.js
@@ -72,7 +72,6 @@ export default {
               href="${session.user
                 ? 'https://account.ghostery.com/'
                 : 'https://signon.ghostery.com/'}"
-              target="_blank"
               layout="block padding margin:0:1"
               onclick="${openTabWithUrl}"
             >
@@ -95,7 +94,6 @@ export default {
                   <ui-text>
                     <a
                       href="${href}"
-                      target="_blank"
                       layout="block padding margin:0:1"
                       onclick="${openTabWithUrl}"
                     >

--- a/extension-manifest-v3/src/pages/panel/views/navigation.js
+++ b/extension-manifest-v3/src/pages/panel/views/navigation.js
@@ -12,6 +12,7 @@
 import { html, msg, router, store } from 'hybrids';
 
 import Session from '/store/session.js';
+import { openTabWithUrl } from '/utils/tabs.js';
 
 const MENU = [
   {},
@@ -73,6 +74,7 @@ export default {
                 : 'https://signon.ghostery.com/'}"
               target="_blank"
               layout="block padding margin:0:1"
+              onclick="${openTabWithUrl}"
             >
               <gh-panel-menu-item icon="user">
                 ${session.user
@@ -95,6 +97,7 @@ export default {
                       href="${href}"
                       target="_blank"
                       layout="block padding margin:0:1"
+                      onclick="${openTabWithUrl}"
                     >
                       <gh-panel-menu-item icon="${icon}">
                         ${label}

--- a/extension-manifest-v3/src/pages/panel/views/tracker-details.js
+++ b/extension-manifest-v3/src/pages/panel/views/tracker-details.js
@@ -65,7 +65,7 @@ export default {
           ${wtmUrl &&
           html`
             <ui-text type="label-xs" color="primary-700" underline>
-              <a href="${wtmUrl}" target="_blank" onclick="${openTabWithUrl}">
+              <a href="${wtmUrl}" onclick="${openTabWithUrl}">
                 Read more on WhoTracks.Me
               </a>
             </ui-text>
@@ -107,11 +107,7 @@ export default {
                 underline
                 layout="padding margin:-1"
               >
-                <a
-                  href="${tracker.website}"
-                  target="_blank"
-                  onclick="${openTabWithUrl}"
-                >
+                <a href="${tracker.website}" onclick="${openTabWithUrl}">
                   ${tracker.website}
                 </a>
               </ui-text>
@@ -131,11 +127,7 @@ export default {
                 underline
                 layout="padding margin:-1"
               >
-                <a
-                  href="${tracker.privacyPolicy}"
-                  target="_blank"
-                  onclick="${openTabWithUrl}"
-                >
+                <a href="${tracker.privacyPolicy}" onclick="${openTabWithUrl}">
                   ${tracker.privacyPolicy}
                 </a>
               </ui-text>
@@ -157,7 +149,6 @@ export default {
                   href="${tracker.contact.startsWith('http')
                     ? ''
                     : 'mailto:'}${tracker.contact}"
-                  target="_blank"
                   onclick="${openTabWithUrl}"
                 >
                   ${tracker.contact}

--- a/extension-manifest-v3/src/pages/panel/views/tracker-details.js
+++ b/extension-manifest-v3/src/pages/panel/views/tracker-details.js
@@ -10,7 +10,9 @@
  */
 
 import { html, router, store } from 'hybrids';
+
 import TabStats from '/store/tab-stats.js';
+import { openTabWithUrl } from '/utils/tabs.js';
 
 function cleanUp(text) {
   return text.replace(/(\\"|\\n|\\t|\\r)/g, '').trim();
@@ -63,7 +65,7 @@ export default {
           ${wtmUrl &&
           html`
             <ui-text type="label-xs" color="primary-700" underline>
-              <a href="${wtmUrl}" target="_blank">
+              <a href="${wtmUrl}" target="_blank" onclick="${openTabWithUrl}">
                 Read more on WhoTracks.Me
               </a>
             </ui-text>
@@ -105,7 +107,11 @@ export default {
                 underline
                 layout="padding margin:-1"
               >
-                <a href="${tracker.website}" target="_blank">
+                <a
+                  href="${tracker.website}"
+                  target="_blank"
+                  onclick="${openTabWithUrl}"
+                >
                   ${tracker.website}
                 </a>
               </ui-text>
@@ -125,7 +131,11 @@ export default {
                 underline
                 layout="padding margin:-1"
               >
-                <a href="${tracker.privacyPolicy}" target="_blank">
+                <a
+                  href="${tracker.privacyPolicy}"
+                  target="_blank"
+                  onclick="${openTabWithUrl}"
+                >
                   ${tracker.privacyPolicy}
                 </a>
               </ui-text>
@@ -148,6 +158,7 @@ export default {
                     ? ''
                     : 'mailto:'}${tracker.contact}"
                   target="_blank"
+                  onclick="${openTabWithUrl}"
                 >
                   ${tracker.contact}
                 </a>

--- a/extension-manifest-v3/src/utils/tabs.js
+++ b/extension-manifest-v3/src/utils/tabs.js
@@ -9,20 +9,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import '../utils/shims.js';
+export function openTabWithUrl(host, event) {
+  const { href } = event.currentTarget;
+  event.preventDefault();
 
-import './onboarding.js';
-
-import './autoconsent.js';
-import './adblocker.js';
-import './stats.js';
-import './trackers-preview.js';
-
-import './alarms.js';
-import './dnr.js';
-import './helpers.js';
-
-import './telemetry.js';
-import './reporting.js';
-import './external.js';
-import './devtools.js';
+  Promise.resolve(chrome.tabs.create({ url: href })).then(() => {
+    window.close();
+  });
+}

--- a/extension-manifest-v3/src/utils/tabs.js
+++ b/extension-manifest-v3/src/utils/tabs.js
@@ -13,7 +13,7 @@ export function openTabWithUrl(host, event) {
   const { href } = event.currentTarget;
   event.preventDefault();
 
-  Promise.resolve(chrome.tabs.create({ url: href })).then(() => {
+  chrome.tabs.create({ url: href }).then(() => {
     window.close();
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,7 @@
         "underscore-template-loader": "^1.2.0",
         "url-loader": "^4.1.1",
         "vendor-copy": "^3.0.1",
-        "web-ext": "^7.4.0",
+        "web-ext": "^7.6.2",
         "webpack": "^5.75.0",
         "webpack-cli": "^5.0.1",
         "webpack-shell-plugin-next": "^2.3.1"
@@ -129,7 +129,7 @@
         "prettier": "^2.6.1",
         "shelljs": "^0.8.5",
         "vite": "^4.0.2",
-        "web-ext": "^7.3.1"
+        "web-ext": "^7.6.2"
       }
     },
     "libs": {
@@ -638,9 +638,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.3.tgz",
-      "integrity": "sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -1282,14 +1282,14 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
-      "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
+      "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.4.0",
+        "espree": "^9.5.2",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -1367,12 +1367,22 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.41.0.tgz",
-      "integrity": "sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
+      "integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fluent/syntax": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@fluent/syntax/-/syntax-0.19.0.tgz",
+      "integrity": "sha512-5D2qVpZrgpjtqU4eNOcWGp1gnUCgjfM+vKGE2y03kKN6z5EBhtx0qdRFbg8QuNNj8wXNoX93KJoYb+NqoxswmQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@ghostery/extension-manifest-v2": {
@@ -1397,9 +1407,9 @@
       "integrity": "sha512-WAf1EQV5Sn6jGuAIQur/ztKlEV9R+VHDNwqEbeaOb6s9fiwM5z7+ujlWNZtgFkDp3lF0H8D/f0vdiPlfHz0ZTQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
-      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -2994,9 +3004,9 @@
       }
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "5.2.17",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.17.tgz",
-      "integrity": "sha512-aA+rFHhXmq14GVIcEWNk8OntLEOQFwEZk9ZgG5VcDquz+pQhIjJPXacR+rwL9Z0Elfg909EcRRHC96p06/CNUg==",
+      "version": "5.2.42",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.42.tgz",
+      "integrity": "sha512-CD/2ai1W45cDN/zN2AcYduDavU+nq9aStyQizi4MHxnwkRvS/H24WIjgc1qD8CISoqXa8AAIe+A+zpWxwV7a2Q==",
       "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3243,9 +3253,9 @@
       }
     },
     "node_modules/@tanem/svg-injector/node_modules/tslib": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
-      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -3915,41 +3925,42 @@
       }
     },
     "node_modules/addons-linter": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/addons-linter/-/addons-linter-5.23.0.tgz",
-      "integrity": "sha512-Vo6+5YlM2Ge3yYMY+gNg9Smcfcl1J0ZMfGVXnGJjUwDVHuszHVIvurunQuJURnO4FR1gi4Vy1sWye8ArRL5LOw==",
+      "version": "5.32.0",
+      "resolved": "https://registry.npmjs.org/addons-linter/-/addons-linter-5.32.0.tgz",
+      "integrity": "sha512-Lf6oOyw8X9z5BMd9xhQwSbPlN2PUlzDLnYLAVT5lkrgXEx0fO9hRk4JRxWZ8+rFGz+mCIA2TTClZF2f+MKgJQA==",
       "dev": true,
       "dependencies": {
-        "@mdn/browser-compat-data": "5.2.17",
+        "@fluent/syntax": "0.19.0",
+        "@mdn/browser-compat-data": "5.2.42",
         "addons-moz-compare": "1.3.0",
-        "addons-scanner-utils": "8.1.0",
-        "ajv": "8.11.2",
-        "ajv-merge-patch": "5.0.1",
+        "addons-scanner-utils": "8.5.0",
+        "ajv": "8.12.0",
         "chalk": "4.1.2",
         "cheerio": "1.0.0-rc.12",
         "columnify": "1.6.0",
         "common-tags": "1.8.2",
-        "deepmerge": "4.2.2",
-        "eslint": "8.28.0",
-        "eslint-plugin-no-unsanitized": "4.0.1",
+        "deepmerge": "4.3.1",
+        "eslint": "8.36.0",
+        "eslint-plugin-no-unsanitized": "4.0.2",
         "eslint-visitor-keys": "3.3.0",
-        "espree": "9.4.1",
+        "espree": "9.5.0",
         "esprima": "4.0.1",
-        "fluent-syntax": "0.13.0",
-        "glob": "8.0.3",
+        "fast-json-patch": "3.1.1",
+        "glob": "9.3.0",
         "image-size": "1.0.2",
         "is-mergeable-object": "1.1.1",
         "jed": "1.1.1",
+        "json-merge-patch": "1.0.2",
         "os-locale": "5.0.0",
-        "pino": "8.7.0",
-        "postcss": "8.4.19",
+        "pino": "8.11.0",
+        "postcss": "8.4.21",
         "relaxed-json": "1.0.3",
         "semver": "7.3.8",
         "sha.js": "2.4.11",
         "source-map-support": "0.5.21",
         "tosource": "1.0.0",
         "upath": "2.0.1",
-        "yargs": "17.6.2",
+        "yargs": "17.7.1",
         "yauzl": "2.10.0"
       },
       "bin": {
@@ -3960,9 +3971,9 @@
       }
     },
     "node_modules/addons-linter/node_modules/addons-scanner-utils": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/addons-scanner-utils/-/addons-scanner-utils-8.1.0.tgz",
-      "integrity": "sha512-wxqnmmrzZXjz4B4GZbFcR4HJxTP+pGu+C6iOjMJdmL6mgZZey/UEVJlU6XTxu8GdGv0bUoJxyIioH8XEDxy91Q==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/addons-scanner-utils/-/addons-scanner-utils-8.5.0.tgz",
+      "integrity": "sha512-X35SYZRdSnxx7UZuAk+DizKihQp2Ze2c5GV+5nnRr/FFyx/fOgE3Zo8jdhzSne57PENE9w1ZVocBLJTN6UDB3g==",
       "dev": true,
       "dependencies": {
         "@types/yauzl": "2.10.0",
@@ -3973,7 +3984,7 @@
         "yauzl": "2.10.0"
       },
       "peerDependencies": {
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "express": "4.18.2",
         "node-fetch": "2.6.7",
         "safe-compare": "1.1.4"
@@ -3994,9 +4005,9 @@
       }
     },
     "node_modules/addons-linter/node_modules/ajv": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
-      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -4007,19 +4018,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/addons-linter/node_modules/ajv-merge-patch": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-merge-patch/-/ajv-merge-patch-5.0.1.tgz",
-      "integrity": "sha512-0UP3aJCzfzBOkmLR+EinJDCfg6DNtprj3bVPo7JJNgUpZMKt097t9xxQOWFGRoB4JvKKIHE2qe0HkVaS/HyrjQ==",
-      "dev": true,
-      "dependencies": {
-        "fast-json-patch": "^2.0.6",
-        "json-merge-patch": "^1.0.2"
-      },
-      "peerDependencies": {
-        "ajv": ">=8.0.0"
       }
     },
     "node_modules/addons-linter/node_modules/ansi-styles": {
@@ -4036,12 +4034,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/addons-linter/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
     },
     "node_modules/addons-linter/node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -4086,83 +4078,24 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/addons-linter/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/addons-linter/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+    "node_modules/addons-linter/node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true,
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/addons-linter/node_modules/eslint": {
-      "version": "8.28.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.28.0.tgz",
-      "integrity": "sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==",
+    "node_modules/addons-linter/node_modules/espree": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
+      "integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.3.3",
-        "@humanwhocodes/config-array": "^0.11.6",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.10.0",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
-        "debug": "^4.3.2",
-        "doctrine": "^3.0.0",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.1",
-        "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.4.0",
-        "esquery": "^1.4.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "globals": "^13.15.0",
-        "grapheme-splitter": "^1.0.4",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "is-path-inside": "^3.0.3",
-        "js-sdsl": "^4.1.4",
-        "js-yaml": "^4.1.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.1",
-        "regexpp": "^3.2.0",
-        "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
-        "text-table": "^0.2.0"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
+        "acorn": "^8.8.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4171,88 +4104,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/addons-linter/node_modules/eslint/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/addons-linter/node_modules/eslint/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
-    },
-    "node_modules/addons-linter/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/addons-linter/node_modules/glob": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.0.tgz",
+      "integrity": "sha512-EAZejC7JvnQINayvB/7BJbpZpNOJ8Lrw2OZNEvQxe0vaLn1SuwMcfV7/MNaX8L/T0wmptBFI4YMtDvSBxYDc7w==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "minimatch": "^7.4.1",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/addons-linter/node_modules/glob/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/addons-linter/node_modules/globals": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/addons-linter/node_modules/has-flag": {
@@ -4264,38 +4131,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/addons-linter/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/addons-linter/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
-    },
-    "node_modules/addons-linter/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/addons-linter/node_modules/lru-cache": {
       "version": "6.0.0",
@@ -4307,6 +4147,21 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/addons-linter/node_modules/minimatch": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/addons-linter/node_modules/node-fetch": {
@@ -4329,45 +4184,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/addons-linter/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/addons-linter/node_modules/postcss": {
-      "version": "8.4.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
-      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        }
-      ],
-      "dependencies": {
-        "nanoid": "^3.3.4",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/addons-linter/node_modules/semver": {
@@ -4414,18 +4230,6 @@
       "dev": true,
       "optional": true,
       "peer": true
-    },
-    "node_modules/addons-linter/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/addons-linter/node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -6122,27 +5926,6 @@
         "typedarray": "^0.0.6"
       }
     },
-    "node_modules/concat-stream/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
-    },
-    "node_modules/concat-stream/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
     "node_modules/config-chain": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
@@ -6208,9 +5991,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.25.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.3.tgz",
-      "integrity": "sha512-y1hvKXmPHvm5B7w4ln1S4uc9eV/O5+iFExSRUimnvIph11uaizFR8LFMdONN8hG3P2pipUfX4Y/fR8rAEtcHcQ==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.29.0.tgz",
+      "integrity": "sha512-VG23vuEisJNkGl6XQmFJd3rEG/so/CNatqeE+7uZAwTSwFeB/qaO0be8xZYUNWprJ/GIwL8aMt9cj1kvbpTZhg==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -6942,9 +6725,9 @@
       }
     },
     "node_modules/deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -7742,15 +7525,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.41.0.tgz",
-      "integrity": "sha512-WQDQpzGBOP5IrXPo4Hc0814r4/v2rrIsB0rhT7jtunIalgg6gYXWhRMOejVO8yH21T/FGaxjmFjBMNqcIlmH1Q==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
+      "integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.0.3",
-        "@eslint/js": "8.41.0",
+        "@eslint/eslintrc": "^2.0.1",
+        "@eslint/js": "8.36.0",
         "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -7760,9 +7543,9 @@
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.0",
-        "eslint-visitor-keys": "^3.4.1",
-        "espree": "^9.5.2",
+        "eslint-scope": "^7.1.1",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.5.0",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -7770,12 +7553,13 @@
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
         "globals": "^13.19.0",
-        "graphemer": "^1.4.0",
+        "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
+        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
@@ -8004,9 +7788,9 @@
       }
     },
     "node_modules/eslint-plugin-no-unsanitized": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-4.0.1.tgz",
-      "integrity": "sha512-y/lAMWnPPC7RYuUdxlEL/XiCL8FehN9h9s3Kjqbp/Kv0i9NZs+IXSC2kS546Fa4Bumwy31HlVS/OdWX0Kxb5Xg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-4.0.2.tgz",
+      "integrity": "sha512-Pry0S9YmHoz8NCEMRQh7N0Yexh2MYCNPIlrV52hTmS7qXnTghWsjXouF08bgsrrZqaW9tt1ZiK3j5NEmPE+EjQ==",
       "dev": true,
       "peerDependencies": {
         "eslint": "^6 || ^7 || ^8"
@@ -8133,40 +7917,16 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
-    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-webpack-plugin": {
@@ -8191,29 +7951,6 @@
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0",
         "webpack": "^5.0.0"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/eslintrc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
-      "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^9.5.2",
-        "globals": "^13.19.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/ansi-styles": {
@@ -8298,35 +8035,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/espree": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
-      "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.8.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/find-up": {
@@ -8436,14 +8144,14 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-      "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
+      "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -8921,21 +8629,9 @@
       "dev": true
     },
     "node_modules/fast-json-patch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
-      "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/fast-json-patch/node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
       "dev": true
     },
     "node_modules/fast-json-stable-stringify": {
@@ -8951,9 +8647,9 @@
       "dev": true
     },
     "node_modules/fast-redact": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
-      "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.2.0.tgz",
+      "integrity": "sha512-zaTadChr+NekyzallAMXATXLOR8MNx3zqpZ0MUF2aGf4EathnG0f32VLODNlY8IuGY3HoRO2L6/6fSzNsLaHIw==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -9101,16 +8797,16 @@
       }
     },
     "node_modules/firefox-profile": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/firefox-profile/-/firefox-profile-4.2.2.tgz",
-      "integrity": "sha512-3kI17Xl9dL9AeRkpV1yahsJ+UbekkPtlQswKrIsTY1NLgxtEOR4R19rjGGz5+7/rP8Jt6fvxHk+Bai9R6Eai3w==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/firefox-profile/-/firefox-profile-4.3.2.tgz",
+      "integrity": "sha512-/C+Eqa0YgIsQT2p66p7Ygzqe7NlE/GNTbhw2SBCm5V3OsWDPITNdTPEcH2Q2fe7eMpYYNPKdUcuVioZBZiR6kA==",
       "dev": true,
       "dependencies": {
         "adm-zip": "~0.5.x",
         "fs-extra": "~9.0.1",
         "ini": "~2.0.0",
         "minimist": "^1.2.5",
-        "xml2js": "~0.4.23"
+        "xml2js": "^0.5.0"
       },
       "bin": {
         "firefox-profile": "lib/cli.js"
@@ -9143,15 +8839,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
-    },
-    "node_modules/fluent-syntax": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/fluent-syntax/-/fluent-syntax-0.13.0.tgz",
-      "integrity": "sha512-0Bk1AsliuYB550zr4JV9AYhsETsD3ELXUQzdXGJfIc1Ni/ukAfBdQInDhVMYJUaT2QxoamNslwkYF7MlOrPUwg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.9.0"
-      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -9678,12 +9365,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-      "dev": true
-    },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
     "node_modules/growly": {
@@ -14293,9 +13974,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.1.tgz",
-      "integrity": "sha512-YRv4Tk/Wlug8qicwqFNFVEZSdbROCHRAC6qu/i0dyNKr5JQdoa2pIGoS04lLO/jXQX7Z9omoNewYIVIxqZBd9Q==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.13.1.tgz",
+      "integrity": "sha512-MSJQC5vXco5Br38mzaQKiq9mwt7lwj2eXpgpRyQYNHYt2lq1PjkWa7DLXX0WVcQLE9HhMh3jPiufS7fhJf+CLQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -14551,26 +14232,53 @@
       }
     },
     "node_modules/jsonwebtoken": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+      "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
       "dev": true,
       "dependencies": {
         "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
+        "lodash": "^4.17.21",
         "ms": "^2.1.1",
-        "semver": "^5.6.0"
+        "semver": "^7.3.8"
       },
       "engines": {
-        "node": ">=4",
-        "npm": ">=1.4.28"
+        "node": ">=12",
+        "npm": ">=6"
       }
+    },
+    "node_modules/jsonwebtoken/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/jsprim": {
       "version": "1.4.2",
@@ -14613,32 +14321,11 @@
         "setimmediate": "^1.0.5"
       }
     },
-    "node_modules/jszip/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
-    },
     "node_modules/jszip/node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true
-    },
-    "node_modules/jszip/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
     },
     "node_modules/just-extend": {
       "version": "4.2.1",
@@ -14932,34 +14619,10 @@
       "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
     },
-    "node_modules/lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-      "dev": true
-    },
-    "node_modules/lodash.isboolean": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-      "dev": true
-    },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "dev": true
-    },
-    "node_modules/lodash.isinteger": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-      "dev": true
-    },
-    "node_modules/lodash.isnumber": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
       "dev": true
     },
     "node_modules/lodash.isplainobject": {
@@ -14968,22 +14631,10 @@
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true
     },
-    "node_modules/lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-      "dev": true
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
-    },
-    "node_modules/lodash.once": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "dev": true
     },
     "node_modules/lolex": {
@@ -15292,6 +14943,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -15570,9 +15230,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
       "dev": true,
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
@@ -16597,6 +16257,40 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/path-scurry": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.2.tgz",
+      "integrity": "sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^9.1.1",
+        "minipass": "^5.0.0 || ^6.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
+      "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
+      "dev": true,
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
+      "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
@@ -16671,9 +16365,9 @@
       }
     },
     "node_modules/pino": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.7.0.tgz",
-      "integrity": "sha512-l9sA5uPxmZzwydhMWUcm1gI0YxNnYl8MfSr2h8cwLvOAzQLBLewzF247h/vqHe3/tt6fgtXeG9wdjjoetdI/vA==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.11.0.tgz",
+      "integrity": "sha512-Z2eKSvlrl2rH8p5eveNUnTdd4AjJk8tAsLkHYZQKGHP4WTh2Gi1cOSOs3eWPqaj+niS3gj4UkoreoaWgF3ZWYg==",
       "dev": true,
       "dependencies": {
         "atomic-sleep": "^1.0.0",
@@ -16702,10 +16396,25 @@
         "split2": "^4.0.0"
       }
     },
+    "node_modules/pino-abstract-transport/node_modules/readable-stream": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.0.tgz",
+      "integrity": "sha512-kDMOq0qLtxV9f/SQv522h8cxZBqNZXuXNyjyezmfAAuribMyVXziljpQ/uQhfE1XLg2/TLTW2DsnoE4VAi/krg==",
+      "dev": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/pino-std-serializers": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.1.0.tgz",
-      "integrity": "sha512-KO0m2f1HkrPe9S0ldjx7za9BJjeHqBku5Ch8JyxETxT8dEFGz1PwgrHaOQupVYitpzbFSYm7nnljxD8dik2c+g==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.1.tgz",
+      "integrity": "sha512-wHuWB+CvSVb2XqXM0W/WOYUkVSPbiJb9S5fNB7TBhd8s892Xq910bRxwHtC4l71hgztObTjXL6ZheZXFjhDrDQ==",
       "dev": true
     },
     "node_modules/pirates": {
@@ -16739,9 +16448,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+      "version": "8.4.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
       "dev": true,
       "funding": [
         {
@@ -16751,14 +16460,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -16929,9 +16634,9 @@
       "dev": true
     },
     "node_modules/process-warning": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.1.0.tgz",
-      "integrity": "sha512-9C20RLxrZU/rFnxWncDkuF6O999NdIf3E1ws4B0ZeY3sRVPzWBMsYDE2lxjxhiXxg464cQTgKUGm8/i6y2YGXg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
+      "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg==",
       "dev": true
     },
     "node_modules/promise-polyfill": {
@@ -17351,19 +17056,25 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.0.tgz",
-      "integrity": "sha512-kDMOq0qLtxV9f/SQv522h8cxZBqNZXuXNyjyezmfAAuribMyVXziljpQ/uQhfE1XLg2/TLTW2DsnoE4VAi/krg==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
     },
     "node_modules/readdir-scoped-modules": {
       "version": "1.1.0",
@@ -17486,18 +17197,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/registry-auth-token": {
@@ -17915,9 +17614,9 @@
       }
     },
     "node_modules/safe-stable-stringify": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.2.tgz",
-      "integrity": "sha512-gMxvPJYhP0O9n2pvcfYfIuYgbledAOJFcqRThtPRmjscaipiwcwPPKLytpVzMkG2HAN87Qmo2d4PtGiri1dSLA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -18602,17 +18301,17 @@
       }
     },
     "node_modules/sign-addon": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/sign-addon/-/sign-addon-5.1.0.tgz",
-      "integrity": "sha512-fag/csbsw25WpW+G+uWE6rRImSjlfwQNjuP28fFhvXpfW+kXccxl/o1QEW+hXtTidwpysksb7Y0B8UCeMkYkSA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/sign-addon/-/sign-addon-5.3.0.tgz",
+      "integrity": "sha512-7nHlCzhQgVMLBNiXVEgbG/raq48awOW0lYMN5uo1BaB3mp0+k8M8pvDwbfTlr3apcxZJsk9HQsAW1POwoJugpQ==",
       "dev": true,
       "dependencies": {
         "common-tags": "1.8.2",
-        "core-js": "3.25.3",
+        "core-js": "3.29.0",
         "deepcopy": "2.1.0",
         "es6-error": "4.1.1",
         "es6-promisify": "7.0.0",
-        "jsonwebtoken": "8.5.1",
+        "jsonwebtoken": "9.0.0",
         "mz": "2.7.0",
         "request": "2.88.2",
         "source-map-support": "0.5.21",
@@ -18883,9 +18582,9 @@
       }
     },
     "node_modules/sonic-boom": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.2.1.tgz",
-      "integrity": "sha512-iITeTHxy3B9FGu8aVdiDXUVAcHMF9Ss0cCsAOo2HfCrmVGT3/DT5oYaeu0M/YKZDlKTvChEyPq0zI9Hf33EX6A==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.3.0.tgz",
+      "integrity": "sha512-LYxp34KlZ1a2Jb8ZQgFCK3niIHzibdwtwNUWKg0qQRzsDoJ3Gfgkf8KdBTFU3SkejDEIlWwnSnpVdOZIhFMl/g==",
       "dev": true,
       "dependencies": {
         "atomic-sleep": "^1.0.0"
@@ -19042,9 +18741,9 @@
       }
     },
     "node_modules/split2": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
-      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "dev": true,
       "engines": {
         "node": ">= 10.x"
@@ -19833,9 +19532,9 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
-      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dev": true,
       "dependencies": {
         "psl": "^1.1.33",
@@ -20580,42 +20279,42 @@
       }
     },
     "node_modules/web-ext": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/web-ext/-/web-ext-7.4.0.tgz",
-      "integrity": "sha512-dT2HJaGNXxRNuOtzaVBtEULccL0kM2SN1ark1NnN/ZSlbucobBxCDj6119iki72YyuXpaXZCJGqfZtVf1Znocg==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/web-ext/-/web-ext-7.6.2.tgz",
+      "integrity": "sha512-xlxbzgFBIS/UWWlvWxyR1PIqRRzDj1cutoHh+VZu4ZTcJTfv35KVdKkLRZv4PQwHu4dg8VfTg7WEcNP4QLaaFQ==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "7.20.1",
+        "@babel/runtime": "7.21.0",
         "@devicefarmer/adbkit": "3.2.3",
-        "addons-linter": "5.23.0",
+        "addons-linter": "5.32.0",
         "bunyan": "1.8.15",
-        "camelcase": "7.0.0",
+        "camelcase": "7.0.1",
         "chrome-launcher": "0.15.1",
         "debounce": "1.2.1",
         "decamelize": "6.0.0",
         "es6-error": "4.1.1",
-        "firefox-profile": "4.2.2",
-        "fs-extra": "10.1.0",
+        "firefox-profile": "4.3.2",
+        "fs-extra": "11.1.0",
         "fx-runner": "1.3.0",
         "import-fresh": "3.3.0",
-        "jose": "4.11.1",
+        "jose": "4.13.1",
         "mkdirp": "1.0.4",
         "multimatch": "6.0.0",
         "mz": "2.7.0",
-        "node-fetch": "3.3.0",
+        "node-fetch": "3.3.1",
         "node-notifier": "10.0.1",
-        "open": "8.4.0",
+        "open": "8.4.2",
         "parse-json": "6.0.2",
         "promise-toolbox": "0.21.0",
-        "sign-addon": "5.1.0",
+        "sign-addon": "5.3.0",
         "source-map-support": "0.5.21",
         "strip-bom": "5.0.0",
         "strip-json-comments": "5.0.0",
         "tmp": "0.2.1",
         "update-notifier": "6.0.2",
         "watchpack": "2.4.0",
-        "ws": "8.11.0",
-        "yargs": "17.6.2",
+        "ws": "8.13.0",
+        "yargs": "17.7.1",
         "zip-dir": "2.0.0"
       },
       "bin": {
@@ -20626,22 +20325,10 @@
         "npm": ">=6.9.0"
       }
     },
-    "node_modules/web-ext/node_modules/@babel/runtime": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
-      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
-      "dev": true,
-      "dependencies": {
-        "regenerator-runtime": "^0.13.10"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/web-ext/node_modules/camelcase": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.0.tgz",
-      "integrity": "sha512-JToIvOmz6nhGsUhAYScbo2d6Py5wojjNfoxoc2mEVLUdJ70gJK2gnd+ABY1Tc3sVMyK7QDPtN0T/XdlCQWITyQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
+      "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
       "dev": true,
       "engines": {
         "node": ">=14.16"
@@ -20651,9 +20338,9 @@
       }
     },
     "node_modules/web-ext/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -20661,7 +20348,7 @@
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.14"
       }
     },
     "node_modules/web-ext/node_modules/lines-and-columns": {
@@ -20686,9 +20373,9 @@
       }
     },
     "node_modules/web-ext/node_modules/open": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
@@ -21255,16 +20942,16 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -21297,9 +20984,9 @@
       }
     },
     "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dev": true,
       "dependencies": {
         "sax": ">=0.6.0",
@@ -21355,9 +21042,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",

--- a/patches/web-ext+7.6.2.patch
+++ b/patches/web-ext+7.6.2.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/web-ext/lib/util/file-filter.js b/node_modules/web-ext/lib/util/file-filter.js
+index 0fe23ce..960c57e 100644
+--- a/node_modules/web-ext/lib/util/file-filter.js
++++ b/node_modules/web-ext/lib/util/file-filter.js
+@@ -25,9 +25,7 @@ export class FileFilter {
+   constructor({
+     baseIgnoredPatterns = ['**/*.xpi', '**/*.zip', '**/.*',
+     // any hidden file and folder
+-    '**/.*/**/*',
+-    // and the content inside hidden folder
+-    '**/node_modules', '**/node_modules/**/*'],
++    '**/.*/**/*'],
+     ignoreFiles = [],
+     sourceDir,
+     artifactsDir

--- a/ui/src/modules/panel/components/stats.js
+++ b/ui/src/modules/panel/components/stats.js
@@ -11,6 +11,17 @@
 
 import { html, msg, router, dispatch } from 'hybrids';
 
+function openTabWithUrl(host, event) {
+  if (chrome.tabs?.create) {
+    event.preventDefault();
+    Promise.resolve(chrome.tabs.create({ url: event.currentTarget.href })).then(
+      () => {
+        window.close();
+      },
+    );
+  }
+}
+
 export default {
   categories: undefined,
   categoryList: ({ categories = [] }) =>
@@ -77,7 +88,7 @@ export default {
           <ui-tooltip>
             <span slot="content">WhoTracks.Me Statistical Report</span>
             <ui-panel-action>
-              <a href="${wtmUrl}" target="_blank">
+              <a href="${wtmUrl}" target="_blank" onclick="${openTabWithUrl}">
                 <ui-icon name="whotracksme"></ui-icon>
               </a>
             </ui-panel-action>

--- a/ui/src/modules/panel/components/stats.js
+++ b/ui/src/modules/panel/components/stats.js
@@ -88,7 +88,7 @@ export default {
           <ui-tooltip>
             <span slot="content">WhoTracks.Me Statistical Report</span>
             <ui-panel-action>
-              <a href="${wtmUrl}" target="_blank" onclick="${openTabWithUrl}">
+              <a href="${wtmUrl}" onclick="${openTabWithUrl}">
                 <ui-icon name="whotracksme"></ui-icon>
               </a>
             </ui-panel-action>

--- a/ui/src/modules/settings/components/toggle.js
+++ b/ui/src/modules/settings/components/toggle.js
@@ -89,6 +89,6 @@ export default {
         }
       }
     `,
-    { deleteFocus: true },
+    { delegateFocus: true },
   ),
 };

--- a/ui/src/modules/trackers-preview/index.js
+++ b/ui/src/modules/trackers-preview/index.js
@@ -111,7 +111,7 @@ export default define({
       background: linear-gradient(180deg, #F0F2F7 0%, #FFFFFF 90%);
     }
 
-     ui-button {
+    ui-button {
       text-transform: none;
       border-radius: 8px;
       box-shadow: 0px 2px 6px rgba(32, 44, 68, 0.08);


### PR DESCRIPTION
Minor fixes for UI/navigation for Firefox Andoird / Ghostery Browser for Android.

Highlights:
* Where possible I added a click listener for external links, and used `chrome.tabs.create` API
* Settings page is broken on Firefox if opened in a new tab (there is no way to fix it using data from the browser) - it's a bug, reported here: https://bugzilla.mozilla.org/show_bug.cgi?id=1813882. They should add `env(safe-area-inset-bottom)`, but it returns `0`
* Closing the window from navigated page (not the first in history) in the "popup" window does not work - the tab opens in the background, so in the settings page click on account / log in must stay in the popup

To test it on Firefox Android, build the extension with `npm run build firefox` and use `web-ext`:

```
npx web-ext run --target=firefox-android --android-device=XXXX
```
