### PR TITLE
Add target to contexts, which does not support chrome.tabs (Firefox)

### DIFF
--- a/packages/ui/src/modules/panel/components/stats.js
+++ b/packages/ui/src/modules/panel/components/stats.js
@@ -88,7 +88,7 @@ export default {
           <ui-tooltip>
             <span slot="content">WhoTracks.Me Statistical Report</span>
             <ui-panel-action>
-              <a href="${wtmUrl}" onclick="${openTabWithUrl}">
+              <a href="${wtmUrl}" onclick="${openTabWithUrl}" target="_blank">
                 <ui-icon name="whotracksme"></ui-icon>
               </a>
             </ui-panel-action>


### PR DESCRIPTION
Fixes https://github.com/ghostery/ghostery-extension/issues/1297