### PR TITLE
Experimental filters

### DIFF
--- a/extension-manifest-v3/src/pages/settings/views/privacy.js
+++ b/extension-manifest-v3/src/pages/settings/views/privacy.js
@@ -256,6 +256,41 @@ export default {
                 ></ui-toggle>
               </div>
             </div>
+            <div layout="row items:start gap:2" layout@768px="gap:4">
+              <gh-settings-help-image static>
+                <ui-icon
+                  name="alert-info"
+                  color="gray-400"
+                  layout="size:5"
+                ></ui-icon>
+              </gh-settings-help-image>
+              <div layout="column gap:2" layout@768px="row gap:5 grow">
+                <div layout="column grow gap:0.5">
+                  <ui-text type="headline-s"
+                    >Experimental ad-blocking filters</ui-text
+                  >
+                  <ui-text type="body-l" mobile-type="body-m" color="gray-600">
+                    Helps Ghostery fix broken pages faster. By activating you
+                    can test experimental filters and support us with feedback.
+                    Please send a message to support@ghostery.com describing how
+                    your experience changed after enabling.
+                  </ui-text>
+                  <ui-text type="label-m" color="gray-600" underline>
+                    <a
+                      href="https://github.com/ghostery/broken-page-reports/blob/main/filters/experimental.txt"
+                      target="_blank"
+                      layout="row gap:0.5"
+                    >
+                      Learn more<ui-icon name="arrow-right-s"></ui-icon>
+                    </a>
+                  </ui-text>
+                </div>
+                <ui-toggle
+                  value="${options.experimentalFilters}"
+                  onchange="${html.set(options, 'experimentalFilters')}"
+                ></ui-toggle>
+              </div>
+            </div>
           </section>
 
           <gh-settings-devtools

--- a/extension-manifest-v3/src/pages/settings/views/privacy.js
+++ b/extension-manifest-v3/src/pages/settings/views/privacy.js
@@ -267,7 +267,7 @@ export default {
               <div layout="column gap:2" layout@768px="row gap:5 grow">
                 <div layout="column grow gap:0.5">
                   <ui-text type="headline-s"
-                    >Experimental ad-blocking filters</ui-text
+                    >Experimental Ad-Blocking Filters</ui-text
                   >
                   <ui-text type="body-l" mobile-type="body-m" color="gray-600">
                     Helps Ghostery fix broken pages faster. By activating you

--- a/extension-manifest-v3/src/store/options.js
+++ b/extension-manifest-v3/src/store/options.js
@@ -29,7 +29,7 @@ export const SYNC_OPTIONS = [
   'trackerCount',
   'wtmSerpReport',
   'serpTrackingPrevention',
-  'experimentalCosmeticFilters',
+  'experimentalFilters',
   'panel',
 ];
 

--- a/extension-manifest-v3/src/store/options.js
+++ b/extension-manifest-v3/src/store/options.js
@@ -29,6 +29,7 @@ export const SYNC_OPTIONS = [
   'trackerCount',
   'wtmSerpReport',
   'serpTrackingPrevention',
+  'experimentalCosmeticFilters',
   'panel',
 ];
 
@@ -51,6 +52,9 @@ const Options = {
   // SERP
   wtmSerpReport: true,
   serpTrackingPrevention: true,
+
+  // Optional
+  experimentalFilters: false,
 
   // Onboarding
   terms: false,

--- a/extension-manifest-v3/src/utils/engines.js
+++ b/extension-manifest-v3/src/utils/engines.js
@@ -18,6 +18,7 @@ import {
   Config,
 } from '@cliqz/adblocker';
 
+import { observe } from '../store/options.js';
 import { registerDatabase } from './indexeddb.js';
 import debug from './debug.js';
 
@@ -38,6 +39,7 @@ const ENV = new Map([
   ['env_chromium', checkUserAgent('Chrome')],
   ['env_edge', checkUserAgent('Edg')],
   ['env_mobile', checkUserAgent('Mobile')],
+  ['env_experimental', false],
 ]);
 
 function deserializeEngine(engineBytes) {
@@ -427,6 +429,13 @@ chrome.alarms.onAlarm.addListener((alarm) => {
     chrome.alarms.create(alarm.name, {
       delayInMinutes: ALARM_DELAY,
     });
+  }
+});
+
+observe('experimentalFilters', (experimentalFilters) => {
+  ENV.set('env_experimental', experimentalFilters);
+  for (const engine of engines.values()) {
+    engine.updateEnv(ENV);
   }
 });
 


### PR DESCRIPTION
Allow users to enable experimental filters which may help with some websites like currently Youtube.com

Experimental filters, by definition are not well tested so may cause breakage, that's why they cannot be enabled by default. 

<img width="904" alt="Screenshot 2024-06-14 at 20 02 22" src="https://github.com/ghostery/ghostery-extension/assets/1228153/5aeff4a9-f517-4e8e-9932-32360bd6930b">
