### PR TITLE
Fix failure on empty rule

### DIFF
--- a/extension-manifest-v3/scripts/download-engines/index.js
+++ b/extension-manifest-v3/scripts/download-engines/index.js
@@ -91,7 +91,7 @@ for (const [name, target] of Object.entries(ENGINES)) {
     const stream = setupStream(`${TARGET_PATH}/dnr-safari-${target}.json`);
 
     for (const rule of JSON.parse(dnr)) {
-      if (rule.condition.requestDomains) {
+      if (rule.condition?.requestDomains) {
         if (rule.condition.requestDomains.length > MAX_RULE_REQUEST_DOMAINS) {
           console.log(
             `Rule has too many domains (${rule.condition.requestDomains.length}), omitting it`,

--- a/extension-manifest-v3/scripts/download-engines/utils.js
+++ b/extension-manifest-v3/scripts/download-engines/utils.js
@@ -28,6 +28,10 @@ const supportedResourceTypes = [
 const supportedActions = ['block', 'allow', 'allowAllRequests'];
 
 export function getCompatRule(rule, debug = false) {
+  if (!rule.condition) {
+    return null;
+  }
+
   const resourceTypes = rule.condition.resourceTypes?.filter((type) =>
     supportedResourceTypes.includes(type),
   );


### PR DESCRIPTION
This fixes installation error if there's an empty rule: `{}`.