### PR TITLE
Clean up devtools mode

### DIFF
--- a/extension-manifest-v3/src/pages/settings/components/devtools.js
+++ b/extension-manifest-v3/src/pages/settings/components/devtools.js
@@ -51,18 +51,18 @@ function refresh(host) {
   host.counter += 1;
 
   if (host.counter > 5) {
-    host.isVisible = true;
-    dispatch(host, 'is-shown');
+    host.visible = true;
+    dispatch(host, 'shown');
   }
 }
 
 export default {
   counter: 0,
   options: store(Options),
-  isVisible: false,
-  content: ({ isVisible }) => html`
+  visible: false,
+  content: ({ visible }) => html`
     <template layout="column gap:3">
-      ${isVisible &&
+      ${visible &&
       html`
         <section layout="column gap:3" translate="no">
           <ui-text type="headline-m">Developer tools</ui-text>

--- a/extension-manifest-v3/src/pages/settings/views/privacy.js
+++ b/extension-manifest-v3/src/pages/settings/views/privacy.js
@@ -46,10 +46,6 @@ function toggleNeverConsent({ options }) {
   });
 }
 
-function onDevModeEnabled(host) {
-  host.devMode = true;
-}
-
 export default {
   options: store(Options),
   session: store(Session),
@@ -180,7 +176,8 @@ export default {
           </section>
 
           <gh-settings-devtools
-            onis-shown=${onDevModeEnabled}
+            onshown="${html.set('devMode', true)}"
+            visible="${devMode}"
           ></gh-settings-devtools>
         `}
         ${store.ready(session) &&

--- a/extension-manifest-v3/src/pages/settings/views/privacy.js
+++ b/extension-manifest-v3/src/pages/settings/views/privacy.js
@@ -83,7 +83,7 @@ export default {
                   </ui-text>
                 </div>
                 <ui-toggle
-                  disabled=${!devMode}
+                  disabled=${options.blockAds && !devMode}
                   value="${options.blockAds}"
                   onchange="${html.set(options, 'blockAds')}"
                 ></ui-toggle>
@@ -110,7 +110,7 @@ export default {
                   </ui-text>
                 </div>
                 <ui-toggle
-                  disabled=${!devMode}
+                  disabled=${options.blockTrackers && !devMode}
                   value="${options.blockTrackers}"
                   onchange="${html.set(options, 'blockTrackers')}"
                 ></ui-toggle>
@@ -136,7 +136,7 @@ export default {
                   </ui-text>
                 </div>
                 <ui-toggle
-                  disabled=${!devMode}
+                  disabled=${options.blockAnnoyances && !devMode}
                   value="${options.blockAnnoyances}"
                   onchange="${toggleNeverConsent}"
                 ></ui-toggle>


### PR DESCRIPTION
* Events are actions, not state names - for example, we have "click" event, not "is-clicked", so we should use the name in the sense of what happens, not what is a current state - "shown", not "is-shown"
* Visibility is a bool value from its name - a thing can be visible or not, so the "is" prefix is not needed, it is only helpful with functions, which usually don't have obvious returning value - "is" helps then, that a function return a bool value
* You can pass the `devMode` to the component, so after refresh the dev mode component is visible
* Fixes the issue of keeping DNR lists when all of the options are disabled (as the PR touches that part)

Fixes #1625 