### PR TITLE
Mv3-feat-selective-blocking-is-trusted

### DIFF
--- a/extension-manifest-v3/src/pages/settings/store/tracker-category.js
+++ b/extension-manifest-v3/src/pages/settings/store/tracker-category.js
@@ -13,7 +13,7 @@ import { store } from 'hybrids';
 
 import TrackerException from '/store/tracker-exception.js';
 
-import { getCategories, isCategoryBlockedByDefault } from '../../../utils/trackerdb.js';
+import { getCategories, isCategoryBlockedByDefault } from '/utils/trackerdb.js';
 import Tracker from './tracker.js';
 
 const categories = getCategories();

--- a/extension-manifest-v3/src/pages/settings/store/tracker.js
+++ b/extension-manifest-v3/src/pages/settings/store/tracker.js
@@ -12,7 +12,7 @@
 import { store } from 'hybrids';
 
 import TrackerException from '/store/tracker-exception.js';
-import { getTracker, isCategoryBlockedByDefault } from '../../../utils/trackerdb.js';
+import { getTracker, isCategoryBlockedByDefault } from '/utils/trackerdb.js';
 
 export default {
   id: true,

--- a/extension-manifest-v3/src/utils/trackerdb.js
+++ b/extension-manifest-v3/src/utils/trackerdb.js
@@ -32,20 +32,16 @@ export function isCategoryBlockedByDefault(categoryId) {
   }
 }
 
-export function isTrusted(request, category, exception) {
-  const blockByDefault = isCategoryBlockedByDefault(category);
+export function isTrusted(domain, category, exception) {
+  const blockedByDefault =
+    isCategoryBlockedByDefault(category) !==
+    (exception?.overwriteStatus || false);
 
-  let isTrusted = !blockByDefault;
-
-  if (exception) {
-    if (exception.overwriteStatus) {
-      isTrusted = blockByDefault === exception.overwriteStatus;
-    }
-    isTrusted = isTrusted
-      ? !exception.blocked.includes(request.tab.domain)
-      : exception.allowed.includes(request.tab.domain);
+  if (blockedByDefault) {
+    return exception?.allowed.includes(domain) || false;
+  } else {
+    return !exception?.blocked.includes(domain) ?? true;
   }
-  return isTrusted;
 }
 
 export function getMetadata(request) {
@@ -96,7 +92,7 @@ export function getMetadata(request) {
     country: organization?.country,
     privacyPolicy: organization?.privacy_policy_url,
     isFilterMatched,
-    isTrusted: isTrusted(request, category.key, exception),
+    isTrusted: isTrusted(request.tab.domain, category.key, exception),
   };
 
   return metadata;


### PR DESCRIPTION
* Request was only used to access `.tab.domain` so we can pass it instead - it simplifies a much tests and eliminates import problem
* The logic was still not quire right...