### PR TITLE
Global pause feature

### DIFF
--- a/extension-manifest-v3/src/background/autoconsent.js
+++ b/extension-manifest-v3/src/background/autoconsent.js
@@ -14,13 +14,16 @@ import { snippets } from '@duckduckgo/autoconsent/lib/eval-snippets';
 import { parse } from 'tldts-experimental';
 import { store } from 'hybrids';
 
-import Options from '/store/options.js';
+import Options, { isGlobalPaused } from '/store/options.js';
 
 async function initialize(msg, tab, frameId) {
-  const { terms, blockAnnoyances, paused } = await store.resolve(Options);
+  const options = await store.resolve(Options);
+  const { terms, blockAnnoyances, paused } = options;
+
   const pureHostname = tab.url && parse(tab.url).hostname.replace(/^www\./, '');
 
   if (
+    !isGlobalPaused(options) &&
     terms &&
     blockAnnoyances &&
     (!pureHostname || !paused.includes(pureHostname))

--- a/extension-manifest-v3/src/background/dnr.js
+++ b/extension-manifest-v3/src/background/dnr.js
@@ -9,7 +9,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import { observe, ENGINES } from '/store/options.js';
+import { observe, ENGINES, isGlobalPaused } from '/store/options.js';
 import { TRACKERDB_ENGINE } from '/utils/engines.js';
 
 const PAUSE_RULE_PRIORITY = 10000000;
@@ -24,8 +24,9 @@ if (__PLATFORM__ !== 'firefox') {
   // eg. when web extension updates, the rulesets are reset
   // to the value from the manifest.
   observe(null, async (options) => {
+    const globalPause = isGlobalPaused(options);
     const ids = ENGINES.map(({ name, key }) => {
-      return options.terms && options[key] ? name : '';
+      return !globalPause && options.terms && options[key] ? name : '';
     }).filter((id) => id && DNR_RESOURCES.includes(id));
 
     if (ids.length) {

--- a/extension-manifest-v3/src/background/reporting/webrequest-reporter.js
+++ b/extension-manifest-v3/src/background/reporting/webrequest-reporter.js
@@ -15,7 +15,7 @@ import {
 } from '@whotracksme/webextension-packages/packages/reporting';
 import { getBrowserInfo } from '@ghostery/libs';
 
-import { observe } from '/store/options.js';
+import { observe, GLOBAL_PAUSE_ID } from '/store/options.js';
 
 import Request from '../utils/request.js';
 import { updateTabStats } from '../stats.js';
@@ -40,7 +40,7 @@ if (__PLATFORM__ !== 'safari') {
   });
 
   observe('paused', (paused) => {
-    pausedHostnames = paused || [];
+    pausedHostnames = paused.map(({ id }) => id);
   });
 
   webRequestReporter = new RequestReporter(config.request, {
@@ -54,8 +54,12 @@ if (__PLATFORM__ !== 'safari') {
         return true;
       }
 
-      const pureHostname = state.tabUrlParts.hostname.replace(/^www\./, '');
-      if (pausedHostnames.some(({ id }) => pureHostname === id)) {
+      if (
+        pausedHostnames.includes(GLOBAL_PAUSE_ID) ||
+        pausedHostnames.includes(
+          state.tabUrlParts.hostname.replace(/^www\./, ''),
+        )
+      ) {
         return true;
       }
 

--- a/extension-manifest-v3/src/background/stats.js
+++ b/extension-manifest-v3/src/background/stats.js
@@ -15,7 +15,7 @@ import { getOffscreenImageData } from '@ghostery/ui/wheel';
 import { order } from '@ghostery/ui/categories';
 
 import DailyStats from '/store/daily-stats.js';
-import Options, { observe } from '/store/options.js';
+import Options, { isGlobalPaused, observe } from '/store/options.js';
 
 import { shouldSetDangerBadgeForTabId } from '/notifications/opera-serp.js';
 import AutoSyncingMap from '/utils/map.js';
@@ -59,7 +59,9 @@ async function refreshIcon(tabId) {
   if (!stats) return;
 
   const inactive =
-    !options.terms || options.paused?.some(({ id }) => id === stats.hostname);
+    isGlobalPaused(options) ||
+    !options.terms ||
+    options.paused?.some(({ id }) => id === stats.hostname);
 
   const data = {};
   if (options.trackerWheel && stats.trackers.length > 0) {

--- a/extension-manifest-v3/src/pages/panel/components/notification.js
+++ b/extension-manifest-v3/src/pages/panel/components/notification.js
@@ -27,7 +27,7 @@ export default {
           ${icon &&
           html`
             <div id="icon" layout="row center shrink:0 width:5">
-              <ui-icon name="${icon}" layout="margin"></ui-icon>
+              <ui-icon name="${icon}" layout="margin size:3"></ui-icon>
             </div>
           `}
           <div layout="column gap grow">

--- a/extension-manifest-v3/src/pages/panel/components/pause.js
+++ b/extension-manifest-v3/src/pages/panel/components/pause.js
@@ -76,10 +76,7 @@ export default {
         onclick="${!pauseList && dispatchAction}"
       >
         <div id="label" layout="grow row center gap:0.5 shrink overflow">
-          <ui-icon name="circle" color="gh-panel-action"></ui-icon>
-          <ui-text type="label-m" color="gh-panel-action" layout="block:center">
-            ${paused ? msg`Site is trusted` : msg`Trust this site`}
-          </ui-text>
+          <slot></slot>
         </div>
         <div
           id="type"

--- a/extension-manifest-v3/src/pages/panel/store/notification.js
+++ b/extension-manifest-v3/src/pages/panel/store/notification.js
@@ -47,11 +47,11 @@ const NOTIFICATIONS = {
   globalPause: {
     icon: 'pause',
     type: '',
-    text: msg`Missing the global pause feature? It is in the privacy settings now.`,
+    text: msg`Missing “Pause Ghostery”? You can find it in your privacy protection settings.`,
     url: chrome.runtime.getURL(
       '/pages/settings/index.html#@gh-settings-privacy',
     ),
-    action: msg`Open settings`,
+    action: msg`Open Ghostery settings`,
   },
 };
 

--- a/extension-manifest-v3/src/pages/panel/store/notification.js
+++ b/extension-manifest-v3/src/pages/panel/store/notification.js
@@ -44,6 +44,15 @@ const NOTIFICATIONS = {
     url: 'https://www.ghostery.com/blog/block-search-engine-ads-on-opera-guide?utm_source=gbe&utm_campaign=opera_serp',
     action: msg`Enable Ad Blocking Now`,
   },
+  globalPause: {
+    icon: 'pause',
+    type: '',
+    text: msg`Missing the global pause feature? It is in the privacy settings now.`,
+    url: chrome.runtime.getURL(
+      '/pages/settings/index.html#@gh-settings-privacy',
+    ),
+    action: msg`Open settings`,
+  },
 };
 
 export default {
@@ -58,11 +67,11 @@ export default {
     }
 
     if ((await store.resolve(Session)).contributor) {
-      return null;
+      return NOTIFICATIONS.globalPause;
     }
 
     return !(await store.resolve(Options)).terms
       ? NOTIFICATIONS.terms
-      : NOTIFICATIONS.contributor;
+      : NOTIFICATIONS.globalPause;
   },
 };

--- a/extension-manifest-v3/src/pages/panel/views/home.js
+++ b/extension-manifest-v3/src/pages/panel/views/home.js
@@ -148,8 +148,7 @@ export default {
                   color="gh-panel-action"
                   layout="block:center"
                 >
-                  ${globalPause &&
-                  msg`Global pause | Status info - lowercased in english | panel`}
+                  ${globalPause && msg`Ghostery is paused`}
                   ${!globalPause &&
                   (paused ? msg`Site is trusted` : msg`Trust this site`)}
                 </ui-text>

--- a/extension-manifest-v3/src/pages/panel/views/home.js
+++ b/extension-manifest-v3/src/pages/panel/views/home.js
@@ -9,11 +9,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import { html, store, router } from 'hybrids';
+import { html, store, router, msg } from 'hybrids';
 
 import { openTabWithUrl } from '/utils/tabs.js';
 
-import Options from '/store/options.js';
+import Options, { GLOBAL_PAUSE_ID } from '/store/options.js';
 import TabStats from '/store/tab-stats.js';
 
 import Notification from '../store/notification.js';
@@ -29,10 +29,35 @@ const SETTINGS_URL = chrome.runtime.getURL(
 );
 const ONBOARDING_URL = chrome.runtime.getURL('/pages/onboarding/index.html');
 
+function showAlert(host, message) {
+  Array.from(host.querySelectorAll('#gh-panel-alerts gh-panel-alert')).forEach(
+    (el) => el.parentNode.removeChild(el),
+  );
+
+  const wrapper = document.createDocumentFragment();
+
+  html`
+    <gh-panel-alert type="info" slide autoclose="5">
+      ${message}
+    </gh-panel-alert>
+  `(wrapper);
+
+  host.querySelector('#gh-panel-alerts').appendChild(wrapper);
+}
+
+function reloadTab() {
+  setTimeout(async () => {
+    const [tab] = await chrome.tabs.query({
+      active: true,
+      currentWindow: true,
+    });
+    chrome.tabs.reload(tab.id);
+  }, 1000);
+}
+
 async function togglePause(host, event) {
   const { paused, pauseType } = event.target;
 
-  // Update options
   await store.set(host.options, {
     paused: paused
       ? host.options.paused.filter((p) => p.id !== host.stats.hostname)
@@ -45,31 +70,26 @@ async function togglePause(host, event) {
         ],
   });
 
-  // Reload current tab after 1s
-  setTimeout(async () => {
-    const [tab] = await chrome.tabs.query({
-      active: true,
-      currentWindow: true,
-    });
-    chrome.tabs.reload(tab.id);
-  }, 1000);
+  reloadTab();
 
-  // Show alert message
-  Array.from(host.querySelectorAll('#gh-panel-alerts gh-panel-alert')).forEach(
-    (el) => el.parentNode.removeChild(el),
+  showAlert(
+    host,
+    paused
+      ? msg`Ghostery has been resumed on this site.`
+      : msg`Ghostery is paused on this site.`,
   );
+}
 
-  const wrapper = document.createDocumentFragment();
+function revokeGlobalPause(host) {
+  const { options } = host;
 
-  html`
-    <gh-panel-alert type="info" slide autoclose="5">
-      ${paused
-        ? html`Ghostery has been resumed on this site.`
-        : html`Ghostery is paused on this site.`}
-    </gh-panel-alert>
-  `(wrapper);
+  store.set(options, {
+    paused: options.paused.filter((p) => p.id !== GLOBAL_PAUSE_ID),
+  });
 
-  host.querySelector('#gh-panel-alerts').appendChild(wrapper);
+  reloadTab();
+
+  showAlert(host, msg`Ghostery has been resumed.`);
 }
 
 function setStatsType(host, event) {
@@ -85,7 +105,10 @@ export default {
   paused: ({ options, stats }) =>
     store.ready(options, stats) &&
     options.paused.find(({ id }) => id === stats.hostname),
-  content: ({ options, stats, notification, paused }) => html`
+  globalPause: ({ options }) =>
+    store.ready(options) &&
+    options.paused.find(({ id }) => id === GLOBAL_PAUSE_ID),
+  content: ({ options, stats, notification, paused, globalPause }) => html`
     <template layout="column grow relative">
       ${store.ready(options, stats) &&
       html`
@@ -113,9 +136,24 @@ export default {
           ? stats.hostname &&
             html`
               <gh-panel-pause
-                onaction="${togglePause}"
-                paused="${paused}"
-              ></gh-panel-pause>
+                onaction="${globalPause ? revokeGlobalPause : togglePause}"
+                paused="${paused || globalPause}"
+              >
+                <ui-icon
+                  name="${globalPause ? 'pause' : 'circle'}"
+                  color="gh-panel-action"
+                ></ui-icon>
+                <ui-text
+                  type="label-m"
+                  color="gh-panel-action"
+                  layout="block:center"
+                >
+                  ${globalPause &&
+                  msg`Global pause | Status info - lowercased in english | panel`}
+                  ${!globalPause &&
+                  (paused ? msg`Site is trusted` : msg`Trust this site`)}
+                </ui-text>
+              </gh-panel-pause>
             `
           : html`
               <gh-panel-button>
@@ -138,7 +176,7 @@ export default {
                   domain="${stats.hostname}"
                   categories="${stats.topCategories}"
                   trackers="${stats.trackers}"
-                  paused="${paused || !options.terms}"
+                  paused="${paused || globalPause || !options.terms}"
                   dialog="${TrackerDetails}"
                   exceptionDialog="${ProtectionStatus}"
                   type="${options.panel.statsType}"
@@ -164,7 +202,9 @@ export default {
                     </ui-action>
                   `}
                 </ui-panel-stats>
-                ${!!(stats.trackersModified || stats.trackersBlocked) &&
+                ${!paused &&
+                !globalPause &&
+                !!(stats.trackersModified || stats.trackersBlocked) &&
                 html`
                   <gh-panel-feedback
                     modified=${stats.trackersModified}
@@ -194,6 +234,7 @@ export default {
           <ui-text
             class="${{ last: store.error(notification) }}"
             layout.last="padding:bottom:1.5"
+            hidden="${globalPause}"
           >
             <a
               href="${options.terms ? SETTINGS_URL : ONBOARDING_URL}"

--- a/extension-manifest-v3/src/pages/panel/views/protection-status.js
+++ b/extension-manifest-v3/src/pages/panel/views/protection-status.js
@@ -88,6 +88,7 @@ export default {
                       type="status"
                       color="success-500"
                       layout="margin:top:0.5"
+                      no-label
                     ></ui-toggle>
                   `
                 : html`
@@ -97,6 +98,7 @@ export default {
                       type="status"
                       color="danger-500"
                       layout="margin:top:0.5"
+                      no-label
                     ></ui-toggle>
                   `}
             </gh-panel-card>

--- a/extension-manifest-v3/src/pages/settings/components/devtools.js
+++ b/extension-manifest-v3/src/pages/settings/components/devtools.js
@@ -60,9 +60,9 @@ export default {
   counter: 0,
   options: store(Options),
   visible: false,
-  content: ({ visible }) => html`
+  content: ({ visible, counter }) => html`
     <template layout="column gap:3">
-      ${visible &&
+      ${(visible || counter > 5) &&
       html`
         <section layout="column gap:3" translate="no">
           <ui-text type="headline-m">Developer tools</ui-text>

--- a/extension-manifest-v3/src/pages/settings/components/help-image.js
+++ b/extension-manifest-v3/src/pages/settings/components/help-image.js
@@ -16,8 +16,8 @@ export default {
   render: (host) =>
     html`
       <template
-        layout="grid relative overflow size:12:8 shrink:0"
-        layout@768px="size:15:10"
+        layout="row center relative overflow size:12:8 shrink:0"
+        layout@768px="size:14:9"
       >
         ${host.static
           ? html`<slot></slot>`
@@ -37,7 +37,7 @@ export default {
       </template>
     `.css`
       :host {
-        background: var(--ui-color-white);
+        background: var(--ui-color-gray-100);
         border: 1px solid var(--ui-color-gray-300);
         border-radius: 4px;
       }

--- a/extension-manifest-v3/src/pages/settings/components/page-layout.js
+++ b/extension-manifest-v3/src/pages/settings/components/page-layout.js
@@ -20,7 +20,7 @@ export default {
       layout@1280px="padding:8:3"
     >
       <slot
-        layout::slotted(*)@1280px="width:full::720px self:center:start"
+        layout::slotted(*)@1280px="width:full::800px self:center:start"
       ></slot>
     </template>
   `,

--- a/extension-manifest-v3/src/pages/settings/views/privacy.js
+++ b/extension-manifest-v3/src/pages/settings/views/privacy.js
@@ -123,7 +123,7 @@ export default {
                       mobile-type="body-m"
                       color="gray-600"
                     >
-                      Eliminates ads on wesbites for safe and fast browsing.
+                      Eliminates ads on websites for safe and fast browsing.
                     </ui-text>
                   </div>
                   <ui-toggle
@@ -178,7 +178,7 @@ export default {
                       mobile-type="body-m"
                       color="gray-600"
                     >
-                      Automatically rejects of cookie consent notices.
+                      Automatically rejects cookie consent notices.
                     </ui-text>
                   </div>
                   <ui-toggle
@@ -200,12 +200,9 @@ export default {
               </gh-settings-help-image>
               <div layout="column gap:2" layout@768px="row grow gap:5">
                 <div layout="column gap:0.5 grow">
-                  <ui-text type="headline-s">
-                    <!-- Feature name (capitalized in english) | settings -->
-                    Global Pause
-                  </ui-text>
+                  <ui-text type="headline-s">Pause Ghostery</ui-text>
                   <ui-text type="body-l" mobile-type="body-m" color="gray-600">
-                    Pause Ghostery on all websites for 1&nbsp;day.
+                    Suspends privacy protection globally for 1 day.
                   </ui-text>
                   ${globalPauseRevokeAt &&
                   html`
@@ -249,7 +246,7 @@ export default {
                     Search Engine Redirect Protection
                   </ui-text>
                   <ui-text type="body-l" mobile-type="body-m" color="gray-600">
-                    Prevent Google from redirecting search result links through
+                    Prevents Google from redirecting search result links through
                     their servers instead of linking directly to pages.
                   </ui-text>
                 </div>

--- a/extension-manifest-v3/src/pages/settings/views/privacy.js
+++ b/extension-manifest-v3/src/pages/settings/views/privacy.js
@@ -11,7 +11,7 @@
 
 import { html, msg, store, router } from 'hybrids';
 
-import Options from '/store/options.js';
+import Options, { GLOBAL_PAUSE_ID } from '/store/options.js';
 import Session from '/store/session.js';
 
 import assets from '../assets/index.js';
@@ -46,16 +46,54 @@ function toggleNeverConsent({ options }) {
   });
 }
 
+function updateGlobalPause({ options }, value, lastValue) {
+  if (lastValue === undefined) return;
+
+  if (!value) {
+    store.set(options, {
+      paused: options.paused.filter((p) => p.id !== GLOBAL_PAUSE_ID),
+    });
+  } else if (!options.paused.find((p) => p.id === GLOBAL_PAUSE_ID)) {
+    store.set(options, {
+      paused: [
+        ...options.paused,
+        {
+          id: GLOBAL_PAUSE_ID,
+          revokeAt: Date.now() + 24 * 60 * 60 * 1000,
+        },
+      ],
+    });
+  }
+}
+
 export default {
   options: store(Options),
   session: store(Session),
   devMode: false,
-  content: ({ options, session, devMode }) => html`
+  globalPause: {
+    value: false,
+    observe: updateGlobalPause,
+  },
+  globalPauseRevokeAt: {
+    get: ({ options }) =>
+      store.ready(options) &&
+      options.paused.find((p) => p.id === GLOBAL_PAUSE_ID)?.revokeAt,
+    observe: (host, value) => {
+      host.globalPause = value;
+    },
+  },
+  content: ({
+    options,
+    session,
+    devMode,
+    globalPause,
+    globalPauseRevokeAt,
+  }) => html`
     <template layout="contents">
       <gh-settings-page-layout layout="column gap:4">
         ${store.ready(options) &&
         html`
-          <section layout="column gap:4" layout@768px="gap:5">
+          <section layout="column gap:4" layout@768px="gap:4">
             <div layout="column gap" layout@992px="margin:bottom">
               <ui-text type="headline-l" mobile-type="headline-m">
                 Privacy protection
@@ -66,83 +104,137 @@ export default {
                 cookie pop-ups.
               </ui-text>
             </div>
-            <div layout="row items:start gap:2" layout@768px="gap:5">
-              <a href="${router.url(Preview, PREVIEWS['ad_blocking'])}">
-                <gh-settings-help-image>
-                  <img src="${assets.ad_blocking_small}" alt="Ad-Blocking" />
-                </gh-settings-help-image>
-              </a>
-              <div
-                layout="column gap:2"
-                layout@768px="row items:center gap:5 grow"
-              >
+            <div
+              layout="column gap:4"
+              layout@768px="gap:4"
+              style="${{ opacity: globalPause ? 0.5 : undefined }}"
+            >
+              <div layout="row items:start gap:2" layout@768px="gap:4">
+                <a href="${router.url(Preview, PREVIEWS['ad_blocking'])}">
+                  <gh-settings-help-image>
+                    <img src="${assets.ad_blocking_small}" alt="Ad-Blocking" />
+                  </gh-settings-help-image>
+                </a>
+                <div layout="column gap:2" layout@768px="row gap:5 grow">
+                  <div layout="column gap:0.5 grow">
+                    <ui-text type="headline-s">Ad-Blocking</ui-text>
+                    <ui-text
+                      type="body-l"
+                      mobile-type="body-m"
+                      color="gray-600"
+                    >
+                      Eliminates ads on wesbites for safe and fast browsing.
+                    </ui-text>
+                  </div>
+                  <ui-toggle
+                    disabled="${globalPause}"
+                    value="${options.blockAds}"
+                    onchange="${html.set(options, 'blockAds')}"
+                  ></ui-toggle>
+                </div>
+              </div>
+              <div layout="row items:start gap:2" layout@768px="gap:4">
+                <a href="${router.url(Preview, PREVIEWS['anti_tracking'])}">
+                  <gh-settings-help-image>
+                    <img
+                      src="${assets.anti_tracking_small}"
+                      alt="Anti-Tracking"
+                    />
+                  </gh-settings-help-image>
+                </a>
+                <div layout="column gap:2" layout@768px="row gap:5 grow">
+                  <div layout="column grow gap:0.5">
+                    <ui-text type="headline-s">Anti-Tracking</ui-text>
+                    <ui-text
+                      type="body-l"
+                      mobile-type="body-m"
+                      color="gray-600"
+                    >
+                      Prevents various tracking techniques using AI-driven
+                      technology.
+                    </ui-text>
+                  </div>
+                  <ui-toggle
+                    disabled="${globalPause}"
+                    value="${options.blockTrackers}"
+                    onchange="${html.set(options, 'blockTrackers')}"
+                  ></ui-toggle>
+                </div>
+              </div>
+              <div layout="row items:start gap:2" layout@768px="gap:4">
+                <a href="${router.url(Preview, PREVIEWS['never_consent'])}">
+                  <gh-settings-help-image>
+                    <img
+                      src="${assets.never_consent_small}"
+                      alt="Never-Consent"
+                    />
+                  </gh-settings-help-image>
+                </a>
+                <div layout="column gap:2" layout@768px="row gap:5 grow">
+                  <div layout="column grow gap:0.5">
+                    <ui-text type="headline-s">Never-Consent</ui-text>
+                    <ui-text
+                      type="body-l"
+                      mobile-type="body-m"
+                      color="gray-600"
+                    >
+                      Automatically rejects of cookie consent notices.
+                    </ui-text>
+                  </div>
+                  <ui-toggle
+                    disabled="${globalPause}"
+                    value="${options.blockAnnoyances}"
+                    onchange="${toggleNeverConsent}"
+                  ></ui-toggle>
+                </div>
+              </div>
+            </div>
+            <ui-line></ui-line>
+            <div layout="row items:start gap:2" layout@768px="gap:4">
+              <gh-settings-help-image static>
+                <ui-icon
+                  name="pause"
+                  color="gray-400"
+                  layout="size:5"
+                ></ui-icon>
+              </gh-settings-help-image>
+              <div layout="column gap:2" layout@768px="row grow gap:5">
                 <div layout="column gap:0.5 grow">
-                  <ui-text type="headline-s">Ad-Blocking</ui-text>
-                  <ui-text type="body-l" mobile-type="body-m" color="gray-600">
-                    Eliminates ads on wesbites for safe and fast browsing.
+                  <ui-text type="headline-s">
+                    <!-- Feature name (capitalized in english) | settings -->
+                    Global Pause
                   </ui-text>
+                  <ui-text type="body-l" mobile-type="body-m" color="gray-600">
+                    Pause Ghostery on all websites for 1&nbsp;day.
+                  </ui-text>
+                  ${globalPauseRevokeAt &&
+                  html`
+                    <ui-text type="body-s" color="gray-400">
+                      ${html`
+                        <ui-text type="body-s" ellipsis
+                          ><relative-time
+                            date="${new Date(globalPauseRevokeAt)}"
+                            format="duration"
+                            format-style="narrow"
+                            precision="minute"
+                            lang="${chrome.i18n.getUILanguage()}"
+                          ></relative-time
+                        ></ui-text>
+                      `}
+                      left
+                    </ui-text>
+                  `}
                 </div>
                 <ui-toggle
-                  value="${options.blockAds}"
-                  onchange="${html.set(options, 'blockAds')}"
+                  type="status"
+                  color="danger-500"
+                  value="${globalPause}"
+                  onchange="${html.set('globalPause')}"
                 ></ui-toggle>
               </div>
             </div>
-            <div layout="row items:start gap:2" layout@768px="gap:5">
-              <a href="${router.url(Preview, PREVIEWS['anti_tracking'])}">
-                <gh-settings-help-image>
-                  <img
-                    src="${assets.anti_tracking_small}"
-                    alt="Anti-Tracking"
-                  />
-                </gh-settings-help-image>
-              </a>
-              <div
-                layout="column gap:2"
-                layout@768px="row items:center gap:5 grow"
-              >
-                <div layout="column grow gap:0.5">
-                  <ui-text type="headline-s">Anti-Tracking</ui-text>
-                  <ui-text type="body-l" mobile-type="body-m" color="gray-600">
-                    Prevents various tracking techniques using AI-driven
-                    technology.
-                  </ui-text>
-                </div>
-                <ui-toggle
-                  value="${options.blockTrackers}"
-                  onchange="${html.set(options, 'blockTrackers')}"
-                ></ui-toggle>
-              </div>
-            </div>
-            <div layout="row items:start gap:2" layout@768px="gap:5">
-              <a href="${router.url(Preview, PREVIEWS['never_consent'])}">
-                <gh-settings-help-image>
-                  <img
-                    src="${assets.never_consent_small}"
-                    alt="Never-Consent"
-                  />
-                </gh-settings-help-image>
-              </a>
-              <div
-                layout="column gap:2"
-                layout@768px="row items:center gap:5 grow"
-              >
-                <div layout="column grow gap:0.5">
-                  <ui-text type="headline-s">Never-Consent</ui-text>
-                  <ui-text type="body-l" mobile-type="body-m" color="gray-600">
-                    Automatically rejects of cookie consent notices.
-                  </ui-text>
-                </div>
-                <ui-toggle
-                  value="${options.blockAnnoyances}"
-                  onchange="${toggleNeverConsent}"
-                ></ui-toggle>
-              </div>
-            </div>
-            <ui-text type="headline-m" mobile-type="headline-s">
-              Further Protection
-            </ui-text>
-            <div layout="row items:start gap:2" layout@768px="gap:5">
+            <ui-line></ui-line>
+            <div layout="row items:start gap:2" layout@768px="gap:4">
               <a href="${router.url(Preview, PREVIEWS['serp_tracking'])}">
                 <gh-settings-help-image>
                   <img
@@ -151,10 +243,7 @@ export default {
                   />
                 </gh-settings-help-image>
               </a>
-              <div
-                layout="column gap:2"
-                layout@768px="row items:center gap:5 grow"
-              >
+              <div layout="column gap:2" layout@768px="row gap:5 grow">
                 <div layout="column grow gap:0.5">
                   <ui-text type="headline-s">
                     Search Engine Redirect Protection

--- a/extension-manifest-v3/src/pages/settings/views/websites.js
+++ b/extension-manifest-v3/src/pages/settings/views/websites.js
@@ -12,7 +12,7 @@
 import { html, msg, store, router } from 'hybrids';
 import '@github/relative-time-element';
 
-import Options from '/store/options.js';
+import Options, { GLOBAL_PAUSE_ID } from '/store/options.js';
 import TrackerException from '/store/tracker-exception.js';
 
 import NoWebsitesSVG from '../assets/no_websites.svg';
@@ -73,7 +73,9 @@ export default {
     query = query.toLowerCase().trim();
 
     return [
-      ...paused.filter(({ id }) => !exceptions.some(([d]) => d === id)),
+      ...paused
+        .filter(({ id }) => id !== GLOBAL_PAUSE_ID)
+        .filter(({ id }) => !exceptions.some(([d]) => d === id)),
       ...exceptions.map(([d, exceptions]) => ({
         id: d,
         revokeAt: paused.find((p) => p.id === d)?.revokeAt,

--- a/extension-manifest-v3/src/pages/settings/views/whotracksme.js
+++ b/extension-manifest-v3/src/pages/settings/views/whotracksme.js
@@ -38,7 +38,7 @@ export default {
   options: store(Options),
   content: ({ options }) => html`
     <template layout="contents">
-      <gh-settings-page-layout layout="gap:4" layout@768px="gap:5">
+      <gh-settings-page-layout layout="gap:4" layout@768px="gap:4">
         <div layout="column gap" layout@992px="margin:bottom">
           <ui-text type="headline-l" mobile-type="headline-m" translate="no">
             WhoTracks.Me
@@ -58,7 +58,7 @@ export default {
         ${store.ready(options) &&
         html`
           <section layout="column gap:4">
-            <div layout="row gap:2" layout@768px="gap:5">
+            <div layout="row gap:2" layout@768px="gap:4">
               <a href="${router.url(Preview, PREVIEWS['wtm_wheel'])}">
                 <gh-settings-help-image>
                   <img
@@ -83,7 +83,7 @@ export default {
             </div>
             ${Options.trackerCount &&
             html`
-              <div layout="row gap:2" layout@768px="gap:5">
+              <div layout="row gap:2" layout@768px="gap:4">
                 <a href="${router.url(Preview, PREVIEWS['trackers_count'])}">
                   <gh-settings-help-image>
                     <img
@@ -111,7 +111,7 @@ export default {
                 </div>
               </div>
             `}
-            <div layout="row gap:2" layout@768px="gap:5">
+            <div layout="row gap:2" layout@768px="gap:4">
               <a href="${router.url(Preview, PREVIEWS['trackers_preview'])}">
                 <gh-settings-help-image>
                   <img

--- a/extension-manifest-v3/src/store/options.js
+++ b/extension-manifest-v3/src/store/options.js
@@ -17,6 +17,7 @@ import { getUserOptions, setUserOptions } from '/utils/api.js';
 import Session from './session.js';
 
 const UPDATE_OPTIONS_ACTION_NAME = 'updateOptions';
+export const GLOBAL_PAUSE_ID = '<all_urls>';
 
 const observers = new Set();
 
@@ -146,6 +147,13 @@ const Options = {
     },
   },
 };
+
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.action === UPDATE_OPTIONS_ACTION_NAME) {
+    store.clear(Options, false);
+    store.get(Options);
+  }
+});
 
 export default Options;
 
@@ -312,9 +320,6 @@ export async function observe(property, fn) {
   };
 }
 
-chrome.runtime.onMessage.addListener((msg) => {
-  if (msg.action === UPDATE_OPTIONS_ACTION_NAME) {
-    store.clear(Options, false);
-    store.get(Options);
-  }
-});
+export function isGlobalPaused(options) {
+  return options.paused.some(({ id }) => id === GLOBAL_PAUSE_ID);
+}

--- a/extension-manifest-v3/src/utils/trackerdb.js
+++ b/extension-manifest-v3/src/utils/trackerdb.js
@@ -98,7 +98,10 @@ export function getMetadata(request) {
 
     tracker = {
       id: request.hostname,
-      name: request.hostname,
+      name:
+        request.hostname.length > 24
+          ? '...' + request.hostname.slice(-24)
+          : request.hostname,
       category: 'unidentified',
       exception: request.hostname,
       blockedByDefault: true,

--- a/packages/ui/src/modules/global/components/text.js
+++ b/packages/ui/src/modules/global/components/text.js
@@ -14,6 +14,10 @@ export default {
       color: var(--ui-text-color, inherit);
     }
 
+    :host([hidden]) {
+      display: none;
+    }
+
     ${
       mobileType
         ? /*css*/ `

--- a/packages/ui/src/modules/global/components/toggle.js
+++ b/packages/ui/src/modules/global/components/toggle.js
@@ -19,6 +19,7 @@ function toggle(host) {
 export default {
   value: false,
   disabled: false,
+  noLabel: false,
   type: '',
   color: '',
   render: Object.assign(
@@ -67,7 +68,7 @@ export default {
       #toggle {
         background: var(--ui-color-danger-500);
         border-radius: 12px;
-        transition: color 0.2s;
+        transition: color 0.2s, background 0.2s;
       }
 
       #toggle span {
@@ -88,7 +89,7 @@ export default {
         left: calc(100% - 20px);
       }
 
-      :host([type="status"]) ui-text {
+      :host([no-label]) ui-text {
         display: none;
       }
 
@@ -98,6 +99,14 @@ export default {
 
       :host([value][type="status"]) #toggle {
         background: var(--ui-color-${color});
+      }
+
+      :host([type="status"]) button {
+        --ui-text-color-heading: var(--ui-color-gray-400);
+      }
+
+      :host([value][type="status"]) button {
+        --ui-text-color-heading: var(--ui-color-${color});
       }
 
 
@@ -124,6 +133,14 @@ export default {
 
         :host([value][type="status"]) button:hover #toggle {
           background: var(--ui-color-${color});
+        }
+
+        :host([type="status"]) button:hover {
+          --ui-text-color-heading: var(--ui-color-gray-600);
+        }
+
+        :host([value][type="status"]) button:hover {
+          --ui-text-color-heading: var(--ui-color-${color});
         }
       }
     `,


### PR DESCRIPTION
## Overview

Adds global pause feature. The feature uses a special ID to `options.paused` with 24 hours delay. 

To disable Ghostery completely it turns off the following features:
* Disables all DNR rulesets
* Disables WebRequest reporter (anti-tracking)
* Disables adblocker engines

## Wording & UI

* Added `Main protection` header (instead of `Protection modules`) - it fits more with the `Further protection`
* Updated privacy UI with a toggle
* Panel has new state - global pause - the main "trust/revoke" button has new action when the global pause is activated
* Added temporary notification about the feature - I recommend removing it in the next release - so it will be kept for at least a week on production

![chrome-extension___jccobfekniccmgppgbkonmdmdldhhgjc_pages_settings_index html(iPad Air)](https://github.com/ghostery/ghostery-extension/assets/1906677/d31dc446-ada1-4b29-8efd-28a90f527e94)
![chrome-extension___jccobfekniccmgppgbkonmdmdldhhgjc_pages_settings_index html(iPad Air) (1)](https://github.com/ghostery/ghostery-extension/assets/1906677/fd194be5-e376-454b-b0b4-c411e34e162f)
<img width="380" alt="Zrzut ekranu 2024-06-10 o 16 10 14" src="https://github.com/ghostery/ghostery-extension/assets/1906677/9ecc8371-482a-4afc-8d18-b8d2f2ea160c">

