### PR TITLE
Refactor domain stats to hostname

### DIFF
--- a/extension-manifest-v3/src/background/dnr.js
+++ b/extension-manifest-v3/src/background/dnr.js
@@ -27,7 +27,7 @@ if (__PLATFORM__ !== 'firefox') {
     const enabledRulesetIds =
       (await chrome.declarativeNetRequest.getEnabledRulesets()) || [];
 
-    const enableRulesetIds = [];
+    const enableRulesetIds = options.terms ? ['fixes'] : [];
     const disableRulesetIds = [];
 
     ENGINES.forEach(({ name, key }) => {
@@ -67,13 +67,13 @@ if (__PLATFORM__ !== 'firefox') {
   });
 
   observe('paused', async (paused, prevPaused) => {
-    // Skip if domains has not changed
+    // Skip if hostnames has not changed
     if (!prevPaused) return;
 
     const dynamicRules = await chrome.declarativeNetRequest.getDynamicRules();
 
     if (paused.length) {
-      const domains = paused.map(({ id }) => id);
+      const hostnames = paused.map(({ id }) => id);
 
       chrome.declarativeNetRequest.updateDynamicRules({
         addRules:
@@ -84,7 +84,7 @@ if (__PLATFORM__ !== 'firefox') {
                   priority: PAUSE_RULE_PRIORITY,
                   action: { type: 'allow' },
                   condition: {
-                    domains: domains.map((d) => `*${d}`),
+                    domains: hostnames.map((d) => `*${d}`),
                     urlFilter: '*',
                   },
                 },
@@ -95,7 +95,7 @@ if (__PLATFORM__ !== 'firefox') {
                   priority: PAUSE_RULE_PRIORITY,
                   action: { type: 'allow' },
                   condition: {
-                    initiatorDomains: domains,
+                    initiatorDomains: hostnames,
                     resourceTypes: [
                       'main_frame',
                       'sub_frame',
@@ -119,7 +119,7 @@ if (__PLATFORM__ !== 'firefox') {
                   priority: PAUSE_RULE_PRIORITY,
                   action: { type: 'allowAllRequests' },
                   condition: {
-                    initiatorDomains: domains,
+                    initiatorDomains: hostnames,
                     resourceTypes: ['main_frame', 'sub_frame'],
                   },
                 },

--- a/extension-manifest-v3/src/background/exceptions.js
+++ b/extension-manifest-v3/src/background/exceptions.js
@@ -136,15 +136,9 @@ chrome.storage.onChanged.addListener(async (changes) => {
   if (__PLATFORM__ !== 'firefox') {
     await updateDNRRules(networkFilters);
   }
-  await updateCosmeticFilters(cosmeticFilters);
 
   console.info('Exceptions - Filters updated successfully');
 });
-
-async function updateCosmeticFilters(/* filters */) {
-  // TODO
-  //engines.createCustomEngine(filters.join('\n'))
-}
 
 async function updateDNRRules(networkFilters) {
   const dnrRules = [];

--- a/extension-manifest-v3/src/background/paused.js
+++ b/extension-manifest-v3/src/background/paused.js
@@ -12,27 +12,27 @@
 import { store } from 'hybrids';
 import Options, { observe } from '/store/options.js';
 
-// Pause / unpause domains
+// Pause / unpause hostnames
 const PAUSED_ALARM_PREFIX = 'options:revoke';
 
 observe('paused', async (paused) => {
   const alarms = (await chrome.alarms.getAll()).filter(({ name }) =>
     name.startsWith(PAUSED_ALARM_PREFIX),
   );
-  const revokeDomains = paused.filter(({ revokeAt }) => revokeAt);
+  const revokeHostnames = paused.filter(({ revokeAt }) => revokeAt);
 
-  // Clear alarms for removed domains
+  // Clear alarms for removed hostnames
   alarms.forEach(({ name }) => {
     if (
-      !revokeDomains.find(({ id }) => name === `${PAUSED_ALARM_PREFIX}:${id}`)
+      !revokeHostnames.find(({ id }) => name === `${PAUSED_ALARM_PREFIX}:${id}`)
     ) {
       chrome.alarms.clear(name);
     }
   });
 
-  // Add alarms for new domains
-  if (revokeDomains.length) {
-    revokeDomains
+  // Add alarms for new hostnames
+  if (revokeHostnames.length) {
+    revokeHostnames
       .filter(({ id }) => !alarms.some(({ name }) => name === id))
       .forEach(({ id, revokeAt }) => {
         chrome.alarms.create(`${PAUSED_ALARM_PREFIX}:${id}`, {
@@ -42,7 +42,7 @@ observe('paused', async (paused) => {
   }
 });
 
-// Remove paused domains from options when alarm is triggered
+// Remove paused hostnames from options when alarm is triggered
 chrome.alarms.onAlarm.addListener((alarm) => {
   if (alarm.name.startsWith(PAUSED_ALARM_PREFIX)) {
     store.resolve(Options).then((options) => {

--- a/extension-manifest-v3/src/background/reporting/webrequest-reporter.js
+++ b/extension-manifest-v3/src/background/reporting/webrequest-reporter.js
@@ -32,7 +32,7 @@ if (__PLATFORM__ !== 'safari') {
   // Important to call it in a first tick as it assigns chrome. listeners
   webRequestPipeline.init();
 
-  let pausedDomains = [];
+  let pausedHostnames = [];
   let isAntiTrackingEnabled = false;
 
   observe('blockTrackers', (blockTrackers) => {
@@ -40,7 +40,7 @@ if (__PLATFORM__ !== 'safari') {
   });
 
   observe('paused', (paused) => {
-    pausedDomains = paused || [];
+    pausedHostnames = paused || [];
   });
 
   webRequestReporter = new RequestReporter(config.request, {
@@ -53,13 +53,12 @@ if (__PLATFORM__ !== 'safari') {
       if (!isAntiTrackingEnabled) {
         return true;
       }
-      if (
-        pausedDomains.some(
-          ({ id }) => id === state.tabUrlParts.domainInfo.domain,
-        )
-      ) {
+
+      const pureHostname = state.urlParts.hostname.replace(/^www\./, '');
+      if (pausedHostnames.some(({ id }) => pureHostname === id)) {
         return true;
       }
+
       return false;
     },
     onTrackerInteraction: (event, state) => {

--- a/extension-manifest-v3/src/background/stats.js
+++ b/extension-manifest-v3/src/background/stats.js
@@ -59,7 +59,7 @@ async function refreshIcon(tabId) {
   if (!stats) return;
 
   const inactive =
-    !options.terms || options.paused?.some(({ id }) => id === stats.domain);
+    !options.terms || options.paused?.some(({ id }) => id === stats.hostname);
 
   const data = {};
   if (options.trackerWheel && stats.trackers.length > 0) {
@@ -163,7 +163,9 @@ export async function updateTabStats(tabId, requests) {
   // (e.g. requests on trailing edge when navigation to a new page is in progress)
   requests = requests.filter(
     // As a fallback, we assume that the request is from the origin URL
-    (request) => !request.sourceDomain || request.sourceDomain === stats.domain,
+    (request) =>
+      !request.sourceHostname ||
+      request.sourceHostname.endsWith(stats.hostname),
   );
 
   let trackersUpdated = pushTabStats(stats, requests);
@@ -265,7 +267,7 @@ function setupTabStats(details) {
 
   if (request.isHttp || request.isHttps) {
     tabStats.set(details.tabId, {
-      domain: request.domain,
+      hostname: request.hostname.replace('www.', ''),
       url: request.url,
       trackers: [],
       timestamp: details.timeStamp,

--- a/extension-manifest-v3/src/manifest.chromium.json
+++ b/extension-manifest-v3/src/manifest.chromium.json
@@ -67,7 +67,7 @@
       },
       {
         "id": "fixes",
-        "enabled": true,
+        "enabled": false,
         "path": "rule_resources/dnr-fixes.json"
       }
     ]

--- a/extension-manifest-v3/src/manifest.safari-ios.json
+++ b/extension-manifest-v3/src/manifest.safari-ios.json
@@ -55,7 +55,7 @@
       },
       {
         "id": "fixes",
-        "enabled": true,
+        "enabled": false,
         "path": "rule_resources/dnr-fixes-safari.json"
       }
     ]

--- a/extension-manifest-v3/src/manifest.safari-macos.json
+++ b/extension-manifest-v3/src/manifest.safari-macos.json
@@ -55,7 +55,7 @@
       },
       {
         "id": "fixes",
-        "enabled": true,
+        "enabled": false,
         "path": "rule_resources/dnr-fixes-safari.json"
       }
     ]

--- a/extension-manifest-v3/src/pages/panel/views/home.js
+++ b/extension-manifest-v3/src/pages/panel/views/home.js
@@ -35,11 +35,11 @@ async function togglePause(host, event) {
   // Update options
   await store.set(host.options, {
     paused: paused
-      ? host.options.paused.filter((p) => p.id !== host.stats.domain)
+      ? host.options.paused.filter((p) => p.id !== host.stats.hostname)
       : [
           ...host.options.paused,
           {
-            id: host.stats.domain,
+            id: host.stats.hostname,
             revokeAt: pauseType && Date.now() + 60 * 60 * 1000 * pauseType,
           },
         ],
@@ -82,7 +82,7 @@ export default {
   notification: store(Notification),
   paused: ({ options, stats }) =>
     store.ready(options, stats) &&
-    options.paused.find(({ id }) => id === stats.domain),
+    options.paused.find(({ id }) => id === stats.hostname),
   content: ({ options, stats, notification, paused }) => html`
     <template layout="column grow relative">
       ${store.ready(options, stats) &&
@@ -90,7 +90,7 @@ export default {
         ${options.terms &&
         html`
           <ui-panel-header>
-            ${store.ready(stats) && stats.domain}
+            ${store.ready(stats) && stats.hostname}
             <ui-action slot="icon">
               <a href="https://www.ghostery.com" onclick="${openTabWithUrl}">
                 <ui-icon name="logo"></ui-icon>
@@ -108,7 +108,7 @@ export default {
           layout="fixed inset:1 bottom:auto layer:200"
         ></section>
         ${options.terms
-          ? stats.domain &&
+          ? stats.hostname &&
             html`
               <gh-panel-pause
                 onaction="${togglePause}"
@@ -130,10 +130,10 @@ export default {
               </gh-panel-button>
             `}
         <gh-panel-container>
-          ${stats.domain
+          ${stats.hostname
             ? html`
                 <ui-panel-stats
-                  domain="${stats.domain}"
+                  domain="${stats.hostname}"
                   categories="${stats.topCategories}"
                   trackers="${stats.trackers}"
                   paused="${paused || !options.terms}"
@@ -149,7 +149,7 @@ export default {
                       <a
                         href="${chrome.runtime.getURL(
                           '/pages/settings/index.html#@gh-settings-website-details?domain=' +
-                            stats.domain,
+                            stats.hostname,
                         )}"
                         onclick="${openTabWithUrl}"
                       >

--- a/extension-manifest-v3/src/pages/panel/views/protection-status.js
+++ b/extension-manifest-v3/src/pages/panel/views/protection-status.js
@@ -8,7 +8,7 @@ import { toggleExceptionDomain } from '/store/tracker-exception.js';
 function toggleDomain({ stats, tracker }) {
   toggleExceptionDomain(
     tracker.exception,
-    stats.domain,
+    stats.hostname,
     tracker.blockedByDefault,
   );
 }
@@ -25,10 +25,10 @@ export default {
       : tracker.blockedByDefault,
   blockedOnSite: ({ stats, tracker }) =>
     store.ready(tracker.exception) &&
-    tracker.exception.blockedDomains.includes(stats.domain),
+    tracker.exception.blockedDomains.includes(stats.hostname),
   allowedOnSite: ({ stats, tracker }) =>
     store.ready(tracker.exception) &&
-    tracker.exception.trustedDomains.includes(stats.domain),
+    tracker.exception.trustedDomains.includes(stats.hostname),
   content: ({ stats, tracker, blocked, blockedOnSite, allowedOnSite }) => html`
     <template layout="column">
       <gh-panel-dialog>
@@ -72,7 +72,7 @@ export default {
               <div layout="grow">
                 <ui-text type="label-m">
                   <!-- Add domain as exception -->
-                  Add ${stats.domain} as exception
+                  Add ${stats.hostname} as exception
                 </ui-text>
                 <ui-text type="body-s" color="gray-500">
                   ${blocked

--- a/extension-manifest-v3/src/pages/panel/views/tracker-details.js
+++ b/extension-manifest-v3/src/pages/panel/views/tracker-details.js
@@ -48,14 +48,14 @@ export default {
     stats.trackers.find((t) => t.id === trackerId),
   status: ({ stats, tracker }) =>
     store.ready(tracker.exception)
-      ? tracker.exception.getDomainStatus(stats.domain)
+      ? tracker.exception.getDomainStatus(stats.hostname)
       : { type: tracker.blockedByDefault ? 'block' : 'trust' },
   wtmUrl: ({ tracker }) =>
     tracker.category !== 'unidentified' &&
     `https://www.ghostery.com/whotracksme/trackers/${tracker.id}`,
   paused: ({ options, stats }) =>
     store.ready(options, stats) &&
-    options.paused.find(({ id }) => id === stats.domain),
+    options.paused.find(({ id }) => id === stats.hostname),
   content: ({ tracker, status, wtmUrl, paused, options }) => html`
     <template layout="column">
       <gh-panel-dialog>

--- a/extension-manifest-v3/src/pages/settings/views/tracker-add-exception.js
+++ b/extension-manifest-v3/src/pages/settings/views/tracker-add-exception.js
@@ -16,30 +16,30 @@ import { toggleExceptionDomain } from '/store/tracker-exception.js';
 
 import { parse } from 'tldts-experimental';
 
-const Model = {
+const Hostname = {
   id: true,
   value: '',
   [store.connect]: {
     get: () => null,
     set: (id, model) => {
       const parsed = parse(model.value);
-      if (!parsed.domain && !parsed.isIp) {
-        throw 'The value must be a valid domain name or IP address.';
+      if (!parsed.hostname && !parsed.isIp) {
+        throw 'The value must be a valid hostname or IP address.';
       }
       return {
         ...model,
-        value: parsed.domain || parsed.hostname,
+        value: parsed.hostname.replace(/^www\./, ''),
       };
     },
   },
 };
 
-async function add({ tracker, model }, event) {
+async function add({ tracker, hostname }, event) {
   event.preventDefault();
 
   router.resolve(
     event,
-    store.submit(model).then(({ value }) => {
+    store.submit(hostname).then(({ value }) => {
       return toggleExceptionDomain(
         tracker.exception,
         value,
@@ -57,8 +57,8 @@ export default {
     store.ready(tracker.exception)
       ? tracker.exception.blocked
       : tracker.blockedByDefault,
-  model: store(Model, { draft: true }),
-  content: ({ tracker, blocked, model }) => html`
+  hostname: store(Hostname, { draft: true }),
+  content: ({ tracker, blocked, hostname }) => html`
     <template layout>
       ${store.ready(tracker) &&
       html`
@@ -80,12 +80,12 @@ export default {
             </div>
             <div layout="column gap:0.5">
               <ui-text type="label-m">Website</ui-text>
-              <gh-settings-input error="${store.error(model) || ''}">
+              <gh-settings-input error="${store.error(hostname) || ''}">
                 <input
                   type="text"
                   placeholder="${msg`Enter website URL`}"
-                  value="${model.value}"
-                  oninput="${html.set(model, 'value')}"
+                  value="${hostname.value}"
+                  oninput="${html.set(hostname, 'value')}"
                   tabindex="1"
                 />
               </gh-settings-input>

--- a/extension-manifest-v3/src/pages/settings/views/websites.js
+++ b/extension-manifest-v3/src/pages/settings/views/websites.js
@@ -139,11 +139,7 @@ export default {
                           layout="grid:1|min:auto gap:2 items:center:stretch margin:-2:0 padding:2:0"
                           layout@768px="grid:3fr|3fr|1fr|60px gap:4"
                         >
-                          <ui-text
-                            type="label-l"
-                            ellipsis
-                            layout@768px="width:50%"
-                          >
+                          <ui-text type="label-l" ellipsis>
                             ${item.id}
                           </ui-text>
                           <ui-action>

--- a/extension-manifest-v3/src/store/tab-stats.js
+++ b/extension-manifest-v3/src/store/tab-stats.js
@@ -34,7 +34,7 @@ const tab = await chrome.runtime.sendMessage({
 });
 
 const Stats = {
-  domain: '',
+  hostname: '',
   trackers: [StatsTracker],
   trackersBlocked: ({ trackers }) =>
     trackers.reduce((acc, { blocked }) => acc + Number(blocked), 0),
@@ -72,7 +72,7 @@ const Stats = {
 
       const tabStats = await AutoSyncingMap.get('tabStats:v1', tab.id);
 
-      if (tabStats && tab.url.includes(tabStats.domain)) {
+      if (tabStats && tab.url.includes(tabStats.hostname)) {
         // Tracker has a reference to TrackerException,
         //so we need to resolve exceptions
         await store.resolve([TrackerException]);
@@ -80,10 +80,8 @@ const Stats = {
         return tabStats;
       }
 
-      const { domain, hostname } = parse(tab.url);
-      return {
-        domain: domain || hostname,
-      };
+      const { hostname } = parse(tab.url);
+      return { hostname };
     },
     observe:
       __PLATFORM__ === 'safari' &&

--- a/extension-manifest-v3/src/utils/trackerdb.js
+++ b/extension-manifest-v3/src/utils/trackerdb.js
@@ -57,14 +57,14 @@ export function isCategoryBlockedByDefault(categoryId) {
   }
 }
 
-export function isTrusted(domainOrHostname, category, exception) {
+export function isTrusted(hostname, category, exception) {
   const isCategoryBlocked = isCategoryBlockedByDefault(category);
 
   if (exception.blocked) {
-    return exception.trustedDomains.includes(domainOrHostname) || false;
+    return exception.trustedDomains.includes(hostname) || false;
   } else {
     return (
-      !exception.blockedDomains.includes(domainOrHostname) &&
+      !exception.blockedDomains.includes(hostname) &&
       exception.blocked !== isCategoryBlocked
     );
   }
@@ -90,17 +90,17 @@ export function getMetadata(request) {
   }
 
   if (matches.length === 0) {
-    exception = store.get(TrackerException, request.domain);
+    exception = store.get(TrackerException, request.hostname);
 
     if (!store.ready(exception) && !request.blocked && !request.modified) {
       return null;
     }
 
     tracker = {
-      id: request.domain,
-      name: request.domain,
+      id: request.hostname,
+      name: request.hostname,
       category: 'unidentified',
-      exception: request.domain,
+      exception: request.hostname,
       blockedByDefault: true,
     };
   } else {
@@ -113,7 +113,7 @@ export function getMetadata(request) {
     ...tracker,
     isFilterMatched,
     isTrusted: store.ready(exception)
-      ? isTrusted(request.sourceDomain, tracker.category, exception)
+      ? isTrusted(request.sourceHostname, tracker.category, exception)
       : !isCategoryBlockedByDefault(tracker.category),
   };
 


### PR DESCRIPTION
* Refactor `domain` in stats to use `hostname`
* To support already added pages to paused/exceptions, the hostname is clean up from the `www` subdomain - which is the most common case. Without it already added pages won't be selected properly

Minor fixes:
* `fixes` DNR rules must be added only when terms are accepted

The `tracker-exception.js` code is left as it is in purpose - renaming fields would require data migration. Also, this is likely that this part will be touched with refactor selective blocking.