### PR TITLE
Fix source url check for updating stats on Firefox

### DIFF
--- a/extension-manifest-v3/src/background/stats.js
+++ b/extension-manifest-v3/src/background/stats.js
@@ -129,7 +129,7 @@ export function updateTabStats(tabId, requests) {
 
     // Filter out requests that are not related to the current page
     // (e.g. requests on trailing edge when navigation to a new page is in progress)
-    requests = requests.filter((request) => request.isFromOriginUrl(stats.url));
+    requests = requests.filter((request) => request.isFromDomain(stats.domain));
 
     for (const request of requests) {
       const pattern = await trackerDb.getMetadata(request, {
@@ -241,7 +241,6 @@ function setupTabStats(tabId, request) {
 
   if (request.isHttp || request.isHttps) {
     tabStats.set(tabId, {
-      url: request.url,
       domain: request.domain || request.hostname,
       trackers: [],
     });


### PR DESCRIPTION
Fixes #1423 

On Firefox when you type the URL by hand and navigate, for example, `onet.pl` - the browser navigates at first to `http://onet.pl`, which is saved as the URL of the tab (when stats are initialized). However, the final address is `https://www.onet.pl`. It has not only a different protocol, but also a subdomain added. 

When requests are checked after that navigation, the `request.isFromSourceUrl()` returns false, as those requests have the final URL as the source. After reloading the page, the `stats.url` is set to correct value, as the tab is already at the "final" URL.

~~This PR fixes the issue by loosening the condition, to check if the origin (domain or hostname) is a part of the source URL (ancestors, initiator, or sourceUrl). I am aware that this is not 100% correct, as the pathname or query might contain the domain, but in this case, this is just a protection to not pass through requests from the "previous page" navigation - which is very unlikely to happen. Even using parsed URLs might not be sufficient, as the case with added subdomains would fail (like the example of `onet.pl` -> `www.onet.pl`).~~

EDIT:

The final solution chooses a URL to check, parses it, and then compares the domain or hostname. It should now be 100% complaint. 

The URL comes from a different part of the original request, so it is not parsed before, we have to do it within the function.