### PR TITLE
CI: upload named artefacts only on labeled PRs

### DIFF
--- a/.github/workflows/artifact-upload.yml
+++ b/.github/workflows/artifact-upload.yml
@@ -25,10 +25,27 @@ jobs:
         working-directory: .
       - name: Build packages
         run: npm run package -- --sha
-      - name: Upload builds
+      - name: Upload Chrome build
         uses: actions/upload-artifact@v3
-        id: upload
         with:
-          name: Ghostery 10 builds
-          path: extension-manifest-v3/web-ext-artifacts/*
+          name: Ghostery 10 for Chrome
+          path: extension-manifest-v3/web-ext-artifacts/ghostery-chrome-*
+          if-no-files-found: error
+      - name: Upload Firefox build
+        uses: actions/upload-artifact@v3
+        with:
+          name: Ghostery 10 for Firefox
+          path: extension-manifest-v3/web-ext-artifacts/ghostery-firefox-*
+          if-no-files-found: error
+      - name: Upload Edge build
+        uses: actions/upload-artifact@v3
+        with:
+          name: Ghostery 10 for Edge
+          path: extension-manifest-v3/web-ext-artifacts/ghostery-edge-*
+          if-no-files-found: error
+      - name: Upload Opera build
+        uses: actions/upload-artifact@v3
+        with:
+          name: Ghostery 10 for Opera
+          path: extension-manifest-v3/web-ext-artifacts/ghostery-opera-*
           if-no-files-found: error

--- a/.github/workflows/artifact-upload.yml
+++ b/.github/workflows/artifact-upload.yml
@@ -6,9 +6,11 @@ on:
       - opened
       - reopened
       - synchronize
+      - labeled
 
 jobs:
   artifact-upload:
+    if: contains(github.event.pull_request.labels.*.name, 'package')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -24,28 +26,34 @@ jobs:
         run: npm ci
         working-directory: .
       - name: Build packages
-        run: npm run package -- --sha
+        run: npm run package -- --simple
+      - name: Uncompress packages
+        run: |
+          for PLATFORM in firefox chrome edge opera; do
+            mkdir web-ext-artifacts/ghostery-$PLATFORM
+            unzip "web-ext-artifacts/ghostery-$PLATFORM.zip" -d "web-ext-artifacts/ghostery-$PLATFORM"
+          done
       - name: Upload Chrome build
         uses: actions/upload-artifact@v3
         with:
           name: Ghostery 10 for Chrome
-          path: extension-manifest-v3/web-ext-artifacts/ghostery-chrome-*
+          path: extension-manifest-v3/web-ext-artifacts/ghostery-chrome/*
           if-no-files-found: error
       - name: Upload Firefox build
         uses: actions/upload-artifact@v3
         with:
           name: Ghostery 10 for Firefox
-          path: extension-manifest-v3/web-ext-artifacts/ghostery-firefox-*
+          path: extension-manifest-v3/web-ext-artifacts/ghostery-firefox/*
           if-no-files-found: error
       - name: Upload Edge build
         uses: actions/upload-artifact@v3
         with:
           name: Ghostery 10 for Edge
-          path: extension-manifest-v3/web-ext-artifacts/ghostery-edge-*
+          path: extension-manifest-v3/web-ext-artifacts/ghostery-edge/*
           if-no-files-found: error
       - name: Upload Opera build
         uses: actions/upload-artifact@v3
         with:
           name: Ghostery 10 for Opera
-          path: extension-manifest-v3/web-ext-artifacts/ghostery-opera-*
+          path: extension-manifest-v3/web-ext-artifacts/ghostery-opera/*
           if-no-files-found: error

--- a/.github/workflows/artifact-upload.yml
+++ b/.github/workflows/artifact-upload.yml
@@ -17,6 +17,12 @@ jobs:
         working-directory: extension-manifest-v3
     steps:
       - uses: actions/checkout@v2
+      - run: |
+          SHA=$(git rev-parse --short "$GITHUB_SHA")
+          echo "SHA=$SHA" >> "$GITHUB_ENV"
+
+          VERSION=$(node -p "require('./package.json').version")
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.tool-versions'
@@ -36,24 +42,24 @@ jobs:
       - name: Upload Chrome build
         uses: actions/upload-artifact@v3
         with:
-          name: Ghostery 10 for Chrome
+          name: ghostery-chrome-${{ env.VERSION }}-${{ env.SHA }}
           path: extension-manifest-v3/web-ext-artifacts/ghostery-chrome/*
           if-no-files-found: error
       - name: Upload Firefox build
         uses: actions/upload-artifact@v3
         with:
-          name: Ghostery 10 for Firefox
+          name: ghostery-firefox-${{ env.VERSION }}-${{ env.SHA }}
           path: extension-manifest-v3/web-ext-artifacts/ghostery-firefox/*
           if-no-files-found: error
       - name: Upload Edge build
         uses: actions/upload-artifact@v3
         with:
-          name: Ghostery 10 for Edge
+          name: ghostery-edge-${{ env.VERSION }}-${{ env.SHA }}
           path: extension-manifest-v3/web-ext-artifacts/ghostery-edge/*
           if-no-files-found: error
       - name: Upload Opera build
         uses: actions/upload-artifact@v3
         with:
-          name: Ghostery 10 for Opera
+          name: ghostery-opera-${{ env.VERSION }}-${{ env.SHA }}
           path: extension-manifest-v3/web-ext-artifacts/ghostery-opera/*
           if-no-files-found: error

--- a/extension-manifest-v3/node_modules
+++ b/extension-manifest-v3/node_modules
@@ -1,0 +1,1 @@
+../node_modules

--- a/extension-manifest-v3/scripts/package.sh
+++ b/extension-manifest-v3/scripts/package.sh
@@ -3,7 +3,11 @@
 set -e
 
 SHA=''
+SIMPLE=''
 for val in $@; do
+  if [ $val == '--simple' ]; then
+    SIMPLE=1
+  fi
   if [ $val == '--sha' ]; then
     SHA=$(git rev-parse --short HEAD)
   fi
@@ -12,8 +16,23 @@ done
 VERSION=$(node -p "require('./package.json').version")
 
 for PLATFORM in firefox chrome edge opera; do
+  echo
+  echo "##################################"
+  echo "  Generating package for $PLATFORM"
+  echo "##################################"
+  echo
+
   npm run build -- $PLATFORM --silent
+  NAME="ghostery-$PLATFORM"
+  if ! [ $SIMPLE ]; then
+    NAME+="$VERSION"
+    if [ $SHA ]; then
+      NAME+="-$SHA"
+    fi
+  fi
+  NAME+=".zip"
+
   npm exec web-ext -- build \
     --overwrite-dest \
-    -n ghostery-$PLATFORM-$VERSION$([ $SHA ] && echo "-$SHA").zip
+    -n "$NAME"
 done


### PR DESCRIPTION
PR commenting action should link to individual artefacts directly. Also should only upload artefacts for PRs labeled with `package`.

## CHANGES: 
* [x] artificats downloads for individual platforms
* [x] create artifacts only on labeled PRs
* [x] upload full folders - otherwise we have double zips due to upload-artifact [limitations](https://github.com/actions/upload-artifact#zipped-artifact-downloads)
* [x] name github artifacts similar to package names

Required:
* https://github.com/ghostery/ghostery-extension/commit/33a637da742d3ddd26e7a11dc185c7303da4cac3
* https://github.com/ghostery/ghostery-extension/commit/e1b076effa806cf9a682dc839ff1fc3fa4755550