### PR TITLE
Fix setting `href` attribute for ui-onboarding-state in Android Panel

### DIFF
--- a/extension-manifest-v2/app/panel-android/components/content/OverviewTab.jsx
+++ b/extension-manifest-v2/app/panel-android/components/content/OverviewTab.jsx
@@ -377,7 +377,7 @@ class OverviewTab extends React.Component {
 					</div>
 				)}
 
-				<ui-onboarding-state class="OverviewTab__onboardingState" ref={(el) => { if (el) { el.disabled = !setup_complete; } }} href={chrome.runtime.getURL('/app/templates/onboarding.html')}>
+				<ui-onboarding-state class="OverviewTab__onboardingState" ref={(el) => { if (el) { el.disabled = !setup_complete; el.href = chrome.runtime.getURL('/app/templates/onboarding.html'); } }}>
 					<div className="OverviewTab__GhosteryFeaturesContainer">
 						{this._renderGhosteryFeatures()}
 					</div>


### PR DESCRIPTION
Fixes #1607

FYI: The core problem is with react, which does not support custom elements "at all"... It always uses `setAttribute` for passing dynamic values, even though it should use properties.