### PR TITLE
Refactor TabStats & AutoSyncingMap to limit requests and use session storage

### DIFF
--- a/extension-manifest-v3/src/pages/panel/views/home.js
+++ b/extension-manifest-v3/src/pages/panel/views/home.js
@@ -135,13 +135,11 @@ export default {
                   layout="margin:1:1.5"
                 >
                 </ui-panel-stats>
-                ${!!(
-                  stats.trackersModified.length || stats.trackersBlocked.length
-                ) &&
+                ${!!(stats.trackersModified || stats.trackersBlocked) &&
                 html`
                   <gh-panel-feedback
-                    modified=${stats.trackersModified.length}
-                    blocked=${stats.trackersBlocked.length}
+                    modified=${stats.trackersModified}
+                    blocked=${stats.trackersBlocked}
                     layout="margin:bottom:1.5"
                   ></gh-panel-feedback>
                 `}

--- a/extension-manifest-v3/src/pages/panel/views/tracker-details.js
+++ b/extension-manifest-v3/src/pages/panel/views/tracker-details.js
@@ -98,6 +98,8 @@ export default {
                         </gh-panel-copy>
                       `,
                   )}
+                  ${tracker.requestsObserved.length >= 10 &&
+                  html`<ui-text type="body-s" color="gray-600">...</ui-text>`}
                 </div>
               </div>
             </div>
@@ -117,6 +119,8 @@ export default {
                         </gh-panel-copy>
                       `,
                   )}
+                  ${tracker.requestsBlocked.length >= 10 &&
+                  html`<ui-text type="body-s" color="gray-600">...</ui-text>`}
                 </div>
               </div>
             </div>
@@ -136,6 +140,8 @@ export default {
                         </gh-panel-copy>
                       `,
                   )}
+                  ${tracker.requestsModified.length >= 10 &&
+                  html`<ui-text type="body-s" color="gray-600">...</ui-text>`}
                 </div>
               </div>
             </div>

--- a/packages/ui/src/modules/panel/components/stats.js
+++ b/packages/ui/src/modules/panel/components/stats.js
@@ -197,11 +197,11 @@ export default {
                             >
                               ${tracker.name}
                               <ui-panel-badge>
-                                ${tracker.requests.length}
+                                ${tracker.requestsCount}
                               </ui-panel-badge>
-                              ${tracker.requestsBlocked.length > 0 &&
+                              ${tracker.blocked &&
                               html`<ui-icon name="block" color="gray-400" />`}
-                              ${tracker.requestsModified.length > 0 &&
+                              ${tracker.modified &&
                               html`<ui-icon name="eye" color="gray-400" />`}
                             </a>
                           </ui-text>


### PR DESCRIPTION
* Refactor `AutoSyncingMap` to use `storage.session` and limit ttls to 1 day, and limit entries to 1000 (equals 1k open tabs, so it should be sufficient)
* Limits `tracker.requests` to 10 for each group (observer, blocked, modified)
* Adds `trackersCount` property and`blocked` and `modified` flags to `tracker` model
* Updates Panel UI
* Minor fix of the icon update (sometimes it did not clear the wheel after the navigation to the page without trackers)