### PR TITLE
Fix pin it arrow position for Chrome & Edge

### DIFF
--- a/packages/ui/src/modules/onboarding/components/pin-it.js
+++ b/packages/ui/src/modules/onboarding/components/pin-it.js
@@ -46,9 +46,9 @@ export default {
       transform: rotate(45deg) translateY(-50%);
     }
 
-    :host([platform='chrome']) #arrow { right: 121px; }
-    :host([platform='edge']) { min-width: 175px;  }
-    :host([platform='edge']) #arrow { right: 175px; }
+    :host([platform='chrome']) #arrow { right: 85px; }
+    :host([platform='edge']) { min-width: 220px;  }
+    :host([platform='edge']) #arrow { right: 218px; }
 
     :host([platform='opera']) { top: 16px; right: 8px; }
     :host([platform='opera']) #arrow { right: 22px; }


### PR DESCRIPTION
<img width="288" alt="Zrzut ekranu 2024-05-17 o 15 44 48" src="https://github.com/ghostery/ghostery-extension/assets/1906677/b5583a31-584a-4fa1-96df-6b45297ee823">
<img width="349" alt="Zrzut ekranu 2024-05-17 o 15 42 37" src="https://github.com/ghostery/ghostery-extension/assets/1906677/20a38613-3267-4179-937d-e9a47366b049">
