### PR TITLE
Fix generating html with script tags to ensure correct order

### DIFF
--- a/patches/vite+4.5.0.patch
+++ b/patches/vite+4.5.0.patch
@@ -1,8 +1,17 @@
 diff --git a/node_modules/vite/dist/node/chunks/dep-bb8a8339.js b/node_modules/vite/dist/node/chunks/dep-bb8a8339.js
-index 417b6a1..1f4df66 100644
+index 417b6a1..2a7e0f2 100644
 --- a/node_modules/vite/dist/node/chunks/dep-bb8a8339.js
 +++ b/node_modules/vite/dist/node/chunks/dep-bb8a8339.js
-@@ -41165,7 +41165,7 @@ async function transformGlobImport(code, id, root, resolveId, isProduction, rest
+@@ -37775,8 +37775,6 @@ function buildHtmlPlugin(config) {
+                     const importee = bundle[file];
+                     if (importee?.type === 'chunk' && !seen.has(file)) {
+                         seen.add(file);
+-                        // post-order traversal
+-                        chunks.push(...getImportedChunks(importee, seen));
+                         chunks.push(importee);
+                     }
+                 });
+@@ -41165,7 +41163,7 @@ async function transformGlobImport(code, id, root, resolveId, isProduction, rest
          return staticImports;
      }))).flat();
      if (staticImports.length)
@@ -11,7 +20,7 @@ index 417b6a1..1f4df66 100644
      return {
          s,
          matches,
-@@ -47101,7 +47101,6 @@ function resolveChokidarOptions(config, options) {
+@@ -47101,7 +47099,6 @@ function resolveChokidarOptions(config, options) {
      const resolvedWatchOptions = {
          ignored: [
              '**/.git/**',


### PR DESCRIPTION
Fixes #1400.

The root cause of the issue is the order execution of script tags when the panel is open for the very first time. After the initial load, all of the scripts are cached in memory, so the next load execution order is correct.

The PR adds a fix on the `vite` source code level, as this cannot be set by the Vite configuration. We are using Vite in very specific way, where we do not bundle modules into a single file, so Vite interprets html entries, as having only one import. It tries to resolve it to the list of nested imports, but it goes deep in the tree. As a result, a long list of scripts are loaded by the script tag. It looks like Safari when loading for the first time does not respect the order of async scripts.

The fix is safe, as we can load only the top level of imports  - they import other files just from the `import` statements in the source code.