### PR TITLE
Add separate ios/mac targets with fixed DNR ruleset

### DIFF
--- a/extension-manifest-v3/scripts/build.js
+++ b/extension-manifest-v3/scripts/build.js
@@ -13,14 +13,6 @@ const options = {
   assets: ['_locales', 'icons'],
 };
 
-const TARGET_TO_MANIFEST_MAP = {
-  chrome: 'chromium',
-  opera: 'chromium',
-  edge: 'chromium',
-  firefox: 'firefox',
-  safari: 'safari',
-};
-
 // Generate arguments from command line
 const argv = process.argv.slice(2).reduce(
   (acc, arg) => {
@@ -34,16 +26,41 @@ const argv = process.argv.slice(2).reduce(
   { target: 'chrome' },
 );
 
+const TARGET_MANIFEST_MAP = {
+  chrome: 'chromium',
+  opera: 'chromium',
+  edge: 'chromium',
+  firefox: 'firefox',
+  'safari-ios': 'safari-ios',
+  'safari-mac': 'safari-mac',
+};
+
+if (!TARGET_MANIFEST_MAP[argv.target]) {
+  throw new Error(
+    `Unknown target "${argv.target}". Supported targets: ${Object.keys(
+      TARGET_MANIFEST_MAP,
+    ).join(', ')}`,
+  );
+}
+
 const pkg = JSON.parse(readFileSync(resolve(pwd, 'package.json'), 'utf8'));
+
+// Get manifest from source directory
+console.log(`Reading manifest.${TARGET_MANIFEST_MAP[argv.target]}.json...`);
 const manifest = JSON.parse(
   readFileSync(
     resolve(
       options.srcDir,
-      `manifest.${TARGET_TO_MANIFEST_MAP[argv.target]}.json`,
+      `manifest.${TARGET_MANIFEST_MAP[argv.target]}.json`,
     ),
     'utf8',
   ),
 );
+
+// Clear out Safari platform suffix
+if (argv.target.startsWith('safari')) {
+  argv.target = 'safari';
+}
 
 const config = {
   logLevel: argv.silent ? 'silent' : undefined,

--- a/extension-manifest-v3/scripts/download-engines/utils.js
+++ b/extension-manifest-v3/scripts/download-engines/utils.js
@@ -112,12 +112,7 @@ export function setupStream(path) {
     },
     close: () => {
       output.write(']');
-      console.log(`Generated ${currentId} rules`);
-      if (currentId > 75000) {
-        console.error('-'.repeat(80));
-        console.error('WARNING! Too many DNR rules generated...');
-        console.error('-'.repeat(80));
-      }
+      console.log(`Generated ${currentId - 1} rules`);
       output.close();
     },
   };

--- a/extension-manifest-v3/src/manifest.safari-ios.json
+++ b/extension-manifest-v3/src/manifest.safari-ios.json
@@ -46,7 +46,7 @@
       {
         "id": "ads",
         "enabled": false,
-        "path": "rule_resources/dnr-safari-ads.json"
+        "path": "rule_resources/dnr-safari.json"
       }
     ]
   },

