### PR TITLE
Rollback adblocker engines for Firefox

### DIFF
--- a/extension-manifest-v3/scripts/build.js
+++ b/extension-manifest-v3/scripts/build.js
@@ -89,17 +89,19 @@ const engineType = argv.target === 'firefox' ? '' : '-cosmetics';
 
 engines.forEach((engine) => {
   const path = `engine-${engine}${engineType}.dat`;
-  shelljs.cp(
+  const result = shelljs.cp(
     resolve(options.srcDir, 'rule_resources', path),
     resolve(options.outDir, 'rule_resources'),
   );
+  if (result.stderr) process.exit(1);
 });
 
 // copy trackerdb engine
-shelljs.cp(
+const trackerdbResult = shelljs.cp(
   resolve(options.srcDir, 'rule_resources', 'engine-trackerdb.dat'),
   resolve(options.outDir, 'rule_resources'),
 );
+if (trackerdbResult.stderr) process.exit(1);
 
 // copy declarative net request lists
 if (manifest.declarative_net_request?.rule_resources) {
@@ -117,7 +119,8 @@ if (manifest.declarative_net_request?.rule_resources) {
     }
 
     shelljs.mkdir('-p', destPath);
-    shelljs.cp(sourcePath, destPath);
+    const result = shelljs.cp(sourcePath, destPath);
+    if (result.stderr) process.exit(1);
   });
 
   if (argv.target === 'safari') {

--- a/extension-manifest-v3/scripts/download-engines/index.js
+++ b/extension-manifest-v3/scripts/download-engines/index.js
@@ -19,6 +19,9 @@ import { ENGINE_VERSION } from '@cliqz/adblocker';
 import { getCompatRule, setupStream } from './utils.js';
 
 const ENGINES = {
+  'dnr-ads': 'ads',
+  'dnr-tracking': 'tracking',
+  'dnr-annoyances': 'annoyances',
   'dnr-cosmetics-ads': 'ads-cosmetics',
   'dnr-cosmetics-tracking': 'tracking-cosmetics',
   'dnr-cosmetics-annoyances': 'annoyances-cosmetics',


### PR DESCRIPTION
Those engines are required to generate adblocker engines for Firefox - they contain cosmetics and request blockers.

It means current `v10.2.4` builds for Firefox are broken (does not include engines).