### PR TITLE
Fix paused website

### DIFF
--- a/extension-manifest-v2/src/background.js
+++ b/extension-manifest-v2/src/background.js
@@ -1018,6 +1018,18 @@ function initializeDispatcher() {
 		common.modules.core.action('refreshAppState');
 	});
 }
+/**
+ * Checks if the origin of the request comes from whitelisted sites
+ * @param {webRequestPipeline.request} state
+ * @returns boolean
+ */
+function isOriginWhitelisted(state) {
+	if (state.originUrlParts && conf.site_whitelist.includes(state.originUrlParts.hostname)) {
+		return true;
+	}
+
+	return false;
+}
 
 /**
  * WebRequest pipeline initialization: find which Common modules are enabled,
@@ -1055,10 +1067,15 @@ function initialiseWebRequestPipeline() {
 			spec: 'blocking',
 			before: existingSteps.onBeforeRequest,
 			fn: (state, response) => {
+				if (isOriginWhitelisted(state)) {
+					return true;
+				}
+
 				const result = events.onBeforeRequest(state, response);
 				if (result.cancel || result.redirectUrl) {
 					Object.assign(response, result);
 				}
+
 				return true;
 			}
 		}),
@@ -1067,6 +1084,10 @@ function initialiseWebRequestPipeline() {
 			spec: 'collect',
 			before: existingSteps.onHeadersReceived,
 			fn: (state) => {
+				if (isOriginWhitelisted(state)) {
+					return true;
+				}
+
 				Events.onHeadersReceived(state);
 				return true;
 			}
@@ -1085,12 +1106,18 @@ function isWhitelistedForAdblocking(state) {
 	if (globals.SESSION.paused_blocking) {
 		return true;
 	}
+
+	if (isOriginWhitelisted(state)) {
+		return true;
+	}
+
 	if (state.onlyCheckPause) {
 		// This should only be reachable in the context of push injections,
 		// which lack the context. But push injection handled whitelisted
 		// pages already in a previous step.
 		return false;
 	}
+
 	return (
 		Boolean(state.ghosteryWhitelisted)
 		|| (Policy.getSitePolicy(state.tabUrl, state.url) === 2)
@@ -1102,6 +1129,7 @@ function isWhitelistedForAdblocking(state) {
 function isWhitelistedForAntiTracking(state) {
 	return (
 		Boolean(globals.SESSION.paused_blocking)
+		|| isOriginWhitelisted(state)
 		|| (Policy.getSitePolicy(state.tabUrl, state.url) === 2)
 		// only check common_checklist if the tracker id is unknown
 		|| (!state.ghosteryBug && Policy.checkCommonModuleWhitelist(state.tabUrlParts.domainInfo.domain, state.urlParts.domainInfo.domain))

--- a/extension-manifest-v2/src/classes/EventHandlers.js
+++ b/extension-manifest-v2/src/classes/EventHandlers.js
@@ -286,7 +286,7 @@ class EventHandlers {
 		}
 
 		// TODO fuse this into a single call to improve performance
-		const page_url = tabInfo.getTabInfo(tab_id, 'url');
+		const page_url = eventMutable.tabUrl;
 		const {
 			patternId: bug_id,
 			isFilterMatched,
@@ -421,17 +421,6 @@ class EventHandlers {
 		}
 
 		return { requestHeaders: details.requestHeaders };
-	}
-
-	/**
-	 * Handler for webRequest.onHeadersReceived event
-	 * Called each time that an HTTP(S) response header is received.
-	 *
-	 * @param  {Object} details 	event data
-	 */
-	static onHeadersReceived(details) {
-		// Skip content-length collection if it's a 3XX (redirect)
-		if (details.statusCode >> 8 === 1) { } // eslint-disable-line no-bitwise, no-empty
 	}
 
 	/**

--- a/extension-manifest-v3/scripts/download-engines/utils.js
+++ b/extension-manifest-v3/scripts/download-engines/utils.js
@@ -114,7 +114,9 @@ export function setupStream(path) {
       output.write(']');
       console.log(`Generated ${currentId} rules`);
       if (currentId > 75000) {
-        throw new Error('Too many DNR rules');
+        console.error('-'.repeat(80));
+        console.error('WARNING! Too many DNR rules generated...');
+        console.error('-'.repeat(80));
       }
       output.close();
     },


### PR DESCRIPTION
Fixes #1393 

* In v8 we must add a check in the webRequestPipline events if the origin is added to the trusted sites
* In v10 on chromium the rule with `allowAllRequests` is not sufficient, but still needed. Only with two (original one, and another added) almost all of the requests pass through

If merging, please use rebase option. I separated changes for v8 and v10 in two commits.