--- a/extension-manifest-v3/src/manifest.safari-mac.json
+++ b/extension-manifest-v3/src/manifest.safari-mac.json
@@ -1,0 +1,120 @@
+{
+  "manifest_version": 2,
+  "author": "Ghostery",
+  "name": "Ghostery",
+  "short_name": "Ghostery",
+  "default_locale": "en",
+  "description": "Block Ads, Trackers and Annoyances",
+  "permissions": [
+    "alarms",
+    "cookies",
+    "declarativeNetRequest",
+    "declarativeNetRequestFeedback",
+    "webNavigation",
+    "storage",
+    "scripting",
+    "tabs"
+  ],
+  "host_permissions": [
+    "http://*/*",
+    "https://*/*",
+    "ws://*/*",
+    "wss://*/*"
+  ],
+  "icons": {
+    "64": "/icons/icon-64.png",
+    "128": "/icons/icon-128.png"
+  },
+  "browser_action": {
+    "default_icon": {
+      "64": "/icons/icon-64.png",
+      "128": "/icons/icon-128.png"
+    },
+    "default_title": "Ghostery",
+    "default_popup": "pages/panel/index.html"
+  },
+  "options_ui": {
+    "page": "pages/settings/index.html",
+    "open_in_tab": true
+  },
+  "background": {
+    "page": "background/index.html",
+    "persistent": false
+  },
+  "declarative_net_request" : {
+    "rule_resources" : [
+      {
+        "id": "ads",
+        "enabled": false,
+        "path": "rule_resources/dnr-safari.json"
+      }
+    ]
+  },
+  "content_scripts": [
+    {
+      "matches": ["http://*/*", "https://*/*"],
+      "run_at": "document_start",
+      "js": [
+        "content_scripts/whotracksme/index.js"
+      ]
+    },
+    {
+      "matches": ["http://*/*", "https://*/*"],
+      "run_at": "document_start",
+      "js": [
+        "content_scripts/adblocker.js"
+      ],
+      "all_frames": true
+    },
+    {
+      "matches": ["http://*/*", "https://*/*"],
+      "run_at": "document_start",
+      "js": [
+        "content_scripts/adblocker-scriptlets.js"
+      ]
+    },
+    {
+      "matches": ["http://*/*", "https://*/*"],
+      "run_at": "document_start",
+      "js": [
+        "content_scripts/autoconsent.js"
+      ],
+      "all_frames": true
+    },
+    {
+      "matches": ["http://*/*", "https://*/*"],
+      "run_at": "document_start",
+      "js": [
+        "content_scripts/iframe.js"
+      ]
+    },
+    {
+      "matches": ["http://*/*", "https://*/*"],
+      "run_at": "document_start",
+      "js": [
+        "content_scripts/whotracksme/reporting.js"
+      ]
+    },
+    {
+      "matches": ["*://www.youtube.com/*"],
+      "run_at": "document_start",
+			"js": ["content_scripts/youtube.js"]
+		}
+  ],
+  "web_accessible_resources": [
+    "content_scripts/whotracksme/ghostery-whotracksme.js",
+    "content_scripts/trackers-preview.js",
+    "content_scripts/prevent-serp-tracking.js",
+    "pages/trackers-preview/index.html",
+    "pages/autoconsent/index.html",
+    "pages/onboarding/index.html",
+    "pages/onboarding/iframe.html",
+    "pages/youtube/index.html"
+  ],
+  "content_security_policy" : {},
+  "browser_specific_settings": {
+    "safari": {
+      "strict_min_version": "15.4"
+    }
+  }
+}

--- a/extension-manifest-v3/xcode/Ghostery.xcodeproj/project.pbxproj
+++ b/extension-manifest-v3/xcode/Ghostery.xcodeproj/project.pbxproj
@@ -533,6 +533,7 @@
 			buildPhases = (
 				468E42A62701F84A008B5792 /* Sources */,
 				468E42A72701F84A008B5792 /* Frameworks */,
+				B48C697E2B4D82310005A820 /* Build Source */,
 				468E42A82701F84A008B5792 /* Resources */,
 			);
 			buildRules = (
@@ -550,6 +551,7 @@
 			buildPhases = (
 				468E42B02701F84A008B5792 /* Sources */,
 				468E42B12701F84A008B5792 /* Frameworks */,
+				B48C697F2B4D84600005A820 /* Build Source */,
 				468E42B22701F84A008B5792 /* Resources */,
 			);
 			buildRules = (
@@ -698,6 +700,46 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		B48C697E2B4D82310005A820 /* Build Source */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build Source";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/zsh;
+			shellScript = "# go to the root directory\ncd ..\n\n# setup tool-versions managers\ntest -f /opt/homebrew/bin/mise && eval \\\"$(/opt/homebrew/bin/mise activate zsh)\\\"\ntest -f /usr/local/opt/asdf/libexec/asdf.sh && . /usr/local/opt/asdf/libexec/asdf.sh \n\n# run build script\nnpm run build safari-ios\n";
+		};
+		B48C697F2B4D84600005A820 /* Build Source */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build Source";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/zsh;
+			shellScript = "# go to the root directory\ncd ..\n\n# setup tool-versions managers\ntest -f /opt/homebrew/bin/mise && eval \\\"$(/opt/homebrew/bin/mise activate zsh)\\\"\ntest -f /usr/local/opt/asdf/libexec/asdf.sh && . /usr/local/opt/asdf/libexec/asdf.sh \n\n# run build script\nnpm run build safari-mac\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		468E42872701F84A008B5792 /* Sources */ = {


### PR DESCRIPTION
* Fixes DNR lists for Safari - ios/mac should use `dnr-ios` list from adblocker-filters
* Adds separate targets for iOS and macOS
* Adds build script to Xcode targets, so the extension source is build correctly when Xcode project is compiled