### PR TITLE
Ghostery 10: prevent disabling of privacy protection

### DIFF
--- a/extension-manifest-v3/src/pages/settings/components/devtools.js
+++ b/extension-manifest-v3/src/pages/settings/components/devtools.js
@@ -9,7 +9,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import { html, store } from 'hybrids';
+import { html, store, dispatch } from 'hybrids';
 
 import { openTabWithUrl } from '/utils/tabs.js';
 import Options from '/store/options.js';
@@ -49,14 +49,20 @@ function updateEngines(host, event) {
 
 function refresh(host) {
   host.counter += 1;
+
+  if (host.counter > 5) {
+    host.isVisible = true;
+    dispatch(host, 'is-shown');
+  }
 }
 
 export default {
   counter: 0,
   options: store(Options),
-  content: ({ counter }) => html`
+  isVisible: false,
+  content: ({ isVisible }) => html`
     <template layout="column gap:3">
-      ${counter >= 5 &&
+      ${isVisible &&
       html`
         <section layout="column gap:3" translate="no">
           <ui-text type="headline-m">Developer tools</ui-text>

--- a/extension-manifest-v3/src/pages/settings/views/privacy.js
+++ b/extension-manifest-v3/src/pages/settings/views/privacy.js
@@ -64,10 +64,6 @@ export default {
                 different types of data collection including ads, trackers, and
                 cookie pop-ups.
               </ui-text>
-              <ui-text type="body-l" mobile-type="body-m" color="gray-600">
-                You can adjust the settings below. We recommend keeping them ON
-                at all times.
-              </ui-text>
             </div>
             <div layout="row items:start gap:2" layout@768px="gap:5">
               <a href="${router.url(Preview, PREVIEWS['ad_blocking'])}">
@@ -86,6 +82,7 @@ export default {
                   </ui-text>
                 </div>
                 <ui-toggle
+                  disabled
                   value="${options.blockAds}"
                   onchange="${html.set(options, 'blockAds')}"
                 ></ui-toggle>
@@ -112,6 +109,7 @@ export default {
                   </ui-text>
                 </div>
                 <ui-toggle
+                  disabled
                   value="${options.blockTrackers}"
                   onchange="${html.set(options, 'blockTrackers')}"
                 ></ui-toggle>
@@ -137,6 +135,7 @@ export default {
                   </ui-text>
                 </div>
                 <ui-toggle
+                  disabled
                   value="${options.blockAnnoyances}"
                   onchange="${toggleNeverConsent}"
                 ></ui-toggle>

--- a/extension-manifest-v3/src/pages/settings/views/privacy.js
+++ b/extension-manifest-v3/src/pages/settings/views/privacy.js
@@ -46,10 +46,15 @@ function toggleNeverConsent({ options }) {
   });
 }
 
+function onDevModeEnabled(host) {
+  host.devMode = true;
+}
+
 export default {
   options: store(Options),
   session: store(Session),
-  content: ({ options, session }) => html`
+  devMode: false,
+  content: ({ options, session, devMode }) => html`
     <template layout="contents">
       <gh-settings-page-layout layout="column gap:4">
         ${store.ready(options) &&
@@ -82,7 +87,7 @@ export default {
                   </ui-text>
                 </div>
                 <ui-toggle
-                  disabled
+                  disabled=${!devMode}
                   value="${options.blockAds}"
                   onchange="${html.set(options, 'blockAds')}"
                 ></ui-toggle>
@@ -109,7 +114,7 @@ export default {
                   </ui-text>
                 </div>
                 <ui-toggle
-                  disabled
+                  disabled=${!devMode}
                   value="${options.blockTrackers}"
                   onchange="${html.set(options, 'blockTrackers')}"
                 ></ui-toggle>
@@ -135,7 +140,7 @@ export default {
                   </ui-text>
                 </div>
                 <ui-toggle
-                  disabled
+                  disabled=${!devMode}
                   value="${options.blockAnnoyances}"
                   onchange="${toggleNeverConsent}"
                 ></ui-toggle>
@@ -174,7 +179,9 @@ export default {
             </div>
           </section>
 
-          <gh-settings-devtools></gh-settings-devtools>
+          <gh-settings-devtools
+            onis-shown=${onDevModeEnabled}
+          ></gh-settings-devtools>
         `}
         ${store.ready(session) &&
         html`

--- a/packages/ui/src/modules/global/components/toggle.js
+++ b/packages/ui/src/modules/global/components/toggle.js
@@ -43,11 +43,11 @@ export default {
       }
 
       :host([disabled]) button {
-        --ui-text-color-heading: var(--ui-color-gray-400);
+        --ui-text-color-heading: var(--ui-color-gray-400) !important;
       }
 
       :host([disabled]) #toggle {
-        background: var(--ui-color-gray-400);
+        background: var(--ui-color-gray-400) !important;
       }
 
       button {


### PR DESCRIPTION
Before:
<img width="1304" alt="Screenshot 2024-05-30 at 16 33 20" src="https://github.com/ghostery/ghostery-extension/assets/1228153/8aea8d46-4f0f-4cae-a737-5515139d7701">

After:
<img width="1184" alt="Screenshot 2024-05-30 at 16 33 07" src="https://github.com/ghostery/ghostery-extension/assets/1228153/a3aec04d-bffe-4393-a919-a586f4c81e42">
