### PR TITLE
Limit danger badge only for SERP tabs & minor perf optimization

### DIFF
--- a/extension-manifest-v3/src/background/stats.js
+++ b/extension-manifest-v3/src/background/stats.js
@@ -17,7 +17,7 @@ import { order } from '@ghostery/ui/categories';
 import DailyStats from '/store/daily-stats.js';
 import Options, { observe } from '/store/options.js';
 
-import { shouldShowOperaSerpAlert } from '/notifications/opera-serp.js';
+import { shouldSetDangerBadgeForTabId } from '/notifications/opera-serp.js';
 import AutoSyncingMap from '/utils/map.js';
 
 import Request from './utils/request.js';
@@ -38,10 +38,7 @@ function setBadgeColor(color = '#3f4146' /* gray-600 */) {
 }
 
 observe('terms', async (terms) => {
-  if (
-    !terms ||
-    (__PLATFORM__ === 'opera' && (await shouldShowOperaSerpAlert()))
-  ) {
+  if (!terms) {
     await chromeAction.setBadgeText({ text: '!' });
     setBadgeColor('#f13436' /* danger-500 */);
   } else {
@@ -52,6 +49,12 @@ observe('terms', async (terms) => {
 
 async function refreshIcon(tabId) {
   const options = await store.resolve(Options);
+
+  if (options.terms && __PLATFORM__ === 'opera') {
+    shouldSetDangerBadgeForTabId(tabId).then((danger) => {
+      setBadgeColor(danger ? '#f13436' /* danger-500 */ : undefined);
+    });
+  }
 
   const stats = tabStats.get(tabId);
   if (!stats) return;

--- a/extension-manifest-v3/src/notifications/opera-serp.js
+++ b/extension-manifest-v3/src/notifications/opera-serp.js
@@ -77,8 +77,34 @@ export async function showOperaSerpNotification(tabId) {
 }
 
 export async function shouldShowOperaSerpAlert() {
-  if (await isSerpSupported()) return false;
-
   const options = await store.resolve(Options);
-  return options.onboarding.serpShown < NOTIFICATION_SHOW_LIMIT;
+  if (options.onboarding.serpShown < NOTIFICATION_SHOW_LIMIT) {
+    if (await isSerpSupported()) {
+      store.set(options, {
+        onboarding: { serpShown: NOTIFICATION_SHOW_LIMIT },
+      });
+      return false;
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+export async function shouldSetDangerBadgeForTabId(tabId) {
+  const options = await store.resolve(Options);
+
+  if (options.onboarding.serpShown < NOTIFICATION_SHOW_LIMIT) {
+    try {
+      await chrome.scripting.insertCSS({
+        target: { tabId },
+        css: '',
+      });
+
+      return false;
+    } catch (e) {
+      return true;
+    }
+  }
 }


### PR DESCRIPTION
* Sets danger badge only if stats come from SERP page
* Moves the `options` condition before checking `cookies` or `insertCSS` features
* Sets a limit if the SERP feature is turned on - it means, that after switching in off again, the notification won't be shown