### PR TITLE
Clean up DNR rules generator for Safari

### DIFF
--- a/extension-manifest-v3/scripts/download-engines/index.js
+++ b/extension-manifest-v3/scripts/download-engines/index.js
@@ -90,15 +90,19 @@ for (const [name, target] of Object.entries(ENGINES)) {
     for (const rule of JSON.parse(dnr)) {
       if (rule.condition.requestDomains) {
         for (const domain of rule.condition.requestDomains) {
-          const compatRule = getCompatRule({
-            ...rule,
-            condition: { ...rule.condition, urlFilter: `||${domain}/` },
-          });
-          if (compatRule) stream.write(compatRule);
+          stream.write(
+            getCompatRule({
+              ...rule,
+              condition: {
+                ...rule.condition,
+                requestDomains: undefined,
+                urlFilter: `||${domain}`,
+              },
+            }),
+          );
         }
       } else {
-        const compatRule = getCompatRule(rule);
-        if (compatRule) stream.write(compatRule);
+        stream.write(getCompatRule(rule));
       }
     }
 

--- a/extension-manifest-v3/src/background/dnr.js
+++ b/extension-manifest-v3/src/background/dnr.js
@@ -45,25 +45,25 @@ if (__PLATFORM__ !== 'firefox') {
       const domains = paused.map(({ id }) => id);
       chrome.declarativeNetRequest.updateDynamicRules({
         addRules: [
-          {
-            id: 1,
-            priority: 10000,
-            ...(__PLATFORM__ !== 'safari'
-              ? {
-                  action: { type: 'allowAllRequests' },
-                  condition: {
-                    requestDomains: domains,
-                    resourceTypes: ['main_frame', 'sub_frame'],
-                  },
-                }
-              : {
-                  action: { type: 'allow' },
-                  condition: {
-                    urlFilter: '*',
-                    domains: domains.map((d) => [d, `www.${d}`]).flat(),
-                  },
-                }),
-          },
+          __PLATFORM__ === 'safari'
+            ? {
+                id: 1,
+                priority: 10000,
+                action: { type: 'allow' },
+                condition: {
+                  domains: domains.map((d) => `*${d}`),
+                  urlFilter: '*',
+                },
+              }
+            : {
+                id: 1,
+                priority: 10000,
+                action: { type: 'allowAllRequests' },
+                condition: {
+                  requestDomains: domains,
+                  resourceTypes: ['main_frame', 'sub_frame'],
+                },
+              },
         ],
         removeRuleIds: [1],
       });


### PR DESCRIPTION
It does not fix #1227, but, while testing DNR in Safari, I found that our helper function for list generation can be cleaned up, and it can better support some cases.