### PR TITLE
Disable main features before terms are accepted

### DIFF
--- a/extension-manifest-v3/src/background/adblocker.js
+++ b/extension-manifest-v3/src/background/adblocker.js
@@ -35,7 +35,7 @@ const setup = asyncSetup([
   observe(null, (options) => {
     ENGINES.forEach(({ name, option }) => {
       const engine = adblockerEngines.find((e) => e.name === name);
-      engine.isEnabled = options[option];
+      engine.isEnabled = options.terms && options[option];
     });
 
     pausedDomains = options.paused ? options.paused.map(String) : [];

--- a/extension-manifest-v3/src/background/autoconsent.js
+++ b/extension-manifest-v3/src/background/autoconsent.js
@@ -21,10 +21,13 @@ async function getTabDomain(tabId) {
 }
 
 async function initialize(msg, tabId, frameId) {
-  const { blockAnnoyances, autoconsent, paused } = await store.resolve(Options);
+  const { terms, blockAnnoyances, autoconsent, paused } = await store.resolve(
+    Options,
+  );
   const domain = await getTabDomain(tabId);
 
   if (
+    terms &&
     blockAnnoyances &&
     !autoconsent.disallowed.includes(domain) &&
     (!paused || !paused.some(({ id }) => id === domain))

--- a/extension-manifest-v3/src/background/dnr.js
+++ b/extension-manifest-v3/src/background/dnr.js
@@ -23,7 +23,7 @@ if (__PLATFORM__ !== 'firefox') {
     const disableRulesetIds = [];
 
     ENGINES.forEach(({ name, option }) => {
-      const enabled = options[option];
+      const enabled = options.terms && options[option];
       if (enabledRulesetIds.includes(name) !== enabled) {
         (enabled ? enableRulesetIds : disableRulesetIds).push(name);
       }

--- a/extension-manifest-v3/src/pages/onboarding/index.js
+++ b/extension-manifest-v3/src/pages/onboarding/index.js
@@ -18,9 +18,6 @@ async function updateOptions(host, event) {
   const success = event.type === 'success';
 
   await store.set(Options, {
-    blockAds: success,
-    blockTrackers: success,
-    blockAnnoyances: success,
     terms: success,
     onboarding: { done: true },
   });

--- a/extension-manifest-v3/src/pages/panel/components/options-item.js
+++ b/extension-manifest-v3/src/pages/panel/components/options-item.js
@@ -23,7 +23,7 @@ export default {
       </ui-text>
       <ui-text
         type="label-s"
-        color="${enabled ? '' : 'danger-500'}"
+        color="${terms && enabled ? '' : 'danger-500'}"
         ellipsis
         layout="shrink:0"
       >

--- a/extension-manifest-v3/src/store/options.js
+++ b/extension-manifest-v3/src/store/options.js
@@ -45,9 +45,9 @@ export const ENGINES = [
 
 const Options = {
   // Main features
-  blockAds: false,
-  blockTrackers: false,
-  blockAnnoyances: false,
+  blockAds: true,
+  blockTrackers: true,
+  blockAnnoyances: true,
 
   // Never-consent popup
   autoconsent: {


### PR DESCRIPTION
It's rather an edge case, but if a user clears out the storage by the dev tools, and still has open the settings page, it is possible to switch on the features without accepting the terms.

The PR adds a hard condition to main features, to be enabled only if `options.terms` is set. Because of that, we can simplify the default values for main options to be `true` (then onboarding does not have to switch them).