### PR TITLE
Update autoconsent to 9.4.0

### DIFF
--- a/extension-manifest-v2/package.json
+++ b/extension-manifest-v2/package.json
@@ -41,7 +41,7 @@
     "@cliqz/adblocker": "^1.26.12",
     "@cliqz/adblocker-webextension": "^1.26.12",
     "@cliqz/url-parser": "^1.1.5",
-    "@duckduckgo/autoconsent": "^8.1.0",
+    "@duckduckgo/autoconsent": "^9.4.0",
     "@ghostery/libs": "^1.0.0",
     "@ghostery/trackers-preview": "^1.0.0",
     "@ghostery/ui": "^1.0.0",

--- a/extension-manifest-v3/package.json
+++ b/extension-manifest-v3/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@cliqz/adblocker": "^1.26.12",
     "@cliqz/adblocker-webextension-cosmetics": "^1.26.12",
-    "@duckduckgo/autoconsent": "^8.1.0",
+    "@duckduckgo/autoconsent": "^9.4.0",
     "@ghostery/libs": "^1.0.0",
     "@ghostery/trackers-preview": "^1.0.0",
     "@ghostery/ui": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@cliqz/adblocker": "^1.26.12",
         "@cliqz/adblocker-webextension": "^1.26.12",
         "@cliqz/url-parser": "^1.1.5",
-        "@duckduckgo/autoconsent": "^8.1.0",
+        "@duckduckgo/autoconsent": "^9.4.0",
         "@ghostery/libs": "^1.0.0",
         "@ghostery/trackers-preview": "^1.0.0",
         "@ghostery/ui": "^1.0.0",
@@ -104,6 +104,11 @@
         "webpack-shell-plugin-next": "^2.3.1"
       }
     },
+    "extension-manifest-v2/node_modules/@duckduckgo/autoconsent": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-9.4.0.tgz",
+      "integrity": "sha512-Q/+MxBQvHRtJWkJCjyy4DNfCqFH9SCPZKP9ReArUnrMCGDwC9ldXxhfqCSqvzyeAVucO1tvl38ewYp0r4vUzyg=="
+    },
     "extension-manifest-v3": {
       "name": "@ghostery/extension-manifest-v3",
       "version": "10.2.9",
@@ -112,7 +117,7 @@
       "dependencies": {
         "@cliqz/adblocker": "^1.26.12",
         "@cliqz/adblocker-webextension-cosmetics": "^1.26.12",
-        "@duckduckgo/autoconsent": "^8.1.0",
+        "@duckduckgo/autoconsent": "^9.4.0",
         "@ghostery/libs": "^1.0.0",
         "@ghostery/trackers-preview": "^1.0.0",
         "@ghostery/ui": "^1.0.0",
@@ -128,6 +133,11 @@
         "vite": "^4.5.0",
         "web-ext": "^7.8.0"
       }
+    },
+    "extension-manifest-v3/node_modules/@duckduckgo/autoconsent": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-9.4.0.tgz",
+      "integrity": "sha512-Q/+MxBQvHRtJWkJCjyy4DNfCqFH9SCPZKP9ReArUnrMCGDwC9ldXxhfqCSqvzyeAVucO1tvl38ewYp0r4vUzyg=="
     },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
@@ -864,11 +874,6 @@
       "engines": {
         "node": ">=10.0.0"
       }
-    },
-    "node_modules/@duckduckgo/autoconsent": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-8.1.0.tgz",
-      "integrity": "sha512-ipp2cWHvUQwG7pluvux27FRFL0lk2woXDVj+PDrBrVeUvN2NadTQ7Cn6waC/3ojp1HWWGbA1HE4uRvjdo0loUQ=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.18.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,11 +104,6 @@
         "webpack-shell-plugin-next": "^2.3.1"
       }
     },
-    "extension-manifest-v2/node_modules/@duckduckgo/autoconsent": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-9.4.0.tgz",
-      "integrity": "sha512-Q/+MxBQvHRtJWkJCjyy4DNfCqFH9SCPZKP9ReArUnrMCGDwC9ldXxhfqCSqvzyeAVucO1tvl38ewYp0r4vUzyg=="
-    },
     "extension-manifest-v3": {
       "name": "@ghostery/extension-manifest-v3",
       "version": "10.2.9",
@@ -133,11 +128,6 @@
         "vite": "^4.5.0",
         "web-ext": "^7.8.0"
       }
-    },
-    "extension-manifest-v3/node_modules/@duckduckgo/autoconsent": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-9.4.0.tgz",
-      "integrity": "sha512-Q/+MxBQvHRtJWkJCjyy4DNfCqFH9SCPZKP9ReArUnrMCGDwC9ldXxhfqCSqvzyeAVucO1tvl38ewYp0r4vUzyg=="
     },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
@@ -874,6 +864,11 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@duckduckgo/autoconsent": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-9.4.0.tgz",
+      "integrity": "sha512-Q/+MxBQvHRtJWkJCjyy4DNfCqFH9SCPZKP9ReArUnrMCGDwC9ldXxhfqCSqvzyeAVucO1tvl38ewYp0r4vUzyg=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.18.20",


### PR DESCRIPTION
There's no breaking changes from version 8.1 to 9.4.

- https://github.com/duckduckgo/autoconsent/compare/v8.1.0...v9.4.0

The configuration change includes the following PR but GBE doesn't require any change:

- https://github.com/duckduckgo/autoconsent/pull/332