### PR TITLE
MV2: prevent tracker stats leakage between visits

### DIFF
--- a/extension-manifest-v2/package.json
+++ b/extension-manifest-v2/package.json
@@ -51,7 +51,7 @@
     "classnames": "^2.3.2",
     "d3": "^5.16.0",
     "foundation-sites": "^6.6.2",
-    "ghostery-common": "^1.3.7",
+    "ghostery-common": "^1.3.11",
     "history": "^4.10.1",
     "hybrids": "^8.2.4",
     "linkedom": "^0.14.21",

--- a/extension-manifest-v2/src/classes/EventHandlers.js
+++ b/extension-manifest-v2/src/classes/EventHandlers.js
@@ -331,6 +331,9 @@ class EventHandlers {
 		// process the tracker asynchronously
 		// very important to block request processing as little as necessary
 		setTimeout(() => {
+			if (tabInfo.getTabInfo(tab_id, 'url') !== eventMutable.tabUrl) {
+				return;
+			}
 			this._processBug({
 				bug_id,
 				app_id,

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "classnames": "^2.3.2",
         "d3": "^5.16.0",
         "foundation-sites": "^6.6.2",
-        "ghostery-common": "^1.3.7",
+        "ghostery-common": "^1.3.11",
         "history": "^4.10.1",
         "hybrids": "^8.2.4",
         "linkedom": "^0.14.21",
@@ -8767,13 +8767,13 @@
       }
     },
     "node_modules/ghostery-common": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/ghostery-common/-/ghostery-common-1.3.7.tgz",
-      "integrity": "sha512-uHCHfWtGYoV/9/HHP7NtkOM5hxiPvvIw760UAJLxlWNcWzyZiTwdsCS/BSufuEstmj/OG09t7fi3luvHw6Y61A==",
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/ghostery-common/-/ghostery-common-1.3.11.tgz",
+      "integrity": "sha512-svUHvacv5oHMKJrRXSx0x4jiCv+QoBt0WbU8bzp7RthK/eFLeFI2Xbsh+AA425vuELuyAgN2knLNqdwXL9vv3A==",
       "dependencies": {
         "@cliqz-oss/dexie": "^2.0.4",
-        "@cliqz/adblocker-webextension": "^1.26.6",
-        "@cliqz/adblocker-webextension-cosmetics": "^1.26.6",
+        "@cliqz/adblocker-webextension": "^1.26.8",
+        "@cliqz/adblocker-webextension-cosmetics": "^1.26.8",
         "@cliqz/url-parser": "^1.1.5",
         "abortcontroller-polyfill": "^1.5.0",
         "anonymous-credentials": "https://github.com/whotracksme/anonymous-credentials/releases/download/1.0.0/anonymous-credentials-1.0.0.tgz",


### PR DESCRIPTION
This PR fixes a a common bug that Google Beacons were reported on websites navigated from google.com.

fix #1241 