### PR TITLE
MV2: fix unidentified category

### DIFF
--- a/extension-manifest-v2/.eslintrc.js
+++ b/extension-manifest-v2/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
 	},
 	// 0 = off, 1 = warn, 2 = error
 	rules: {
+		'no-restricted-syntax': ['error', 'ForInStatement', 'LabeledStatement', 'WithStatement'],
 		'arrow-parens': [2, 'as-needed', { requireForBlockBody: true }],
 		camelcase: [0],
 		'comma-dangle': [2, {

--- a/extension-manifest-v2/app/panel/components/Blocking/Categories.jsx
+++ b/extension-manifest-v2/app/panel/components/Blocking/Categories.jsx
@@ -80,7 +80,15 @@ class Categories extends React.Component {
 					num_total: unidentifiedCategory.unidentifiedTrackers.length,
 					num_blocked: unidentifiedCategory.unidentifiedTrackerCount - whitelistedTotal,
 					num_shown: unidentifiedCategory.hide ? 0 : unidentifiedCategory.unidentifiedTrackers.length,
-					trackers,
+					trackers: trackers.sort((a, b) => {
+						if (a.name < b.name) {
+							return -1;
+						}
+						if (a.name > b.name) {
+							return 1;
+						}
+						return 0;
+					}),
 					whitelistedTotal,
 				};
 			}

--- a/extension-manifest-v2/app/panel/components/Blocking/Categories.jsx
+++ b/extension-manifest-v2/app/panel/components/Blocking/Categories.jsx
@@ -81,10 +81,12 @@ class Categories extends React.Component {
 					num_blocked: unidentifiedCategory.unidentifiedTrackerCount - whitelistedTotal,
 					num_shown: unidentifiedCategory.hide ? 0 : unidentifiedCategory.unidentifiedTrackers.length,
 					trackers: trackers.sort((a, b) => {
-						if (a.name < b.name) {
+						const aName = a.name.toLowerCase();
+						const bName = b.name.toLowerCase();
+						if (aName < bName) {
 							return -1;
 						}
-						if (a.name > b.name) {
+						if (aName > bName) {
 							return 1;
 						}
 						return 0;

--- a/extension-manifest-v2/app/panel/reducers/blocking.js
+++ b/extension-manifest-v2/app/panel/reducers/blocking.js
@@ -70,9 +70,15 @@ function mergeTrackers(adblockerTrackers, antiTrackingTrackers, whitelist, pageU
 			all.set(tracker.name, existing);
 		}
 	});
-	const findTrackerByWhitelistedDomain = domain => Array.from(all.values()).find(
-		tracker => !!tracker.domains.some(whitelistedDomain => whitelistedDomain.endsWith(domain))
-	);
+
+	const findTrackerByWhitelistedDomain = (domain) => {
+		for (const tracker of all.values()) {
+			if (tracker.domains.some(whitelistedDomain => whitelistedDomain.endsWith(domain))) {
+				return tracker;
+			}
+		}
+		return null;
+	};
 
 	const pageTld = parse(pageUrl).domain;
 
@@ -81,7 +87,7 @@ function mergeTrackers(adblockerTrackers, antiTrackingTrackers, whitelist, pageU
 			return;
 		}
 		const tld = parse(domain).domain;
-		const existing = findTrackerByWhitelistedDomain(tld) || all.get(tld);
+		const existing = all.get(tld) || findTrackerByWhitelistedDomain(tld);
 		if (existing) {
 			existing.whitelisted = true;
 			existing.domains = [...new Set([...existing.domains, domain])];

--- a/extension-manifest-v2/app/panel/reducers/blocking.js
+++ b/extension-manifest-v2/app/panel/reducers/blocking.js
@@ -176,30 +176,34 @@ const _updateCommonModuleWhitelist = (state, action) => {
 	const updatedUnidentifiedCategory = JSON.parse(JSON.stringify(state.unidentifiedCategory));
 	const { whitelistedUrls } = updatedUnidentifiedCategory;
 	const { unidentifiedTracker, pageHost } = action.data;
+	const pageTld = parse(pageHost).domain;
 
 	const addToWhitelist = () => {
 		unidentifiedTracker.domains.forEach((domain) => {
-			if (whitelistedUrls.hasOwnProperty(domain)) {
-				whitelistedUrls[domain].name = unidentifiedTracker.name;
-				whitelistedUrls[domain].hosts.push(pageHost);
+			const tld = parse(domain).domain;
+			if (whitelistedUrls.hasOwnProperty(tld)) {
+				whitelistedUrls[tld].name = unidentifiedTracker.name;
+				whitelistedUrls[tld].hosts = [...new Set([...whitelistedUrls[tld].hosts, pageTld])];
 			} else {
-				whitelistedUrls[domain] = {
+				whitelistedUrls[tld] = {
 					name: unidentifiedTracker.name,
-					hosts: [pageHost],
+					hosts: [pageTld],
 				};
 			}
 		});
 	};
 
 	const removeFromWhitelist = (domain) => {
-		if (!whitelistedUrls[domain]) { return; }
+		const tld = parse(domain).domain;
 
-		whitelistedUrls[domain].hosts = whitelistedUrls[domain].hosts.filter(hostUrl => (
-			hostUrl !== pageHost
+		if (!whitelistedUrls[tld]) { return; }
+
+		whitelistedUrls[tld].hosts = whitelistedUrls[tld].hosts.filter(hostUrl => (
+			hostUrl !== pageTld
 		));
 
-		if (whitelistedUrls[domain].hosts.length === 0) {
-			delete whitelistedUrls[domain];
+		if (whitelistedUrls[tld].hosts.length === 0) {
+			delete whitelistedUrls[tld];
 		}
 	};
 

--- a/extension-manifest-v2/src/background.js
+++ b/extension-manifest-v2/src/background.js
@@ -1087,9 +1087,15 @@ function initialiseWebRequestPipeline() {
  * @return {boolean}
  */
 function isWhitelisted(state) {
-	// state.ghosteryWhitelisted is sometimes undefined so force to bool
-	return Boolean(globals.SESSION.paused_blocking || Policy.getSitePolicy(state.tabUrl, state.url) === 2 || state.ghosteryWhitelisted);
+	return (
+		Boolean(globals.SESSION.paused_blocking)
+		|| Boolean(state.ghosteryWhitelisted)
+		|| Policy.getSitePolicy(state.tabUrl, state.url) === 2
+		// only check common_checklist if the tracker id is unknown
+		|| (!state.ghosteryBug && Policy.checkCommonModuleWhitelist(state.tabUrlParts.domain, state.urlParts.domain))
+	);
 }
+
 /**
  * Set listener for 'enabled' event for Antitracking module which replaces
  * Antitracking isWhitelisted method with Ghostery's isWhitelisted method.

--- a/extension-manifest-v2/src/classes/PanelData.js
+++ b/extension-manifest-v2/src/classes/PanelData.js
@@ -249,7 +249,7 @@ class PanelData {
 	 */
 	_getBlockingData() {
 		const {
-			expand_all_trackers, selected_app_ids, show_tracker_urls,
+			expand_all_trackers, selected_app_ids, show_tracker_urls, common_whitelist,
 			site_specific_blocks, site_specific_unblocks, toggle_individual_trackers,
 			setup_complete,
 		} = conf;
@@ -258,6 +258,7 @@ class PanelData {
 			setup_complete,
 			expand_all_trackers,
 			selected_app_ids,
+			common_whitelist,
 			show_tracker_urls,
 			site_specific_blocks,
 			site_specific_unblocks,

--- a/extension-manifest-v2/src/classes/Policy.js
+++ b/extension-manifest-v2/src/classes/Policy.js
@@ -13,6 +13,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
+import { parse } from 'tldts-experimental';
 import c2pDb from './Click2PlayDb';
 import conf from './Conf';
 import globals from './Globals';
@@ -88,13 +89,13 @@ class Policy {
 	 */
 	static checkCommonModuleWhitelist(hostUrl, trackerUrl) {
 		let isWhitelisted = false;
-		const processedHostUrl = processUrl(hostUrl).host;
-		const processedTrackerUrl = processUrl(trackerUrl).host;
+		const pageTld = parse(hostUrl).domain;
+		const trackerTld = parse(trackerUrl).domain;
 		const cliqzModuleWhitelist = conf.common_whitelist;
 
-		if (cliqzModuleWhitelist[processedTrackerUrl]) {
-			cliqzModuleWhitelist[processedTrackerUrl].hosts.some((host) => {
-				if (host === processedHostUrl) {
+		if (cliqzModuleWhitelist[trackerTld]) {
+			cliqzModuleWhitelist[trackerTld].hosts.some((host) => {
+				if (host === pageTld) {
 					isWhitelisted = true;
 					return true;
 				}

--- a/extension-manifest-v2/src/classes/Policy.js
+++ b/extension-manifest-v2/src/classes/Policy.js
@@ -13,7 +13,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import { parse } from 'tldts-experimental';
 import c2pDb from './Click2PlayDb';
 import conf from './Conf';
 import globals from './Globals';
@@ -45,11 +44,11 @@ class Policy {
 	 * @param  {string} url		site url
 	 * @return {boolean}
 	 */
-	static getSitePolicy(hostUrl, trackerUrl) {
+	static getSitePolicy(hostUrl) {
 		if (Policy.blacklisted(hostUrl)) {
 			return globals.BLACKLISTED;
 		}
-		if (Policy.checkSiteWhitelist(hostUrl) || Policy.checkCommonModuleWhitelist(hostUrl, trackerUrl)) {
+		if (Policy.checkSiteWhitelist(hostUrl)) {
 			return globals.WHITELISTED;
 		}
 		return false;
@@ -82,15 +81,8 @@ class Policy {
 		return false;
 	}
 
-	/**
-	 * Check given url against anti-tracking whitelist
-	 * @param  {string} url 		site url
-	 * @return {string|boolean} 	corresponding whitelist entry or false, if none
-	 */
-	static checkCommonModuleWhitelist(hostUrl, trackerUrl) {
+	static checkCommonModuleWhitelist(pageTld, trackerTld) {
 		let isWhitelisted = false;
-		const pageTld = parse(hostUrl).domain;
-		const trackerTld = parse(trackerUrl).domain;
 		const cliqzModuleWhitelist = conf.common_whitelist;
 
 		if (cliqzModuleWhitelist[trackerTld]) {


### PR DESCRIPTION
This PR aim to fix problem with unidentified category trackers, most notably:
* once whitelisted trackers did not appear in the panel
* whitelisting did not cover eTLD+ 
* whitelisting was exact page hostname matched
* unidentified trackers had random order in the panel