### PR TITLE
Safari: use single DNR list

### DIFF
--- a/extension-manifest-v3/scripts/build.js
+++ b/extension-manifest-v3/scripts/build.js
@@ -125,7 +125,7 @@ if (manifest.declarative_net_request?.rule_resources) {
 
     // https://github.com/WebKit/WebKit/blob/c85962a5c0e929991e5963811da957b75d1501db/Source/WebCore/contentextensions/ContentExtensionCompiler.cpp#L199
     if (rulesCount > 75000) {
-      console.warn(
+      throw new Error(
         `Warning: The number of rules exceeds the limit of 75k rules.`,
       );
     }

--- a/extension-manifest-v3/scripts/download-engines/index.js
+++ b/extension-manifest-v3/scripts/download-engines/index.js
@@ -19,9 +19,6 @@ import { ENGINE_VERSION } from '@cliqz/adblocker';
 import { getCompatRule, setupStream } from './utils.js';
 
 const ENGINES = {
-  'dnr-ads': 'ads',
-  'dnr-tracking': 'tracking',
-  'dnr-annoyances': 'annoyances',
   'dnr-cosmetics-ads': 'ads-cosmetics',
   'dnr-cosmetics-tracking': 'tracking-cosmetics',
   'dnr-cosmetics-annoyances': 'annoyances-cosmetics',
@@ -72,6 +69,28 @@ for (const [name, target] of Object.entries(ENGINES)) {
   });
 
   writeFileSync(`${TARGET_PATH}/engine-${target}.dat`, new Uint8Array(rules));
+}
+
+const DNR = {
+  'dnr-ads-2': 'ads',
+  'dnr-tracking-2': 'tracking',
+  'dnr-annoyances-2': 'annoyances',
+};
+
+for (const [name, target] of Object.entries(DNR)) {
+  console.log(`Downloading "${name}"...`);
+
+  const list = await fetch(
+    `https://cdn.ghostery.com/adblocker/configs/${name}/allowed-lists.json`,
+  ).then((res) => {
+    if (!res.ok) {
+      throw new Error(
+        `Failed to download allowed list for "${name}": ${res.status}: ${res.statusText}`,
+      );
+    }
+
+    return res.json();
+  });
 
   /* DNR rules */
 

--- a/extension-manifest-v3/scripts/download-engines/utils.js
+++ b/extension-manifest-v3/scripts/download-engines/utils.js
@@ -84,6 +84,11 @@ export function getCompatRule(rule, debug = false) {
     log('Fixing regexp');
   }
 
+  if (newRule.priority > 10000) {
+    log('Skipping complex rule');
+    return null;
+  }
+
   return newRule;
 }
 
@@ -107,6 +112,10 @@ export function setupStream(path) {
     },
     close: () => {
       output.write(']');
+      console.log(`Generated ${currentId} rules`);
+      if (currentId > 75000) {
+        throw new Error('Too many DNR rules');
+      }
       output.close();
     },
   };

--- a/extension-manifest-v3/src/background/dnr.js
+++ b/extension-manifest-v3/src/background/dnr.js
@@ -12,6 +12,10 @@
 import { observe, ENGINES } from '/store/options.js';
 
 if (__PLATFORM__ !== 'firefox') {
+  const DNR_RESOURCES = chrome.runtime
+    .getManifest()
+    .declarative_net_request.rule_resources.map(({ id }) => id);
+
   // Ensure that DNR rulesets are equal to those from options.
   // eg. when web extension updates, the rulesets are reset
   // to the value from the manifest.
@@ -23,6 +27,8 @@ if (__PLATFORM__ !== 'firefox') {
     const disableRulesetIds = [];
 
     ENGINES.forEach(({ name, key }) => {
+      if (!DNR_RESOURCES.includes(name)) return;
+
       const enabled = options.terms && options[key];
       if (enabledRulesetIds.includes(name) !== enabled) {
         (enabled ? enableRulesetIds : disableRulesetIds).push(name);

--- a/extension-manifest-v3/src/manifest.safari.json
+++ b/extension-manifest-v3/src/manifest.safari.json
@@ -47,16 +47,6 @@
         "id": "ads",
         "enabled": false,
         "path": "rule_resources/dnr-safari-ads.json"
-      },
-      {
-        "id": "tracking",
-        "enabled": false,
-        "path": "rule_resources/dnr-safari-tracking.json"
-      },
-      {
-        "id": "annoyances",
-        "enabled": false,
-        "path": "rule_resources/dnr-safari-annoyances.json"
       }
     ]
   },


### PR DESCRIPTION
Safari allows only 75k rules and does not support many DNR features like `requestDomains` or `initiatorDomains`. 

To save some space we merge 3 DNR lists for ads, trackers and annoyances into one, so we don't have to add exclusions and fixes multiple times. 

For now the cosmetic filters are still split but it in next iteration we may want to merge them into single engine. 

With those changes we were able to get a decent score in the [d3ward test](https://d3ward.github.io/toolz/adblock.html)

<img width="596" alt="Screenshot 2023-11-02 at 22 25 38" src="https://github.com/ghostery/ghostery-extension/assets/1228153/c968b106-90c4-45d5-af2a-c24bc6e00a82">
