### PR TITLE
CI: cleanup of pr comment workflow

### DIFF
--- a/.github/workflows/pr-comment-artifact-url.yml
+++ b/.github/workflows/pr-comment-artifact-url.yml
@@ -15,59 +15,38 @@ jobs:
       - name: Get Artifact URL & PR Info
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          OWNER: ${{ github.repository_owner }}
-          REPO: ${{ github.event.repository.name }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          GITHUB_WORKFLOW_RUN_CHECK_SUITE_ID: ${{ github.event.workflow_run.check_suite_id }}
           WORKFLOW_RUN_EVENT_OBJ: ${{ toJSON(github.event.workflow_run) }}
         run: |
+          set -e
 
-          PREVIOUS_JOB_ID=$(jq -r '.id' <<< "$WORKFLOW_RUN_EVENT_OBJ")
-          echo "Previous Job ID: $PREVIOUS_JOB_ID"
-          echo "PREVIOUS_JOB_ID=$PREVIOUS_JOB_ID" >> "$GITHUB_ENV"
+          HEAD_SHA=$(jq -r '.pull_requests[0].head.sha' <<< "$WORKFLOW_RUN_EVENT_OBJ")
 
-          ARTIFACT_URL=$(gh api "/repos/$OWNER/$REPO/actions/artifacts" \
-            --jq ".artifacts.[] |
-            select(.workflow_run.id==${PREVIOUS_JOB_ID}) |
-            select(.expired==false) |
-            .archive_download_url")
-
-          echo "ARTIFACT URL: $ARTIFACT_URL"
-          echo "ARTIFACT_URL=$ARTIFACT_URL" >> "$GITHUB_ENV"
-
-          PR_NUMBER=$(jq -r '.pull_requests[0].number' \
-            <<< "$WORKFLOW_RUN_EVENT_OBJ")
-
+          PR_NUMBER=$(jq -r '.pull_requests[0].number' <<< "$WORKFLOW_RUN_EVENT_OBJ")
           echo "PR Number: $PR_NUMBER"
           echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_ENV"
 
-          HEAD_SHA=$(jq -r '.pull_requests[0].head.sha' \
-            <<< "$WORKFLOW_RUN_EVENT_OBJ")
+          gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_WORKFLOW_RUN_ID/artifacts" \
+            --jq "[.artifacts | .[] | {"id": .id, "name": .name}]" \
+            > artifacts.json
 
-          echo "Head sha: $HEAD_SHA"
-          echo "HEAD_SHA=$HEAD_SHA" >> "$GITHUB_ENV"
-
+          PR_COMMENT=$(
+            echo "Builds for commit $HEAD_SHA:"
+            while IFS="§" read -r name url; do
+              echo "* [$name]($url)"
+            done < <(jq -r ".[] | \
+              .name + \"§\" \
+              + ( .id | tostring | \"https://github.com/$GITHUB_REPOSITORY/suites/$GITHUB_WORKFLOW_RUN_CHECK_SUITE_ID/artifacts/\" + . )" \
+              artifacts.json)
+          )
+          echo -e "PR COMMENT: \n$PR_COMMENT"
+          echo "PR_COMMENT=$PR_COMMENT" >> "$GITHUB_ENV"
       - name: Update Comment
         env:
-          JOB_PATH: "${{ github.server_url }}/${{ github.repository }}/actions/\
-            runs/${{ env.PREVIOUS_JOB_ID }}"
           HEAD_SHA: ${{ env.HEAD_SHA }}
         uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ env.PR_NUMBER }}
-          body: |-
-            ## Build Preview
-
-            [![badge]]($JOB_PATH)
-
-            You can find files attached to the below linked Workflow Run URL (Logs).
-
-            Please note that files only stay for around 90 days!
-
-            | Name      | Link
-            --------------------------------------------------------------------
-            | Commit    | ${{ env.HEAD_SHA }}
-
-            | Logs      | ${{ env.JOB_PATH }}
-
-            | Jar Files | ${{ env.ARTIFACT_URL }}
-
-            [badge]: https://img.shields.io/badge/Build-Success!-3fb950?logo=github&style=for-the-badge
+          body: ${{ env.PR_COMMENT }}


### PR DESCRIPTION
Instead of linking to a ZIP file with all build artefact we want to link to individual links directly. In this way we can reference them elsewhere - e.g. in desktop browser builds. 

follow up to https://github.com/ghostery/ghostery-extension/pull/1272

based on https://github.com/ocaml-sf/learn-ocaml/blob/b4d68e80b51b6a59b5dd4e0525a51c89914d0c00/.github/workflows/pin-artifacts.yml