### PR TITLE
Clear script artefact (license generator)

### DIFF
--- a/extension-manifest-v3/node_modules
+++ b/extension-manifest-v3/node_modules
@@ -1,1 +1,0 @@
-../node_modules


### PR DESCRIPTION
@chrmod I suppose that by mistake, you have added `node_modules` symlink (created and removed on the fly for license generation)

https://github.com/ghostery/ghostery-extension/commit/0926a2aeb76ce2873c52544470c145803b0de117#diff-d7d1d751bb0499e54e7ac5c790df2dec5b0f1453d51c29693c1893b41da9c759R1