### PR TITLE
Use frame URL to prevent from using anti-tracking

### DIFF
--- a/extension-manifest-v3/src/background/reporting/webrequest-reporter.js
+++ b/extension-manifest-v3/src/background/reporting/webrequest-reporter.js
@@ -54,7 +54,7 @@ if (__PLATFORM__ !== 'safari') {
         return true;
       }
 
-      const pureHostname = state.urlParts.hostname.replace(/^www\./, '');
+      const pureHostname = state.tabUrlParts.hostname.replace(/^www\./, '');
       if (pausedHostnames.some(({ id }) => pureHostname === id)) {
         return true;
       }

--- a/extension-manifest-v3/src/pages/panel/views/home.js
+++ b/extension-manifest-v3/src/pages/panel/views/home.js
@@ -45,12 +45,14 @@ async function togglePause(host, event) {
         ],
   });
 
-  // Reload current tab
-  const [tab] = await chrome.tabs.query({
-    active: true,
-    currentWindow: true,
-  });
-  chrome.tabs.reload(tab.id);
+  // Reload current tab after 1s
+  setTimeout(async () => {
+    const [tab] = await chrome.tabs.query({
+      active: true,
+      currentWindow: true,
+    });
+    chrome.tabs.reload(tab.id);
+  }, 1000);
 
   // Show alert message
   Array.from(host.querySelectorAll('#gh-panel-alerts gh-panel-alert')).forEach(


### PR DESCRIPTION
Fixes #1622
Fixes #1623
Fixes #1624

* We were checking the request URL instead of frame URL
* For "slower" devices I added 1 second delay for refreshing the page