### PR TITLE
Mv3-feat-selective-blocking-offscreen

### DIFF
--- a/extension-manifest-v3/src/background/exceptions.js
+++ b/extension-manifest-v3/src/background/exceptions.js
@@ -12,7 +12,16 @@
 import { parseFilter } from '@cliqz/adblocker';
 
 import { getTracker, isCategoryBlockedByDefault } from '../utils/trackerdb.js';
-import convert from '../utils/dnr-converter.js';
+
+import {
+  createDocumentConverter,
+  createOffscreenConverter,
+} from '../utils/dnr-converter.js';
+
+const convert =
+  __PLATFORM__ !== 'safari' && __PLATFORM__ !== 'firefox'
+    ? createOffscreenConverter()
+    : createDocumentConverter();
 
 function negateFilter(filter) {
   const cleanFilter = filter.toString();

--- a/extension-manifest-v3/src/pages/offscreen/urlfilter2dnr/index.js
+++ b/extension-manifest-v3/src/pages/offscreen/urlfilter2dnr/index.js
@@ -1,4 +1,6 @@
-import convert from '/utils/dnr-converter.js';
+import { createDocumentConverter } from '/utils/dnr-converter.js';
+
+const convert = createDocumentConverter();
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg.action === 'offscreen:urlfitler2dnr:convert') {

--- a/extension-manifest-v3/src/pages/settings/components/custom-filters.js
+++ b/extension-manifest-v3/src/pages/settings/components/custom-filters.js
@@ -12,9 +12,11 @@
 import { html, store } from 'hybrids';
 import { detectFilterType } from '@cliqz/adblocker';
 
-import convert from '/utils/dnr-converter.js';
+import { createDocumentConverter } from '/utils/dnr-converter.js';
 import CustomFiltersInput from '../store/custom-filters-input.js';
 import { asyncAction } from './devtools.js';
+
+const convert = createDocumentConverter();
 
 function parseFilters(text = '') {
   return text

--- a/extension-manifest-v3/src/store/tracker-exception.js
+++ b/extension-manifest-v3/src/store/tracker-exception.js
@@ -61,7 +61,10 @@ const TrackerException = {
     // Only use list type to fetch all exceptions
     get: () => null,
     set: async (id, values) => {
-      await requestPermission();
+      if (__PLATFORM__ !== 'safari' && __PLATFORM__ !== 'firefox') {
+        await requestPermission();
+      }
+
       return setStorage(values);
     },
     list: async () => Object.values(await getStorage()),

--- a/extension-manifest-v3/src/utils/dnr-converter.js
+++ b/extension-manifest-v3/src/utils/dnr-converter.js
@@ -8,15 +8,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
-import { isPermissionRequired, requestPermission } from './offscreen.js';
 
-let creating;
+import { requestPermission } from './offscreen.js';
 
-function createDocumentConverter() {
+let documentConverter;
+export function createDocumentConverter() {
   const requests = new Map();
 
   function createIframe() {
-    if (creating) return creating;
+    if (documentConverter) return documentConverter;
 
     window.addEventListener('message', (event) => {
       const requestId = event.data.rules.shift().condition.urlFilter;
@@ -28,86 +28,76 @@ function createDocumentConverter() {
     iframe.setAttribute('src', 'https://ghostery.github.io/urlfilter2dnr/');
     iframe.setAttribute('style', 'display: none;');
 
-    creating = new Promise((resolve) => {
+    documentConverter = new Promise((resolve) => {
       iframe.addEventListener('load', () => resolve(iframe));
       document.head.appendChild(iframe);
     });
 
-    return creating;
+    return documentConverter;
   }
 
   let requestCount = 0;
 
-  async function convert(filter) {
+  return async function convert(filter) {
     const iframe = await createIframe();
     const requestId = `request${requestCount++}`;
 
-    iframe.contentWindow.postMessage(
-      {
-        action: 'convert',
-        converter: 'adguard',
-        filters: [requestId, filter],
-      },
-      '*',
-    );
-
     return new Promise((resolve) => {
       requests.set(requestId, resolve);
-    });
-  }
 
-  return convert;
+      iframe.contentWindow.postMessage(
+        {
+          action: 'convert',
+          converter: 'adguard',
+          filters: [requestId, filter],
+        },
+        '*',
+      );
+    });
+  };
 }
 
-function createOffscreenConverter() {
-  async function setupOffscreenDocument() {
-    const path = 'pages/offscreen/urlfilter2dnr/index.html';
-    const offscreenUrl = chrome.runtime.getURL(path);
-    const existingContexts = await chrome.runtime.getContexts({
-      contextTypes: ['OFFSCREEN_DOCUMENT'],
-      documentUrls: [offscreenUrl],
-    });
+async function setupOffscreenDocument() {
+  await requestPermission();
 
-    if (existingContexts.length > 0) {
-      return;
-    }
+  const path = 'pages/offscreen/urlfilter2dnr/index.html';
+  const offscreenUrl = chrome.runtime.getURL(path);
+  const existingContexts = await chrome.runtime.getContexts({
+    contextTypes: ['OFFSCREEN_DOCUMENT'],
+    documentUrls: [offscreenUrl],
+  });
 
-    if (creating) {
-      await creating;
-    } else {
-      creating = chrome.offscreen.createDocument({
-        url: path,
-        reasons: [chrome.offscreen.Reason.IFRAME_SCRIPTING],
-        justification:
-          'Convert network filters to DeclarativeNetRequest format.',
-      });
-      await creating;
-      creating = null;
-    }
+  if (existingContexts.length) {
+    return existingContexts[0];
   }
 
-  async function createOffscreenDocument() {
-    await requestPermission();
-    await setupOffscreenDocument();
-  }
+  await chrome.offscreen.createDocument({
+    url: path,
+    reasons: [chrome.offscreen.Reason.IFRAME_SCRIPTING],
+    justification: 'Convert network filters to DeclarativeNetRequest format.',
+  });
+}
 
-  async function convert(filter) {
+let offscreenDocument;
+export function createOffscreenConverter() {
+  return async function convert(filter) {
     try {
-      await createOffscreenDocument();
+      if (!offscreenDocument) {
+        offscreenDocument = setupOffscreenDocument().then(() => {
+          offscreenDocument = true;
+        });
+      }
+
+      await offscreenDocument;
     } catch (e) {
       return { errors: [e.message], rules: [] };
     }
+
     return (
       (await chrome.runtime.sendMessage({
         action: 'offscreen:urlfitler2dnr:convert',
         filter,
       })) || { errors: ['failed to initiate offscreen document'], rules: [] }
     );
-  }
-
-  return convert;
+  };
 }
-
-export default isPermissionRequired()
-  ? createOffscreenConverter()
-  : createDocumentConverter();

--- a/extension-manifest-v3/src/utils/offscreen.js
+++ b/extension-manifest-v3/src/utils/offscreen.js
@@ -9,29 +9,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-export function isPermissionRequired() {
-  // when run in the offscreen document, there is no `chrome.runtime.getManifest` so the module uses `createDocumentConverter`
-  return (
-    chrome &&
-    (chrome.runtime.getManifest?.().permissions.includes('offscreen') ||
-      chrome.runtime
-        .getManifest?.()
-        .optional_permissions?.includes('offscreen'))
-  );
-}
-
-async function hasPermission() {
-  return chrome.permissions.contains({
-    permissions: ['offscreen'],
-  });
-}
+const permissionRequest = {
+  permissions: ['offscreen'],
+};
 
 export async function requestPermission() {
-  if (!isPermissionRequired()) return;
-
-  if (!(await hasPermission())) {
-    await chrome.permissions.request({ permissions: ['offscreen'] });
-    if (!(await hasPermission())) {
+  if (!(await chrome.permissions.contains(permissionRequest))) {
+    if (!(await chrome.permissions.request(permissionRequest))) {
       throw new Error('Ghostery requires "offscreen" permission');
     }
   }


### PR DESCRIPTION
From my understanding:

* The Offscreen converter is only required in Chromium in the background process. Otherwise, we can safely create an iframe (there are a number of document-based contexts)
* We can avoid messing up with building offscreen documents where it is not required (for example, it was like this before the change in the settings page)
* As it is related to the platform we can simplify access to converter, and clean up requiring permissions when it can be skipped