### PR TITLE
Fix close Opera SERP popup actions after reloading extension

### DIFF
--- a/extension-manifest-v3/src/pages/onboarding/opera-serp.js
+++ b/extension-manifest-v3/src/pages/onboarding/opera-serp.js
@@ -31,15 +31,24 @@ async function updateOptions() {
 }
 
 async function enable(host, event) {
-  openTabWithUrl(host, event);
+  try {
+    openTabWithUrl(host, event);
+    await updateOptions();
 
-  await updateOptions();
-  closeIframe(false, true);
+    closeIframe(false, true);
+  } catch (e) {
+    document.body.outerHTML = '';
+  }
 }
 
 async function ignore() {
-  await updateOptions();
-  closeIframe(false, true);
+  try {
+    await updateOptions();
+
+    closeIframe(false, true);
+  } catch (e) {
+    document.body.outerHTML = '';
+  }
 }
 
 mount(document.body, {


### PR DESCRIPTION
Fxies #1604

This is not a real fix to the problem. 

After reloading the extension all of the open contexts are broken - any action from Chrome API results in the error of "Cotext invalidated"... This is expected.

The only thing we can do is catch errors and force the popup window to disappear (I did it by removing the whole body element). There is no way to communicate to another context to remove the iframe.