### PR TITLE
Fix options assignment for MV2 migration

### DIFF
--- a/extension-manifest-v3/src/store/options.js
+++ b/extension-manifest-v3/src/store/options.js
@@ -91,7 +91,7 @@ const Options = {
 
         // Migrate from Extension v8 (MV2)
         if (__PLATFORM__ !== 'safari') {
-          options = migrateFromMV2();
+          options = await migrateFromMV2();
         }
 
         // The v10.1.0 introduced options rollback when DNR lists fail to update.


### PR DESCRIPTION
Accidentally, I found a bug in the last introduced migration of options. The `migrateFromMV2()` is an async function, so we need to await the result. Fortunately, it would be broken only on other platforms than Safari, so it's not yet on production anywhere.