### PR TITLE
Tracker Preview: detect more Google layouts

### DIFF
--- a/packages/trackers-preview/src/content_scripts/index.js
+++ b/packages/trackers-preview/src/content_scripts/index.js
@@ -94,7 +94,7 @@ function removeWheel(anchor) {
 export default function setupTrackersPreview(popupUrl) {
   const elements = [
     ...window.document.querySelectorAll(
-      '[data-hveid] div.yuRUbf > div > a, [data-hveid] div.xpd a.cz3goc, [data-hveid] > .xpd > div.kCrYT:first-child > a',
+      '[data-hveid] div.yuRUbf > div > span > a, [data-hveid] div.yuRUbf > div > a, [data-hveid] div.xpd a.cz3goc, [data-hveid] > .xpd > div.kCrYT:first-child > a',
     ),
   ];
 


### PR DESCRIPTION
Tracker Preview does not detect all current Google layouts.

Thus, this PR splits
```
[data-hveid] div.yuRUbf > div > a
```
into an extra case that accepts a `<span>` in-between:
```
[data-hveid] div.yuRUbf > div > span > a
``` 