### PR TITLE
Check cookie `expirationDate` or `session` flag to not return expired cookie

### DIFF
--- a/extension-manifest-v3/src/utils/api.js
+++ b/extension-manifest-v3/src/utils/api.js
@@ -74,11 +74,22 @@ async function isFirstPartyIsolation() {
 }
 
 async function getCookie(name) {
-  return chrome.cookies.get({
+  const cookie = await chrome.cookies.get({
     url: COOKIE_URL,
     name,
     ...((await isFirstPartyIsolation()) ? { firstPartyDomain: DOMAIN } : {}),
   });
+
+  if (
+    cookie &&
+    (cookie.session ||
+      cookie.expirationDate * (__PLATFORM__ !== 'safari' ? 1000 : 1) >
+        Date.now())
+  ) {
+    return cookie;
+  }
+
+  return null;
 }
 
 async function setCookie(name, value, durationInSec = COOKIE_DURATION) {


### PR DESCRIPTION
The bug was only discovered in Firefox, as this browser does not clear out expired cookies from memory immediately (https://support.mozilla.org/en-US/questions/983361)

Fixes #1303 (again)