### PR TITLE
Ghostery 8: fix for missing ghostery_id

### DIFF
--- a/extension-manifest-v2/src/utils/matcher.js
+++ b/extension-manifest-v2/src/utils/matcher.js
@@ -98,7 +98,7 @@ export function matchTrackerBD(details) {
 	}
 
 	return {
-		patternId: String(matches[0].pattern.ghostery_id),
+		patternId: String(matches[0].pattern.ghostery_id || matches[0].pattern.key),
 		isFilterMatched,
 		isRedirect,
 	};


### PR DESCRIPTION
more and more TrackerDB patterns come without field `ghostery_id` - Ghostery 8 did not take it into account and was considering all of them alike as having empty value. This could manifest as https://github.com/ghostery/trackerdb/issues/266