### PR TITLE
Fix settings layout on Android Firefox

### DIFF
--- a/extension-manifest-v2/package.json
+++ b/extension-manifest-v2/package.json
@@ -53,7 +53,7 @@
     "foundation-sites": "^6.6.2",
     "ghostery-common": "^1.3.7",
     "history": "^4.10.1",
-    "hybrids": "^8.2.2",
+    "hybrids": "^8.2.4",
     "linkedom": "^0.14.21",
     "moment": "^2.29.1",
     "prop-types": "^15.6.2",

--- a/extension-manifest-v3/package.json
+++ b/extension-manifest-v3/package.json
@@ -40,7 +40,7 @@
     "@ghostery/ui": "^1.0.0",
     "@github/relative-time-element": "^4.1.5",
     "@whotracksme/webextension-packages": "^4.0.1",
-    "hybrids": "^8.2.2",
+    "hybrids": "^8.2.4",
     "idb": "^7.1.1",
     "jwt-decode": "^3.1.2",
     "tldts-experimental": "^6.0.11"

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "foundation-sites": "^6.6.2",
         "ghostery-common": "^1.3.7",
         "history": "^4.10.1",
-        "hybrids": "^8.2.2",
+        "hybrids": "^8.2.4",
         "linkedom": "^0.14.21",
         "moment": "^2.29.1",
         "prop-types": "^15.6.2",
@@ -119,7 +119,7 @@
         "@ghostery/ui": "^1.0.0",
         "@github/relative-time-element": "^4.1.5",
         "@whotracksme/webextension-packages": "^4.0.1",
-        "hybrids": "^8.2.2",
+        "hybrids": "^8.2.4",
         "idb": "^7.1.1",
         "jwt-decode": "^3.1.2",
         "tldts-experimental": "^6.0.11"
@@ -9366,9 +9366,9 @@
       }
     },
     "node_modules/hybrids": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/hybrids/-/hybrids-8.2.2.tgz",
-      "integrity": "sha512-xCangE3oItxeWMNKHLa0yn0MHi0MHBtGLIz0Ty7PwdcBBN2sQ0mrBvVSf4lLMyBFNO7x47/2lO13FSJB/SkPyw==",
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/hybrids/-/hybrids-8.2.4.tgz",
+      "integrity": "sha512-f9di8Jy0kxZNtq5cC5JTgxBMkbwzNcG1FjQtJdP7LwpZZcUCegEGUskkrCoKTACWzFJjV9jusVQyyw85ooPGkA==",
       "bin": {
         "hybrids": "cli/index.js"
       },
@@ -17026,9 +17026,9 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.4",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
-      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
+      "version": "1.22.5",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.5.tgz",
+      "integrity": "sha512-qWhv7PF1V95QPvRoUGHxOtnAlEvlXBylMZcjUR9pAumMmveFtcHJRXGIr+TkjfNJVQypqv2qcDiiars2y1PsSg==",
       "dev": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
@@ -20801,7 +20801,7 @@
       "version": "1.0.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "hybrids": "^8.2.2"
+        "hybrids": "^8.2.4"
       }
     }
   }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,6 +21,6 @@
     "test": "npm run lint"
   },
   "dependencies": {
-    "hybrids": "^8.2.2"
+    "hybrids": "^8.2.4"
   }
 }

