### PR TITLE
Enable blocking of service worker requests in Chrome

### DIFF
--- a/extension-manifest-v2/src/classes/EventHandlers.js
+++ b/extension-manifest-v2/src/classes/EventHandlers.js
@@ -240,11 +240,6 @@ class EventHandlers {
 		const tab_id = eventMutable.tabId;
 		const request_id = eventMutable.requestId;
 
-		// -1 indicates the request isn't related to a tab
-		if (tab_id <= 0) {
-			return { cancel: false };
-		}
-
 		if (!tabInfo.getTabInfo(tab_id)) {
 			log(`tabInfo not found for tab ${tab_id}, initializing...`);
 


### PR DESCRIPTION
To be used in combination https://github.com/ghostery/common/pull/83

Background: requests from a website's service worker will not have a tab. That breaks breaks assumptions in the Ghostery adblocker. The result is that these requests will be skipped.