### PR TITLE
Fix Panel opera SERP notification anchor URL

### DIFF
--- a/extension-manifest-v3/src/pages/panel/store/notification.js
+++ b/extension-manifest-v3/src/pages/panel/store/notification.js
@@ -41,7 +41,7 @@ const NOTIFICATIONS = {
     icon: 'logo-opera',
     type: 'warning',
     text: msg`Expand Ghostery ad blocking to search engines in a few easy steps.`,
-    url: 'https://www.ghostery.com/blog/block-search-engine-ads-on-opera',
+    url: 'https://www.ghostery.com/blog/block-search-engine-ads-on-opera-guide?utm_source=gbe&utm_campaign=opera_serp',
     action: msg`Enable Ad Blocking Now`,
   },
 };


### PR DESCRIPTION
The link should be consistent with the in-content popup set here: https://github.com/ghostery/ghostery-extension/blob/baa87febe03f64acfa63f4d15ccb7b7fe6960d78/extension-manifest-v3/src/pages/onboarding/opera-serp.js