--- a/packages/ui/src/modules/settings/components/layout.js
+++ b/packages/ui/src/modules/settings/components/layout.js
@@ -154,6 +154,6 @@ export default {
       }
     }
   `.style(
-      isAndroidFirefoxBrowser && /*css*/ `:host { height: calc(100% - 56px); }`,
+      isAndroidFirefoxBrowser && /*css*/ `:host { height: calc(100% - 60px); }`,
     ),
 };

--- a/packages/ui/src/modules/settings/components/layout.js
+++ b/packages/ui/src/modules/settings/components/layout.js
@@ -15,40 +15,44 @@ function scrollToTop({ main }) {
   main.scrollTop = 0;
 }
 
+const isAndroidFirefoxBrowser =
+  !!navigator?.userAgent.match(/Android.*Firefox/);
+
 export default {
   main: ({ render }) => render().querySelector('main'),
-  render: () => html`
-    <template
-      layout="column height:100%"
-      layout@992px="grid:280px|1:min|1"
-      layout@1280px="grid:320px|1:min|1"
-    >
-      <header
-        layout="row center gap padding:2 relative layer"
-        layout@992px="padding:5:3 content:start"
+  render: () =>
+    html`
+      <template
+        layout="column height:full"
+        layout@992px="grid:280px|1:min|1"
+        layout@1280px="grid:320px|1:min|1"
       >
-        <ui-icon name="logo" color="primary-500" layout="size:3"></ui-icon>
-        <ui-text type="headline-s" color="primary-500">
-          Ghostery settings
-        </ui-text>
-      </header>
-      <nav
-        layout="order:1 row content:space-around padding gap:0.5"
-        layout@992px="grid:1:repeat(3,max-content)|max|1fr content:stretch padding:0:2:2 layer overflow:y:auto"
-      >
-        <slot name="nav"></slot>
-      </nav>
-      <main layout="column grow overflow:y:scroll" layout@992px="area::2">
-        <slot
-          layout::slotted(*)="padding:4:2"
-          layout::slotted(*)@768px="padding:5:6"
-          layout::slotted(*)@992px="padding:6:3 area::2"
-          layout::slotted(*)@1280px="padding:8:3"
-          onslotchange="${scrollToTop}"
-        ></slot>
-      </main>
-    </template>
-  `.css`
+        <header
+          layout="row center gap padding:2 relative layer"
+          layout@992px="padding:5:3 content:start"
+        >
+          <ui-icon name="logo" color="primary-500" layout="size:3"></ui-icon>
+          <ui-text type="headline-s" color="primary-500">
+            Ghostery settings
+          </ui-text>
+        </header>
+        <nav
+          layout="order:1 row content:space-around padding gap:0.5"
+          layout@992px="grid:1:repeat(3,max-content)|max|1fr content:stretch padding:0:2:2 layer overflow:y:auto"
+        >
+          <slot name="nav"></slot>
+        </nav>
+        <main layout="column grow overflow:y:scroll" layout@992px="area::2">
+          <slot
+            layout::slotted(*)="padding:4:2"
+            layout::slotted(*)@768px="padding:5:6"
+            layout::slotted(*)@992px="padding:6:3 area::2"
+            layout::slotted(*)@1280px="padding:8:3"
+            onslotchange="${scrollToTop}"
+          ></slot>
+        </main>
+      </template>
+    `.css`
     :host {
       background: var(--ui-color-white);
     }
@@ -149,5 +153,7 @@ export default {
         margin: 0 auto;
       }
     }
-  `,
+  `.style(
+      isAndroidFirefoxBrowser && /*css*/ `:host { height: calc(100% - 56px); }`,
+    ),
 };


### PR DESCRIPTION
After a deeper investigation, it looks like only the pages shown by the extensions are broken. 

I made the simplest web page example with empty `<body>` and set `html { height: 100% }`. The result shows a different height (correct one) for the public domain than for the extension protocol page - but pages are identical.

However, it also looks like the additional height is related only to the height of the top navigation bar, so we can assume that most of the users will have the same (it is counted in logic pixels, not device pixels) - and it counts ~~56px~~ 60px (better support - tested in S20 FE). 

The PR bumps hybrids with a minor fix of CSS specificity (found when making a fix).

![Screenshot_20230915-134328_ASUS_Launcher](https://github.com/ghostery/ghostery-extension/assets/1906677/7d7e74a1-59f0-48d3-a079-ce4ede433852)
![Screenshot_20230915-123629_ASUS_Launcher](https://github.com/ghostery/ghostery-extension/assets/1906677/888f8237-69a7-4a93-a388-06ba2f83e61a)
