### PR TITLE
Create fallback tracker in the trackerdb utility

### DIFF
--- a/extension-manifest-v3/src/background/adblocker.js
+++ b/extension-manifest-v3/src/background/adblocker.js
@@ -391,7 +391,7 @@ if (__PLATFORM__ === 'firefox') {
   chrome.webRequest.onHeadersReceived.addListener(
     (details) => {
       const request = Request.fromRequestDetails(details);
-      if (request.metadata?.shouldBlock === false || isPaused(request)) {
+      if (request.metadata?.isTrusted || isPaused(request)) {
         return;
       }
 

--- a/extension-manifest-v3/src/background/stats.js
+++ b/extension-manifest-v3/src/background/stats.js
@@ -138,23 +138,13 @@ export function updateTabStats(tabId, requests) {
     for (const request of requests) {
       const pattern = request.metadata;
 
-      if (pattern || request.blocked || request.modified) {
+      if (pattern) {
         let tracker =
           (pattern && stats.trackers.find((t) => t.id === pattern.id)) ||
           stats.trackers.find((t) => t.id === request.domain);
 
         if (!tracker) {
-          tracker = pattern
-            ? { ...pattern, requests: [] }
-            : {
-                id: request.domain,
-                name: request.domain,
-                category: 'unidentified',
-                exception: request.domain,
-                blockedByDefault: true,
-                requests: [],
-              };
-
+          tracker = { ...pattern, requests: [] };
           stats.trackers.push(tracker);
           trackersUpdated = true;
         }

--- a/extension-manifest-v3/src/background/stats.js
+++ b/extension-manifest-v3/src/background/stats.js
@@ -235,7 +235,7 @@ function setupTabStats(tabId, request) {
 
   if (request.isHttp || request.isHttps) {
     tabStats.set(tabId, {
-      domain: request.domain || request.hostname,
+      domain: request.domain,
       url: request.url,
       trackers: [],
     });

--- a/extension-manifest-v3/src/background/utils/request.js
+++ b/extension-manifest-v3/src/background/utils/request.js
@@ -46,8 +46,7 @@ export default class ExtendedRequest extends Request {
       requestId: details.requestId,
       tabId: details.tabId,
 
-      domain: parsedUrl.domain || '',
-      hostname: parsedUrl.hostname || '',
+      domain: parsedUrl.domain || parsedUrl.hostname || '',
       url: details.url,
 
       sourceUrl,


### PR DESCRIPTION
* Passes through requests without exception where category should not be blocked
* Moves fallback tracker for unidentified trackers to trackerdb - There is a bug when you add exception to the request, which is not in the trackerdb - then the metadata must be created there, as from now the metadata is returned (but without required info)