### PR TITLE
Fix clear tab stats when phone is in idle state

### DIFF
--- a/extension-manifest-v3/src/pages/panel/views/home.js
+++ b/extension-manifest-v3/src/pages/panel/views/home.js
@@ -156,7 +156,8 @@ export default {
               </a>
             </gh-panel-button>
           `}
-          ${store.error(stats) &&
+          ${!store.ready(stats) &&
+          store.error(stats) &&
           html`
             <div layout="column items:center gap margin:2:0:3">
               <img src="${sleep}" alt="Ghosty sleeping" layout="size:160px" />


### PR DESCRIPTION
Fixes #1201

Discovered behavior: When iOS is "turn off" state it clears out the tabs (so the stats are cleared too). If we have a currently opened panel, it suddenly starts receiving errors when fetching stats. However, we have stats already fetched (last proper state - thanks to store implementation).