### PR TITLE
Fix duplicated update of DNR rules for exceptions

### DIFF
--- a/extension-manifest-v3/src/background/adblocker.js
+++ b/extension-manifest-v3/src/background/adblocker.js
@@ -341,7 +341,7 @@ if (__PLATFORM__ === 'firefox') {
       const request = Request.fromRequestDetails(details);
 
       // INFO: request.source... is only available in Firefox
-      if (request.sourceDomain || request.sourceHostname) {
+      if (request.sourceDomain) {
         if (details.type !== 'main_frame') {
           updateTabStats(details.tabId, [request]);
 

--- a/extension-manifest-v3/src/background/dnr.js
+++ b/extension-manifest-v3/src/background/dnr.js
@@ -59,7 +59,7 @@ if (__PLATFORM__ !== 'firefox') {
           enableRulesetIds,
           disableRulesetIds,
         });
-        console.log('DNR - Lists successfully updated');
+        console.info('DNR - Lists successfully updated');
       } catch (e) {
         console.error(`DNR - Error while updating lists:`, e);
       }

--- a/extension-manifest-v3/src/background/exceptions.js
+++ b/extension-manifest-v3/src/background/exceptions.js
@@ -137,11 +137,9 @@ chrome.storage.onChanged.addListener(async (changes) => {
     await updateDNRRules(networkFilters);
   }
   await updateCosmeticFilters(cosmeticFilters);
-});
 
-export function getException(id) {
-  return exceptions[id];
-}
+  console.info('Exceptions - Filters updated successfully');
+});
 
 async function updateCosmeticFilters(/* filters */) {
   // TODO

--- a/extension-manifest-v3/src/background/stats.js
+++ b/extension-manifest-v3/src/background/stats.js
@@ -161,7 +161,10 @@ export async function updateTabStats(tabId, requests) {
 
   // Filter out requests that are not related to the current page
   // (e.g. requests on trailing edge when navigation to a new page is in progress)
-  requests = requests.filter((request) => request.isFromDomain(stats.domain));
+  requests = requests.filter(
+    // As a fallback, we assume that the request is from the origin URL
+    (request) => !request.sourceDomain || request.sourceDomain === stats.domain,
+  );
 
   const trackersUpdated = pushTabStats(stats, requests);
 

--- a/extension-manifest-v3/src/store/tracker-exception.js
+++ b/extension-manifest-v3/src/store/tracker-exception.js
@@ -11,7 +11,7 @@
 
 import { store } from 'hybrids';
 
-import { requestPermission } from '/utils/offscreen.js';
+import { requestPermission } from '../utils/offscreen.js';
 
 async function getStorage() {
   const { exceptions = {} } = await chrome.storage.local.get(['exceptions']);

--- a/extension-manifest-v3/src/store/tracker-exception.js
+++ b/extension-manifest-v3/src/store/tracker-exception.js
@@ -72,6 +72,14 @@ const TrackerException = {
   },
 };
 
+export default TrackerException;
+
+chrome.storage.onChanged.addListener((changes) => {
+  if (changes.exceptions) {
+    store.clear([TrackerException], false);
+  }
+});
+
 export function toggleExceptionDomain(
   exception,
   domain,
@@ -99,5 +107,3 @@ export function toggleExceptionDomain(
 
   return store.set(exception, values);
 }
-
-export default TrackerException;

--- a/extension-manifest-v3/src/utils/trackerdb.js
+++ b/extension-manifest-v3/src/utils/trackerdb.js
@@ -8,9 +8,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
+import { store } from 'hybrids';
+import TrackerException from '/store/tracker-exception.js';
 
 import * as engines from './engines.js';
-import { getException } from '../background/exceptions.js';
 
 // TODO: remove after sunsetting Ghostery 8
 // This code is a duplicate of '@ghostery/ui/categories'
@@ -35,9 +36,12 @@ const categoryOrder = [
   'other',
 ];
 
-let promise = engines.init(engines.TRACKERDB_ENGINE).then(() => {
-  promise = null;
-});
+let promise = Promise.all([
+  store.resolve([TrackerException]),
+  engines.init(engines.TRACKERDB_ENGINE).then(() => {
+    promise = null;
+  }),
+]);
 
 export function isCategoryBlockedByDefault(categoryId) {
   switch (categoryId) {
@@ -86,9 +90,9 @@ export function getMetadata(request) {
   }
 
   if (matches.length === 0) {
-    exception = getException(request.domain);
+    exception = store.get(TrackerException, request.domain);
 
-    if (!exception && !request.blocked && !request.modified) {
+    if (!store.ready(exception) && !request.blocked && !request.modified) {
       return null;
     }
 
@@ -103,18 +107,13 @@ export function getMetadata(request) {
     tracker = getTrackers().get(matches[0].pattern.key);
   }
 
-  exception = exception || getException(tracker.id);
+  exception = exception || store.get(TrackerException, tracker.id);
 
   const metadata = {
     ...tracker,
     isFilterMatched,
-    isTrusted: exception
-      ? request.tab &&
-        isTrusted(
-          request.tab.domain || request.tab.hostname,
-          tracker.category,
-          exception,
-        )
+    isTrusted: store.ready(exception)
+      ? isTrusted(request.sourceDomain, tracker.category, exception)
       : !isCategoryBlockedByDefault(tracker.category),
   };
 

--- a/extension-manifest-v3/src/utils/trackerdb.js
+++ b/extension-manifest-v3/src/utils/trackerdb.js
@@ -9,7 +9,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 import { store } from 'hybrids';
-import TrackerException from '/store/tracker-exception.js';
+import TrackerException from '../store/tracker-exception.js';
 
 import * as engines from './engines.js';
 

--- a/extension-manifest-v3/tests/setup.js
+++ b/extension-manifest-v3/tests/setup.js
@@ -2,6 +2,7 @@ import './setup/browser.js';
 
 globalThis.navigator = {
   userAgent: '',
+  languages: ['en-US'],
 };
 
 globalThis.__PLATFORM__ = 'tests';


### PR DESCRIPTION
The `/utils/trackerdb.js` imports`/background/exceptions.js`, which has a side effect of updating filters/DNR when exceptions have changed.

The tracker db is imported by the panel and settings page too, those pages runs the update code as well. In the result we have those duplicated ids problem, as the update process is triggered twice.

The solution is to relay on the store model in the TrackerDB rather than a background implementation. It is safe, as cache holds the exceptions, and updates them when the storage changes.

Additionally, I refactored the `request.tab`, as this can be much simplified and unified to generate proper `request.sourceDomain` when request is created. 