### PR TITLE
Remove click listener from notification element

### DIFF
--- a/extension-manifest-v3/src/pages/panel/views/home.js
+++ b/extension-manifest-v3/src/pages/panel/views/home.js
@@ -240,7 +240,6 @@ export default {
                 icon="${notification.icon}"
                 href="${notification.url}"
                 type="${notification.type}"
-                onclick="${openTabWithUrl}"
               >
                 ${notification.text}
                 <span slot="action">${notification.action}</span>


### PR DESCRIPTION
This relates to issue nr 7 from https://github.com/ghostery/user-agent-android/pull/41#issuecomment-1719854223

The click listener was attached twice by mistake, as there is a `href` attribute.