### PR TITLE
Pausing happens on a hostname level

### DIFF
--- a/extension-manifest-v3/src/background/stats.js
+++ b/extension-manifest-v3/src/background/stats.js
@@ -264,7 +264,7 @@ function setupTabStats(details) {
 
   if (request.isHttp || request.isHttps) {
     tabStats.set(details.tabId, {
-      domain: request.domain,
+      domain: request.hostname,
       url: request.url,
       trackers: [],
       timestamp: details.timeStamp,

--- a/extension-manifest-v3/src/store/tab-stats.js
+++ b/extension-manifest-v3/src/store/tab-stats.js
@@ -71,7 +71,6 @@ const Stats = {
       }
 
       const tabStats = await AutoSyncingMap.get('tabStats:v1', tab.id);
-
       if (tabStats && tab.url.includes(tabStats.domain)) {
         // Tracker has a reference to TrackerException,
         //so we need to resolve exceptions
@@ -79,10 +78,10 @@ const Stats = {
 
         return tabStats;
       }
+      const { hostname } = parse(tab.url);
 
-      const { domain, hostname } = parse(tab.url);
       return {
-        domain: domain || hostname,
+        domain: hostname,
       };
     },
     observe:


### PR DESCRIPTION
fix https://github.com/ghostery/broken-page-reports/issues/660

Current stats logic works on the domain level, so for url https://ads.google.com, the stats are saved on domain `google.com`.
<img width="505" alt="Screenshot 2024-05-24 at 11 28 14" src="https://github.com/ghostery/ghostery-extension/assets/1228153/cdd8503a-cf38-498d-9580-4dc7a5d7e694">

This does not work well with the pausing logic which rely on stats domain name. When pausing at ads.google.com, the exception is added for `google.com` and not for the subdomain `ads.google.com`
