### PR TITLE
Fix errors that can happen if tabs are closed

### DIFF
--- a/extension-manifest-v3/src/background/adblocker.js
+++ b/extension-manifest-v3/src/background/adblocker.js
@@ -78,7 +78,7 @@ function adblockerInjectStylesWebExtension(
         origin: 'USER',
         target,
       })
-      .catch((e) => console.error('Failed to inject CSS', e));
+      .catch((e) => console.warn('Failed to inject CSS', e));
   } else {
     const details = {
       allFrames,
@@ -92,7 +92,7 @@ function adblockerInjectStylesWebExtension(
     }
     chrome.tabs
       .insertCSS(tabId, details)
-      .catch((e) => console.error('Failed to inject CSS', e));
+      .catch((e) => console.warn('Failed to inject CSS', e));
   }
 }
 
@@ -267,7 +267,7 @@ ${scripts.join('\n\n')}}
     },
     () => {
       if (chrome.runtime.lastError) {
-        console.error(chrome.runtime.lastError);
+        console.warn(chrome.runtime.lastError);
       }
     },
   );

--- a/extension-manifest-v3/src/background/autoconsent.js
+++ b/extension-manifest-v3/src/background/autoconsent.js
@@ -70,7 +70,7 @@ async function evalCode(code, id, tabId, frameId) {
     },
   });
 
-  chrome.tabs.sendMessage(
+  await chrome.tabs.sendMessage(
     tabId,
     {
       action: 'autoconsent',


### PR DESCRIPTION
Fixes some situations where closed tabs are not handled. Or convert error to warnings, since it is expected that tabs are being closed and attempts like injecting CSS will fail.
