### PR TITLE
Follow the `true` default value for main options in the MV2 migration

### DIFF
--- a/extension-manifest-v3/src/store/options.js
+++ b/extension-manifest-v3/src/store/options.js
@@ -225,9 +225,9 @@ async function migrateFromMV2() {
 
     // Proceed if the storage contains data from v2
     if ('version_history' in storage) {
-      options.blockAds = storage.enable_ad_block || false;
-      options.blockTrackers = storage.enable_anti_tracking || false;
-      options.blockAnnoyances = storage.enable_autoconsent || false;
+      options.blockAds = storage.enable_ad_block || true;
+      options.blockTrackers = storage.enable_anti_tracking || true;
+      options.blockAnnoyances = storage.enable_autoconsent || true;
 
       options.onboarding = {
         done: storage.setup_complete || storage.setup_skip || false,


### PR DESCRIPTION
The https://github.com/ghostery/ghostery-extension/pull/1262 switched the default values of the main options. I forgot to update them in the MV2 migration function.