### PR TITLE
chore: use chrome.tabs.reload

### DIFF
--- a/extension-manifest-v2/src/background.js
+++ b/extension-manifest-v2/src/background.js
@@ -199,19 +199,19 @@ function reloadTab(data) {
 	if (data && data.tab_id) {
 		utils.getTab(data.tab_id, (tab) => {
 			if (tab && tab.url) {
-				chrome.tabs.update(tab.id, { url: tab.url });
+				chrome.tabs.reload(tab.id);
 			}
 		}, () => {
 			utils.getActiveTab((tab) => {
 				if (tab && tab.url) {
-					chrome.tabs.update(tab.id, { url: tab.url });
+					chrome.tabs.reload(tab.id);
 				}
 			});
 		});
 	} else {
 		utils.getActiveTab((tab) => {
 			if (tab && tab.url) {
-				chrome.tabs.update(tab.id, { url: tab.url });
+				chrome.tabs.reload(tab.id);
 			}
 		});
 	}


### PR DESCRIPTION
This fixes automatic reload doesn't work if the URL of the targeted tab includes hashtag.