### PR TITLE
Fix request metadata for Firefox

### DIFF
--- a/extension-manifest-v3/src/background/utils/request.js
+++ b/extension-manifest-v3/src/background/utils/request.js
@@ -30,6 +30,7 @@ export default class ExtendedRequest extends Request {
       hostname: parsedUrl.hostname || '',
       url: details.url,
 
+      sourceUrl,
       sourceDomain: parsedSourceUrl.domain || '',
       sourceHostname: parsedSourceUrl.hostname || '',
 
@@ -47,6 +48,7 @@ export default class ExtendedRequest extends Request {
     this.blocked = false;
     this.modified = false;
 
+    this.sourceUrl = data.sourceUrl;
     this.sourceDomain = data.sourceDomain;
     this.sourceHostname = data.sourceHostname;
   }


### PR DESCRIPTION
The `this.sourceUrl` is used by the `isFromOriginUrl(url)` method. As it wasn't used before, by mistake I had to remove it.

https://github.com/ghostery/ghostery-extension/pull/1338/files#diff-11f5c6de0735679adbeccad4491bdb08ad5e5daf458cdf7b31430c8667a5b44cL63