### PR TITLE
MV2: fix opening tabs

### DIFF
--- a/extension-manifest-v2/src/utils/utils.js
+++ b/extension-manifest-v2/src/utils/utils.js
@@ -243,6 +243,7 @@ function _openNewTab(data) {
 				url: data.url,
 				active: data.become_active || false,
 				openerTabId: tab.id,
+				windowId: tab.windowId,
 				index: tab.index + 1
 			});
 		} else {


### PR DESCRIPTION
`chrome.tabs.create` throws an exception `Tab opener must be in the same window as the updated tab.` if `openerTabId` comes from not-first window.
https://chromium.googlesource.com/chromium/src/+/938b37a6d2886bf8335fc7db792f1eb46c65b2ae/chrome/browser/extensions/api/tabs/tabs_api.cc#1317

This happens as `chrome.tabs.create` wants to open in a default/first window by default. 

fix #1306
surpasses #1307 (?)