### PR TITLE
Fix Safari host permissions

### DIFF
--- a/extension-manifest-v3/src/utils/api.js
+++ b/extension-manifest-v3/src/utils/api.js
@@ -61,16 +61,24 @@ if (__PLATFORM__ === 'safari') {
 }
 
 async function isFirstPartyIsolation() {
-  if (isFirstPartyIsolation.value === undefined) {
-    try {
-      await chrome.cookies.getAll({ domain: '' });
-      isFirstPartyIsolation.value = false;
-    } catch (e) {
-      isFirstPartyIsolation.value = e.message.indexOf('firstPartyDomain') > -1;
+  // Safari has a bug with cookies.getAll(),
+  // which shows a permission popup to the user about random domains.
+  // This feature is not yet supported in Safari we can safely return false.
+  if (__PLATFORM__ !== 'safari') {
+    if (isFirstPartyIsolation.value === undefined) {
+      try {
+        await chrome.cookies.getAll({ domain: '' });
+        isFirstPartyIsolation.value = false;
+      } catch (e) {
+        isFirstPartyIsolation.value =
+          e.message.indexOf('firstPartyDomain') > -1;
+      }
     }
-  }
 
-  return isFirstPartyIsolation.value;
+    return isFirstPartyIsolation.value;
+  } else {
+    return false;
+  }
 }
 
 async function getCookie(name) {


### PR DESCRIPTION
Fixes https://github.com/ghostery/ghostery-extension/issues/1293

## Prove

To reproduce the problem just restart the browser - the buggy code runs on every BG start. Without a fix, you will see a prompt on the extension icon for the random domain (usually for unsplash.com if already visited).

## Explenation

It looks like `chrome.cookies.getAll()` in Safari tries to load them all, even though I tried to set the `domain` option to a specific one. It also somehow touches permissions, which were already granted.

As this API is used to detect the `firstPartyDomain` option (which is currently only supported in Firefox) we can remove this code from Safari build.