### PR TITLE
chore: update autoconsent to version 9.6.0

### DIFF
--- a/extension-manifest-v2/package.json
+++ b/extension-manifest-v2/package.json
@@ -41,7 +41,7 @@
     "@cliqz/adblocker": "^1.26.12",
     "@cliqz/adblocker-webextension": "^1.26.12",
     "@cliqz/url-parser": "^1.1.5",
-    "@duckduckgo/autoconsent": "^9.4.0",
+    "@duckduckgo/autoconsent": "^9.6.0",
     "@ghostery/libs": "^1.0.0",
     "@ghostery/trackers-preview": "^1.0.0",
     "@ghostery/ui": "^1.0.0",

--- a/extension-manifest-v3/package.json
+++ b/extension-manifest-v3/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@cliqz/adblocker": "^1.26.12",
     "@cliqz/adblocker-webextension-cosmetics": "^1.26.12",
-    "@duckduckgo/autoconsent": "^9.4.0",
+    "@duckduckgo/autoconsent": "^9.6.0",
     "@ghostery/libs": "^1.0.0",
     "@ghostery/trackers-preview": "^1.0.0",
     "@ghostery/ui": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@cliqz/adblocker": "^1.26.12",
         "@cliqz/adblocker-webextension": "^1.26.12",
         "@cliqz/url-parser": "^1.1.5",
-        "@duckduckgo/autoconsent": "^9.4.0",
+        "@duckduckgo/autoconsent": "^9.6.0",
         "@ghostery/libs": "^1.0.0",
         "@ghostery/trackers-preview": "^1.0.0",
         "@ghostery/ui": "^1.0.0",
@@ -112,7 +112,7 @@
       "dependencies": {
         "@cliqz/adblocker": "^1.26.12",
         "@cliqz/adblocker-webextension-cosmetics": "^1.26.12",
-        "@duckduckgo/autoconsent": "^9.4.0",
+        "@duckduckgo/autoconsent": "^9.6.0",
         "@ghostery/libs": "^1.0.0",
         "@ghostery/trackers-preview": "^1.0.0",
         "@ghostery/ui": "^1.0.0",
@@ -866,9 +866,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-9.4.0.tgz",
-      "integrity": "sha512-Q/+MxBQvHRtJWkJCjyy4DNfCqFH9SCPZKP9ReArUnrMCGDwC9ldXxhfqCSqvzyeAVucO1tvl38ewYp0r4vUzyg=="
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-9.6.0.tgz",
+      "integrity": "sha512-K/djOYY4geEG8SPtM4+QCL7NDX2sogUmksu9+C3TO17s3Lj7PE7HYEddCsus0BjepKA2k6pOiLGfabjiJWVr/g=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.18.20",


### PR DESCRIPTION
Important updates:

- https://github.com/duckduckgo/autoconsent/pull/365
- https://github.com/duckduckgo/autoconsent/pull/361 (refs https://github.com/ghostery/broken-page-reports/issues/472)