### PR TITLE
fix: use Set over the Array instance for paused hostnames

### DIFF
--- a/extension-manifest-v3/src/background/adblocker.js
+++ b/extension-manifest-v3/src/background/adblocker.js
@@ -24,7 +24,7 @@ import asyncSetup from './utils/setup.js';
 import { updateTabStats } from './stats.js';
 
 let enabledEngines = [];
-let pausedHostnames = [];
+let pausedHostnames = new Set();
 
 const setup = asyncSetup([
   observe(null, (options) => {
@@ -39,7 +39,10 @@ const setup = asyncSetup([
       : [];
 
     // Set paused hostnames
-    pausedHostnames = options.paused.map(String);
+    pausedHostnames.clear();
+    for (const { id } of options.paused) {
+      pausedHostnames.add(id);
+    }
   }),
   engines.init(engines.CUSTOM_ENGINE),
   engines.init(engines.FIXES_ENGINE),
@@ -48,8 +51,8 @@ const setup = asyncSetup([
 
 function isPaused(hostname) {
   return (
-    pausedHostnames.includes(GLOBAL_PAUSE_ID) ||
-    pausedHostnames.includes(hostname.replace(/^www\./, ''))
+    pausedHostnames.has(GLOBAL_PAUSE_ID) ||
+    pausedHostnames.has(hostname.replace(/^www\./, ''))
   );
 }
 

--- a/extension-manifest-v3/src/background/reporting/webrequest-reporter.js
+++ b/extension-manifest-v3/src/background/reporting/webrequest-reporter.js
@@ -32,7 +32,7 @@ if (__PLATFORM__ !== 'safari') {
   // Important to call it in a first tick as it assigns chrome. listeners
   webRequestPipeline.init();
 
-  let pausedHostnames = [];
+  let pausedHostnames = new Set();
   let isAntiTrackingEnabled = false;
 
   observe('blockTrackers', (blockTrackers) => {
@@ -40,7 +40,10 @@ if (__PLATFORM__ !== 'safari') {
   });
 
   observe('paused', (paused) => {
-    pausedHostnames = paused.map(({ id }) => id);
+    pausedHostnames.clear();
+    for (const { id } of paused) {
+      pausedHostnames.add(id);
+    }
   });
 
   webRequestReporter = new RequestReporter(config.request, {
@@ -55,10 +58,8 @@ if (__PLATFORM__ !== 'safari') {
       }
 
       if (
-        pausedHostnames.includes(GLOBAL_PAUSE_ID) ||
-        pausedHostnames.includes(
-          state.tabUrlParts.hostname.replace(/^www\./, ''),
-        )
+        pausedHostnames.has(GLOBAL_PAUSE_ID) ||
+        pausedHostnames.has(state.tabUrlParts.hostname.replace(/^www\./, ''))
       ) {
         return true;
       }

--- a/extension-manifest-v3/src/background/stats.js
+++ b/extension-manifest-v3/src/background/stats.js
@@ -61,7 +61,7 @@ async function refreshIcon(tabId) {
   const inactive =
     isGlobalPaused(options) ||
     !options.terms ||
-    options.paused?.some(({ id }) => id === stats.hostname);
+    options.paused.some(({ id }) => id === stats.hostname);
 
   const data = {};
   if (options.trackerWheel && stats.trackers.length > 0) {


### PR DESCRIPTION
Fixes #1651

Still, I am not sure if this is better. The real question is if `Array.prototype.includes` is much slower than `Set.prototype.has`... The list has unique IDs (so no benefit here), and it must be cleared each time, as otherwise, we would need to check if the user removed the domain (and it might be then even slower).