### PR TITLE
Remove hacky fix for the android pages height issue

### DIFF
--- a/packages/ui/src/modules/settings/components/layout.js
+++ b/packages/ui/src/modules/settings/components/layout.js
@@ -15,9 +15,6 @@ function scrollToTop({ main }) {
   main.scrollTop = 0;
 }
 
-const isAndroidFirefoxBrowser =
-  !!navigator?.userAgent.match(/Android.*Firefox/);
-
 export default {
   main: ({ render }) => render().querySelector('main'),
   render: () =>
@@ -153,7 +150,5 @@ export default {
         margin: 0 auto;
       }
     }
-  `.style(
-      isAndroidFirefoxBrowser && /*css*/ `:host { height: calc(100% - 60px); }`,
-    ),
+  `,
 };


### PR DESCRIPTION
It looks like Firefox (v122) fixed the layout problem of the extension's pages. The previous hack can be removed (https://github.com/ghostery/ghostery-extension/pull/1292)

<img src="https://github.com/ghostery/ghostery-extension/assets/1906677/ce35747f-b8b7-4ebb-9500-48dd4ba575de" width="350px"/>
