### PR TITLE
MV3: fix cosmetic filter injection

### DIFF
--- a/extension-manifest-v3/src/background/adblocker.js
+++ b/extension-manifest-v3/src/background/adblocker.js
@@ -301,7 +301,7 @@ async function injectScriptlets(tabId, url) {
 
 if (__PLATFORM__ === 'safari') {
   chrome.runtime.onMessage.addListener((msg, sender) => {
-    if (sender.url && msg.action === 'onCommitted') {
+    if (sender.url && msg.action === 'injectScriptlets') {
       injectScriptlets(sender.tab.id, sender.url);
     }
 

--- a/extension-manifest-v3/src/content_scripts/adblocker-scriptlets.js
+++ b/extension-manifest-v3/src/content_scripts/adblocker-scriptlets.js
@@ -1,0 +1,5 @@
+// Should only be needed on Safari:
+// the tabId of the initial chrome.webNavigation.onCommitted
+// is not reliable. When opening bookmarks, it can happen that
+// the event is associated with a tabId of 0.
+chrome.runtime.sendMessage({ action: 'onCommitted' });

--- a/extension-manifest-v3/src/content_scripts/adblocker-scriptlets.js
+++ b/extension-manifest-v3/src/content_scripts/adblocker-scriptlets.js
@@ -2,4 +2,4 @@
 // the tabId of the initial chrome.webNavigation.onCommitted
 // is not reliable. When opening bookmarks, it can happen that
 // the event is associated with a tabId of 0.
-chrome.runtime.sendMessage({ action: 'onCommitted' });
+chrome.runtime.sendMessage({ action: 'injectScriptlets' });

--- a/extension-manifest-v3/src/manifest.chromium.json
+++ b/extension-manifest-v3/src/manifest.chromium.json
@@ -67,7 +67,8 @@
       "run_at": "document_start",
       "js": [
         "content_scripts/adblocker.js"
-      ]
+      ],
+      "all_frames": true
     },
     {
       "matches": ["http://*/*", "https://*/*"],

--- a/extension-manifest-v3/src/manifest.firefox.json
+++ b/extension-manifest-v3/src/manifest.firefox.json
@@ -49,7 +49,8 @@
       "run_at": "document_start",
       "js": [
         "content_scripts/adblocker.js"
-      ]
+      ],
+      "all_frames": true
     },
     {
       "matches": ["http://*/*", "https://*/*"],

--- a/extension-manifest-v3/src/manifest.safari.json
+++ b/extension-manifest-v3/src/manifest.safari.json
@@ -73,6 +73,14 @@
       "run_at": "document_start",
       "js": [
         "content_scripts/adblocker.js"
+      ],
+      "all_frames": true
+    },
+    {
+      "matches": ["http://*/*", "https://*/*"],
+      "run_at": "document_start",
+      "js": [
+        "content_scripts/adblocker-scriptlets.js"
       ]
     },
     {


### PR DESCRIPTION
The injection got broken on Safari due to removal of `onCommited` content script message in https://github.com/ghostery/ghostery-extension/pull/1333
But the MV3 implementation was never complete as the `adblocker` content script was injected to main frame only.