### PR TITLE
Update hybrids to v9.0.0

### DIFF
--- a/extension-manifest-v2/package.json
+++ b/extension-manifest-v2/package.json
@@ -52,7 +52,7 @@
     "foundation-sites": "^6.6.2",
     "ghostery-common": "^1.3.12",
     "history": "^4.10.1",
-    "hybrids": "^8.2.23",
+    "hybrids": "^9.0.0",
     "linkedom": "^0.16.11",
     "moment": "^2.29.1",
     "prop-types": "^15.6.2",

--- a/extension-manifest-v3/package.json
+++ b/extension-manifest-v3/package.json
@@ -41,7 +41,7 @@
     "@ghostery/ui": "^1.0.0",
     "@github/relative-time-element": "^4.3.0",
     "@whotracksme/webextension-packages": "^5.0.16",
-    "hybrids": "^8.2.23",
+    "hybrids": "^9.0.0",
     "idb": "^7.1.1",
     "jwt-decode": "^4.0.0",
     "tldts-experimental": "^6.0.19"

--- a/extension-manifest-v3/src/pages/onboarding/iframe.js
+++ b/extension-manifest-v3/src/pages/onboarding/iframe.js
@@ -29,7 +29,7 @@ async function close(host, event) {
 
 mount(document.body, {
   stats: store(TabStats),
-  content: ({ stats }) => html`
+  render: ({ stats }) => html`
     <ui-onboarding-iframe
       trackers="${store.ready(stats) ? stats.trackers.length : 0}"
       onignore="${close}"

--- a/extension-manifest-v3/src/pages/onboarding/index.js
+++ b/extension-manifest-v3/src/pages/onboarding/index.js
@@ -29,7 +29,7 @@ async function updateOptions(host, event) {
 }
 
 mount(document.body, {
-  content: () => html`
+  render: () => html`
     <ui-onboarding
       platform="${__PLATFORM__}"
       onsuccess="${updateOptions}"

--- a/extension-manifest-v3/src/pages/onboarding/opera-serp.js
+++ b/extension-manifest-v3/src/pages/onboarding/opera-serp.js
@@ -52,7 +52,7 @@ async function ignore() {
 }
 
 mount(document.body, {
-  content: () => html`
+  render: () => html`
     <ui-onboarding-serp
       onenable="${enable}"
       onignore="${ignore}"

--- a/extension-manifest-v3/src/pages/panel/components/alert.js
+++ b/extension-manifest-v3/src/pages/panel/components/alert.js
@@ -28,7 +28,7 @@ const slide = {
 };
 
 export default {
-  type: '',
+  type: { value: '', reflect: true },
   icon: 'alert-info',
   autoclose: {
     value: 0,

--- a/extension-manifest-v3/src/pages/panel/components/card.js
+++ b/extension-manifest-v3/src/pages/panel/components/card.js
@@ -1,7 +1,7 @@
 import { html } from 'hybrids';
 
 export default {
-  type: '',
+  type: { value: '', reflect: true },
   render: () => html`
     <template layout="block padding:1.5">
       <slot></slot>

--- a/extension-manifest-v3/src/pages/panel/components/container.js
+++ b/extension-manifest-v3/src/pages/panel/components/container.js
@@ -20,9 +20,8 @@ function updateShadow({ render }) {
 }
 
 export default {
-  _: {
-    get: () => {},
-    connect(host) {
+  render: {
+    connect: (host) => {
       const resizeObserver = new ResizeObserver(() => updateShadow(host));
       resizeObserver.observe(host);
 
@@ -30,50 +29,50 @@ export default {
         resizeObserver.disconnect();
       };
     },
+    value: () => html`
+      <template layout="row height::0 relative">
+        <div
+          id="scroll"
+          onscroll="${updateShadow}"
+          layout="grow overflow:x:hidden overflow:y:auto"
+        >
+          <slot onslotchange="${updateShadow}"></slot>
+        </div>
+        <div class="shadow top" layout="absolute width:full height:3"></div>
+        <div class="shadow bottom" layout="absolute width:full height:3"></div>
+      </template>
+    `.css`
+      /* set custom scrollbar */
+      #scroll {
+        scrollbar-width: thin;
+        scrollbar-color: var(--ui-color-gray-200) transparent;
+      }
+
+      .shadow {
+        pointer-events: none;
+        background: linear-gradient(
+          to bottom,
+          rgba(0, 0, 0, 0) 0%,
+          rgba(0, 0, 0, 0.1) 100%
+        );
+        visibility: hidden;
+        opacity: 0;
+        transition: visibility 0.1s, opacity 0.1s;
+      }
+
+      .shadow.show {
+        visibility: visible;
+        opacity: 1;
+      }
+
+      .shadow.top {
+        top: 0;
+        transform: rotate(180deg);
+      }
+
+      .shadow.bottom {
+        bottom: 0;
+      }
+    `,
   },
-  render: () => html`
-    <template layout="row height::0 relative">
-      <div
-        id="scroll"
-        onscroll="${updateShadow}"
-        layout="grow overflow:x:hidden overflow:y:auto"
-      >
-        <slot onslotchange="${updateShadow}"></slot>
-      </div>
-      <div class="shadow top" layout="absolute width:full height:3"></div>
-      <div class="shadow bottom" layout="absolute width:full height:3"></div>
-    </template>
-  `.css`
-    /* set custom scrollbar */
-    #scroll {
-      scrollbar-width: thin;
-      scrollbar-color: var(--ui-color-gray-200) transparent;
-    }
-
-    .shadow {
-      pointer-events: none;
-      background: linear-gradient(
-        to bottom,
-        rgba(0, 0, 0, 0) 0%,
-        rgba(0, 0, 0, 0.1) 100%
-      );
-      visibility: hidden;
-      opacity: 0;
-      transition: visibility 0.1s, opacity 0.1s;
-    }
-
-    .shadow.show {
-      visibility: visible;
-      opacity: 1;
-    }
-
-    .shadow.top {
-      top: 0;
-      transform: rotate(180deg);
-    }
-
-    .shadow.bottom {
-      bottom: 0;
-    }
-  `,
 };

--- a/extension-manifest-v3/src/pages/panel/components/dialog.js
+++ b/extension-manifest-v3/src/pages/panel/components/dialog.js
@@ -30,6 +30,7 @@ function animateOnClose(host, event) {
 export default {
   open: {
     value: false,
+    reflect: true,
     connect(host, key) {
       const timeout = setTimeout(() => {
         host[key] = true;

--- a/extension-manifest-v3/src/pages/panel/components/notification.js
+++ b/extension-manifest-v3/src/pages/panel/components/notification.js
@@ -15,7 +15,7 @@ import { openTabWithUrl } from '/utils/tabs.js';
 export default {
   icon: '',
   href: '',
-  type: '', // warning
+  type: { value: '', reflect: true }, // warning
   render: ({ icon, href }) => html`
     <template layout="block">
       <ui-action>

--- a/extension-manifest-v3/src/pages/panel/components/pause.js
+++ b/extension-manifest-v3/src/pages/panel/components/pause.js
@@ -64,7 +64,7 @@ function simulateClickOnEnter(host, event) {
 }
 
 export default {
-  paused: false,
+  paused: { value: false, reflect: true },
   pauseType: 1,
   pauseList: false,
   render: ({ paused, pauseType, pauseList }) => html`

--- a/extension-manifest-v3/src/pages/panel/index.js
+++ b/extension-manifest-v3/src/pages/panel/index.js
@@ -29,7 +29,7 @@ define.from(
 // Mount the app
 mount(document.body, {
   stack: router([Home]),
-  content: ({ stack }) => html`
+  render: ({ stack }) => html`
     <template layout="row width:full:350px">${stack}</template>
   `,
 });

--- a/extension-manifest-v3/src/pages/panel/views/home.js
+++ b/extension-manifest-v3/src/pages/panel/views/home.js
@@ -108,7 +108,7 @@ export default {
   globalPause: ({ options }) =>
     store.ready(options) &&
     options.paused.find(({ id }) => id === GLOBAL_PAUSE_ID),
-  content: ({ options, stats, notification, paused, globalPause }) => html`
+  render: ({ options, stats, notification, paused, globalPause }) => html`
     <template layout="column grow relative">
       ${store.ready(options, stats) &&
       html`

--- a/extension-manifest-v3/src/pages/panel/views/navigation.js
+++ b/extension-manifest-v3/src/pages/panel/views/navigation.js
@@ -92,7 +92,7 @@ if (__PLATFORM__ !== 'safari') {
 
 export default {
   session: store(Session),
-  content: ({ session }) => html`
+  render: ({ session }) => html`
     <template layout="grid grow">
       <ui-panel-header>
         Menu

--- a/extension-manifest-v3/src/pages/panel/views/protection-status.js
+++ b/extension-manifest-v3/src/pages/panel/views/protection-status.js
@@ -29,7 +29,7 @@ export default {
   allowedOnSite: ({ stats, tracker }) =>
     store.ready(tracker.exception) &&
     tracker.exception.trustedDomains.includes(stats.hostname),
-  content: ({ stats, tracker, blocked, blockedOnSite, allowedOnSite }) => html`
+  render: ({ stats, tracker, blocked, blockedOnSite, allowedOnSite }) => html`
     <template layout="column">
       <gh-panel-dialog>
         <div

--- a/extension-manifest-v3/src/pages/panel/views/tracker-details.js
+++ b/extension-manifest-v3/src/pages/panel/views/tracker-details.js
@@ -56,7 +56,7 @@ export default {
   paused: ({ options, stats }) =>
     store.ready(options, stats) &&
     options.paused.find(({ id }) => id === stats.hostname),
-  content: ({ tracker, status, wtmUrl, paused, options }) => html`
+  render: ({ tracker, status, wtmUrl, paused, options }) => html`
     <template layout="column">
       <gh-panel-dialog>
         <div

--- a/extension-manifest-v3/src/pages/settings/components/badge.js
+++ b/extension-manifest-v3/src/pages/settings/components/badge.js
@@ -12,7 +12,7 @@
 import { html } from 'hybrids';
 
 export default {
-  type: 'danger',
+  type: { value: 'danger', reflect: true },
   uppercase: false,
   render: () => html`
     <template layout="row center padding:0.5:1">

--- a/extension-manifest-v3/src/pages/settings/components/card.js
+++ b/extension-manifest-v3/src/pages/settings/components/card.js
@@ -11,7 +11,7 @@
 import { html } from 'hybrids';
 
 export default {
-  inContent: false,
+  inContent: { value: false, reflect: true },
   render: () => html`
     <template
       layout="column gap:3 padding:3"

--- a/extension-manifest-v3/src/pages/settings/components/custom-filters.js
+++ b/extension-manifest-v3/src/pages/settings/components/custom-filters.js
@@ -96,7 +96,7 @@ export default {
   filters: ({ input }) => parseFilters(store.ready(input) ? input.text : ''),
   dnrErrors: undefined,
   errors: ({ filters, dnrErrors = [] }) => [...filters.errors, ...dnrErrors],
-  content: ({ input, filters, dnrRules, errors }) => html`
+  render: ({ input, filters, dnrRules, errors }) => html`
     <template layout="block">
       <div layout="column gap" translate="no">
         ${store.ready(input) &&

--- a/extension-manifest-v3/src/pages/settings/components/devtools.js
+++ b/extension-manifest-v3/src/pages/settings/components/devtools.js
@@ -60,7 +60,7 @@ export default {
   counter: 0,
   options: store(Options),
   visible: false,
-  content: ({ visible, counter }) => html`
+  render: ({ visible, counter }) => html`
     <template layout="column gap:3">
       ${(visible || counter > 5) &&
       html`

--- a/extension-manifest-v3/src/pages/settings/components/dialog.js
+++ b/extension-manifest-v3/src/pages/settings/components/dialog.js
@@ -18,6 +18,7 @@ function close(host) {
 export default {
   open: {
     value: false,
+    reflect: true,
     connect(host, key) {
       const timeout = setTimeout(() => {
         host[key] = true;

--- a/extension-manifest-v3/src/pages/settings/components/input.js
+++ b/extension-manifest-v3/src/pages/settings/components/input.js
@@ -12,8 +12,8 @@
 import { html } from 'hybrids';
 
 export default {
-  icon: '',
-  error: '',
+  icon: { value: '', reflect: true },
+  error: { value: '', reflect: true },
   render: ({ icon, error }) => html`
     <template layout="grid gap:0.5 relative">
       ${icon &&

--- a/extension-manifest-v3/src/pages/settings/components/protection-badge.js
+++ b/extension-manifest-v3/src/pages/settings/components/protection-badge.js
@@ -13,7 +13,7 @@ import { html } from 'hybrids';
 
 export default {
   blocked: false,
-  content: ({ blocked }) => html`
+  render: ({ blocked }) => html`
     <template layout="block">
       ${blocked
         ? html`

--- a/extension-manifest-v3/src/pages/settings/components/table.js
+++ b/extension-manifest-v3/src/pages/settings/components/table.js
@@ -12,7 +12,7 @@
 import { html } from 'hybrids';
 
 export default {
-  responsive: false,
+  responsive: { value: false, reflect: true },
   render: () => html`
     <template layout="column gap">
       <header layout="padding:1.5" layout@768px="padding:1.5:2">

--- a/extension-manifest-v3/src/pages/settings/components/trackers-list.js
+++ b/extension-manifest-v3/src/pages/settings/components/trackers-list.js
@@ -19,8 +19,8 @@ export default {
   adjusted: 0,
   blocked: 0,
   trusted: 0,
-  open: false,
   blockedByDefault: false,
+  open: { value: false, reflect: true },
   render: ({
     name,
     description,

--- a/extension-manifest-v3/src/pages/settings/settings.js
+++ b/extension-manifest-v3/src/pages/settings/settings.js
@@ -27,138 +27,141 @@ import assets from './assets/index.js';
 export default {
   stack: router([Privacy, Websites, Whotracksme, Account, Preview, Trackers]),
   session: store(Session),
-  content: ({ stack, session }) => html`
-    <template layout="contents">
-      <gh-settings-layout>
-        <a
-          href="${router.url(Privacy)}"
-          class="${{ active: router.active(Privacy) }}"
-          slot="nav"
-        >
-          <ui-icon name="shield-menu" color="nav" layout="size:3"></ui-icon>
-          Privacy protection
-        </a>
-        <a
-          href="${router.url(Websites)}"
-          class="${{
-            active:
-              router.active(Websites, { stack: true }) &&
-              !router.active(Trackers, { stack: true }),
-          }}"
-          slot="nav"
-        >
-          <ui-icon name="websites" color="nav" layout="size:3"></ui-icon>
-          Websites
-        </a>
-        <a
-          href="${router.url(Trackers)}"
-          class="${{
-            active: router.active(Trackers, { stack: true }),
-          }}"
-          slot="nav"
-        >
-          <ui-icon name="block-m" color="nav" layout="size:3"></ui-icon>
-          Trackers
-        </a>
-        <a
-          href="${router.url(Whotracksme)}"
-          class="${{ active: router.active(Whotracksme), wrap: true }}"
-          slot="nav"
-          translate="no"
-        >
-          <ui-icon name="wtm" color="nav" layout="size:3"></ui-icon>
-          WhoTracks.Me
-        </a>
+  render: {
+    value: ({ stack, session }) => html`
+      <template layout="contents">
+        <gh-settings-layout>
+          <a
+            href="${router.url(Privacy)}"
+            class="${{ active: router.active(Privacy) }}"
+            slot="nav"
+          >
+            <ui-icon name="shield-menu" color="nav" layout="size:3"></ui-icon>
+            Privacy protection
+          </a>
+          <a
+            href="${router.url(Websites)}"
+            class="${{
+              active:
+                router.active(Websites, { stack: true }) &&
+                !router.active(Trackers, { stack: true }),
+            }}"
+            slot="nav"
+          >
+            <ui-icon name="websites" color="nav" layout="size:3"></ui-icon>
+            Websites
+          </a>
+          <a
+            href="${router.url(Trackers)}"
+            class="${{
+              active: router.active(Trackers, { stack: true }),
+            }}"
+            slot="nav"
+          >
+            <ui-icon name="block-m" color="nav" layout="size:3"></ui-icon>
+            Trackers
+          </a>
+          <a
+            href="${router.url(Whotracksme)}"
+            class="${{ active: router.active(Whotracksme), wrap: true }}"
+            slot="nav"
+            translate="no"
+          >
+            <ui-icon name="wtm" color="nav" layout="size:3"></ui-icon>
+            WhoTracks.Me
+          </a>
 
-        <a
-          href="${router.url(Account)}"
-          class="${{ active: router.active(Account), bottom: true }}"
-          slot="nav"
-        >
-          ${store.ready(session) && session.user
-            ? html`
-                ${session.contributor
-                  ? html`<ui-icon name="contributor"></ui-icon>`
-                  : html`<ui-icon name="user" color="nav"></ui-icon>`}
-                <span layout@992px="hidden">My Account</span>
-                <div
-                  layout="hidden"
-                  layout@992px="column margin:left:2px width::0"
-                >
-                  <div>My Account</div>
-                  <ui-text type="body-m" ellipsis>${session.email}</ui-text>
-                </div>
-              `
-            : html`<ui-icon name="user" color="nav"></ui-icon> My Account`}
-        </a>
-        ${store.ready(session) &&
-        html`
-          <gh-settings-card
-            layout="hidden"
-            layout@992px="
+          <a
+            href="${router.url(Account)}"
+            class="${{ active: router.active(Account), bottom: true }}"
+            slot="nav"
+          >
+            ${store.ready(session) && session.user
+              ? html`
+                  ${session.contributor
+                    ? html`<ui-icon name="contributor"></ui-icon>`
+                    : html`<ui-icon name="user" color="nav"></ui-icon>`}
+                  <span layout@992px="hidden">My Account</span>
+                  <div
+                    layout="hidden"
+                    layout@992px="column margin:left:2px width::0"
+                  >
+                    <div>My Account</div>
+                    <ui-text type="body-m" ellipsis>${session.email}</ui-text>
+                  </div>
+                `
+              : html`<ui-icon name="user" color="nav"></ui-icon> My Account`}
+          </a>
+          ${store.ready(session) &&
+          html`
+            <gh-settings-card
+              layout="hidden"
+              layout@992px="
               area::6/7 self:end:stretch
               margin:top:2 padding:2 gap content:center
               column
             "
-            slot="nav"
-          >
-            ${session.contributor
-              ? html`
-                  <img
-                    src="${assets['contributor_badge']}"
-                    layout="size:12"
-                    alt="Contribution"
-                    slot="picture"
-                  />
-                  <div layout="column gap:0.5">
-                    <ui-text type="label-l" layout="block:center">
-                      You are awesome!
-                    </ui-text>
-                    <ui-text
-                      type="body-s"
-                      color="gray-600"
-                      layout="block:center"
-                    >
-                      Thank you for your support in Ghostery's fight for a web
-                      where privacy is a basic human right!
-                    </ui-text>
-                  </div>
-                `
-              : html`
-                  <img
-                    src="${assets['hands']}"
-                    layout="size:12"
-                    alt="Contribution"
-                    slot="picture"
-                  />
-                  <div layout="column gap:0.5">
-                    <ui-text type="label-l" layout="block:center">
-                      Become a Contributor
-                    </ui-text>
-                    <ui-text
-                      type="body-s"
-                      color="gray-600"
-                      layout="block:center"
-                    >
-                      Help Ghostery fight for a web where privacy is a basic
-                      human right.
-                    </ui-text>
-                    <ui-button layout="margin:top">
-                      <a
-                        href="https://www.ghostery.com/become-a-contributor?utm_source=gbe"
-                        onclick="${openTabWithUrl}"
+              slot="nav"
+            >
+              ${session.contributor
+                ? html`
+                    <img
+                      src="${assets['contributor_badge']}"
+                      layout="size:12"
+                      alt="Contribution"
+                      slot="picture"
+                    />
+                    <div layout="column gap:0.5">
+                      <ui-text type="label-l" layout="block:center">
+                        You are awesome!
+                      </ui-text>
+                      <ui-text
+                        type="body-s"
+                        color="gray-600"
+                        layout="block:center"
                       >
+                        Thank you for your support in Ghostery's fight for a web
+                        where privacy is a basic human right!
+                      </ui-text>
+                    </div>
+                  `
+                : html`
+                    <img
+                      src="${assets['hands']}"
+                      layout="size:12"
+                      alt="Contribution"
+                      slot="picture"
+                    />
+                    <div layout="column gap:0.5">
+                      <ui-text type="label-l" layout="block:center">
                         Become a Contributor
-                      </a>
-                    </ui-button>
-                  </div>
-                `}
-          </gh-settings-card>
-        `}
-        ${stack}
-      </gh-settings-layout>
-    </template>
-  `.css`
-    html, body { height: 100%; }
-  `,
+                      </ui-text>
+                      <ui-text
+                        type="body-s"
+                        color="gray-600"
+                        layout="block:center"
+                      >
+                        Help Ghostery fight for a web where privacy is a basic
+                        human right.
+                      </ui-text>
+                      <ui-button layout="margin:top">
+                        <a
+                          href="https://www.ghostery.com/become-a-contributor?utm_source=gbe"
+                          onclick="${openTabWithUrl}"
+                        >
+                          Become a Contributor
+                        </a>
+                      </ui-button>
+                    </div>
+                  `}
+            </gh-settings-card>
+          `}
+          ${stack}
+        </gh-settings-layout>
+      </template>
+    `.css`
+      html, body { height: 100%; }
+    `,
+    shadow: false,
+  },
 };

--- a/extension-manifest-v3/src/pages/settings/views/account.js
+++ b/extension-manifest-v3/src/pages/settings/views/account.js
@@ -60,7 +60,7 @@ function openGhosteryPage(url) {
 export default {
   options: store(Options),
   session: store(Session),
-  content: ({ options, session }) => html`
+  render: ({ options, session }) => html`
     <template layout="contents">
       <gh-settings-page-layout>
         <section layout="column gap:4" layout@768px="gap:5">

--- a/extension-manifest-v3/src/pages/settings/views/preview.js
+++ b/extension-manifest-v3/src/pages/settings/views/preview.js
@@ -5,7 +5,7 @@ export default {
   src: '',
   title: '',
   description: '',
-  content: ({ src, title, description }) => html`
+  render: ({ src, title, description }) => html`
     <template layout="block">
       <gh-settings-preview-dialog>
         <img src="${src}" />

--- a/extension-manifest-v3/src/pages/settings/views/privacy.js
+++ b/extension-manifest-v3/src/pages/settings/views/privacy.js
@@ -75,14 +75,14 @@ export default {
     observe: updateGlobalPause,
   },
   globalPauseRevokeAt: {
-    get: ({ options }) =>
+    value: ({ options }) =>
       store.ready(options) &&
       options.paused.find((p) => p.id === GLOBAL_PAUSE_ID)?.revokeAt,
     observe: (host, value) => {
       host.globalPause = value;
     },
   },
-  content: ({
+  render: ({
     options,
     session,
     devMode,

--- a/extension-manifest-v3/src/pages/settings/views/tracker-add-exception.js
+++ b/extension-manifest-v3/src/pages/settings/views/tracker-add-exception.js
@@ -39,7 +39,7 @@ export default {
       ? tracker.exception.blocked
       : tracker.blockedByDefault,
   hostname: store(Hostname, { draft: true }),
-  content: ({ tracker, blocked, hostname }) => html`
+  render: ({ tracker, blocked, hostname }) => html`
     <template layout>
       ${store.ready(tracker) &&
       html`

--- a/extension-manifest-v3/src/pages/settings/views/tracker-details.js
+++ b/extension-manifest-v3/src/pages/settings/views/tracker-details.js
@@ -50,7 +50,7 @@ export default {
         tracker.exception.blocked ? 'trustedDomains' : 'blockedDomains'
       ]) ||
     [],
-  content: ({ tracker, domains, otherTrackers }) => html`
+  render: ({ tracker, domains, otherTrackers }) => html`
     <template layout="contents">
       <gh-settings-page-layout>
         <div layout="column gap">

--- a/extension-manifest-v3/src/pages/settings/views/trackers.js
+++ b/extension-manifest-v3/src/pages/settings/views/trackers.js
@@ -92,7 +92,7 @@ export default {
   limits: undefined,
   query: '',
   filter: '',
-  content: ({
+  render: ({
     options,
     categories,
     category,

--- a/extension-manifest-v3/src/pages/settings/views/website-details.js
+++ b/extension-manifest-v3/src/pages/settings/views/website-details.js
@@ -67,7 +67,7 @@ export default {
   options: store(Options),
   paused: ({ options, domain }) =>
     (store.ready(options) && options.paused.find((p) => p.id === domain)) || {},
-  content: ({ domain, trackers, paused }) => html`
+  render: ({ domain, trackers, paused }) => html`
     <template layout="contents">
       <gh-settings-page-layout layout="gap:4">
         <div layout="column items:start gap">

--- a/extension-manifest-v3/src/pages/settings/views/websites.js
+++ b/extension-manifest-v3/src/pages/settings/views/websites.js
@@ -84,7 +84,7 @@ export default {
       })),
     ].filter((item) => item.id.includes(query));
   },
-  content: ({ websites, query }) => html`
+  render: ({ websites, query }) => html`
     <template layout="contents">
       <gh-settings-page-layout layout="gap:4">
         <div layout="column gap" layout@992px="margin:bottom">

--- a/extension-manifest-v3/src/pages/settings/views/whotracksme.js
+++ b/extension-manifest-v3/src/pages/settings/views/whotracksme.js
@@ -36,7 +36,7 @@ const PREVIEWS = {
 
 export default {
   options: store(Options),
-  content: ({ options }) => html`
+  render: ({ options }) => html`
     <template layout="contents">
       <gh-settings-page-layout layout="gap:4" layout@768px="gap:4">
         <div layout="column gap" layout@992px="margin:bottom">

--- a/extension-manifest-v3/src/pages/trackers-preview/index.js
+++ b/extension-manifest-v3/src/pages/trackers-preview/index.js
@@ -24,7 +24,7 @@ const stats = getStats(domain);
 updateIframeHeight();
 
 mount(document.body, {
-  content: () => html`
+  render: () => html`
     <template layout="block">
       <ui-trackers-preview
         stats="${stats}"

--- a/extension-manifest-v3/src/pages/youtube/index.js
+++ b/extension-manifest-v3/src/pages/youtube/index.js
@@ -39,7 +39,7 @@ function openPrivateWindow() {
 setupIframe();
 
 mount(document.body, {
-  content: () => html`
+  render: () => html`
     <template layout="block">
       <ui-youtube-wall
         onclose="${() => closeIframe()}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "foundation-sites": "^6.6.2",
         "ghostery-common": "^1.3.12",
         "history": "^4.10.1",
-        "hybrids": "^8.2.23",
+        "hybrids": "^9.0.0",
         "linkedom": "^0.16.11",
         "moment": "^2.29.1",
         "prop-types": "^15.6.2",
@@ -119,7 +119,7 @@
         "@ghostery/ui": "^1.0.0",
         "@github/relative-time-element": "^4.3.0",
         "@whotracksme/webextension-packages": "^5.0.16",
-        "hybrids": "^8.2.23",
+        "hybrids": "^9.0.0",
         "idb": "^7.1.1",
         "jwt-decode": "^4.0.0",
         "tldts-experimental": "^6.0.19"
@@ -3871,9 +3871,9 @@
       "integrity": "sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ=="
     },
     "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
+      "integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -10069,9 +10069,9 @@
       }
     },
     "node_modules/hybrids": {
-      "version": "8.2.23",
-      "resolved": "https://registry.npmjs.org/hybrids/-/hybrids-8.2.23.tgz",
-      "integrity": "sha512-4d13/3tSQM8mSgrE3X9htOZYUu5AvLNeer1uRSv+eEVl5G0OP0r1HdzjSGMTYsnoZKAgHmu+M3B4mjY9z8FDlQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/hybrids/-/hybrids-9.0.0.tgz",
+      "integrity": "sha512-BEwhBvhJlUB3cKJJbnrKrsdr871T1VC/tDL5Umeuoy4DWz9ssJNldgYot4QP8zHPPxUlUpGv+41QYq9m4kzQ5g==",
       "bin": {
         "hybrids": "cli/index.js"
       },
@@ -21225,7 +21225,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/libs": "^1.0.0",
-        "hybrids": "^8.2.23"
+        "hybrids": "^9.0.0"
       }
     }
   }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -22,6 +22,6 @@
   },
   "dependencies": {
     "@ghostery/libs": "^1.0.0",
-    "hybrids": "^8.2.23"
+    "hybrids": "^9.0.0"
   }
 }

--- a/packages/ui/src/modules/global/components/button.js
+++ b/packages/ui/src/modules/global/components/button.js
@@ -12,8 +12,8 @@
 import { html } from 'hybrids';
 
 export default {
-  type: 'primary',
-  size: '',
+  type: { value: 'primary', reflect: true },
+  size: { value: '', reflect: true },
   disabled: {
     value: false,
     observe: (host, value) => {

--- a/packages/ui/src/modules/global/components/icon.js
+++ b/packages/ui/src/modules/global/components/icon.js
@@ -528,6 +528,6 @@ const icons = {
   'zoom-in': html`
     <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path d="M13 13L9.66672 9.66667M10.7778 6.88889C10.7778 9.03667 9.03667 10.7778 6.88889 10.7778C4.74112 10.7778 3 9.03667 3 6.88889C3 4.74112 4.74112 3 6.88889 3C9.03667 3 10.7778 4.74112 10.7778 6.88889Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-  </svg>
+    </svg>
   `,
  };

--- a/packages/ui/src/modules/global/components/text.js
+++ b/packages/ui/src/modules/global/components/text.js
@@ -1,12 +1,12 @@
 import { html } from 'hybrids';
 
 export default {
-  type: 'body-m',
-  mobileType: '',
-  color: '',
-  ellipsis: false,
-  underline: false,
-  uppercase: false,
+  type: { value: 'body-m', reflect: true },
+  mobileType: { value: '', reflect: true },
+  color: { value: '', reflect: true },
+  ellipsis: { value: false, reflect: true },
+  underline: { value: false, reflect: true },
+  uppercase: { value: false, reflect: true },
   render: ({ type, mobileType, color }) => html`<slot></slot>`.css`
     :host {
       display: block;

--- a/packages/ui/src/modules/global/components/toggle.js
+++ b/packages/ui/src/modules/global/components/toggle.js
@@ -17,10 +17,10 @@ function toggle(host) {
 }
 
 export default {
-  value: false,
-  disabled: false,
-  noLabel: false,
-  type: '',
+  value: { value: false, reflect: true },
+  disabled: { value: false, reflect: true },
+  noLabel: { value: false, reflect: true },
+  type: { value: '', reflect: true },
   color: '',
   render: Object.assign(
     ({ disabled, value, color }) => html`

--- a/packages/ui/src/modules/global/components/tooltip.js
+++ b/packages/ui/src/modules/global/components/tooltip.js
@@ -35,7 +35,7 @@ function toggle(value) {
 
 export default {
   autohide: 2,
-  wrap: false,
+  wrap: { value: false, reflect: true },
   position: 'top', // top, bottom
   delay: 1,
   inline: false,

--- a/packages/ui/src/modules/onboarding/components/card.js
+++ b/packages/ui/src/modules/onboarding/components/card.js
@@ -12,7 +12,7 @@
 import { html } from 'hybrids';
 
 export default {
-  type: '',
+  type: { value: '', reflect: true },
   render: ({ type }) => html`
     <template layout="column padding:3">
       <div class="${{ [type]: type }}">
@@ -20,7 +20,7 @@ export default {
       </div>
     </template>
   `.css`
-    :host { 
+    :host {
       background: var(--ui-color-white);
       border-radius: 16px;
       box-shadow: 15px 30px 80px rgba(0, 0, 0, 0.15);

--- a/packages/ui/src/modules/onboarding/components/pin-it.js
+++ b/packages/ui/src/modules/onboarding/components/pin-it.js
@@ -12,7 +12,7 @@
 import { html } from 'hybrids';
 
 export default {
-  platform: '',
+  platform: { value: '', reflect: true },
   render: ({ platform }) => html`
     <template
       layout="fixed top:3 right:3 layer:1000 row items:center gap:1.5 padding:2:3:2:2"

--- a/packages/ui/src/modules/onboarding/iframe.js
+++ b/packages/ui/src/modules/onboarding/iframe.js
@@ -14,7 +14,7 @@ import { define, html, msg, dispatch } from 'hybrids';
 export default define({
   tag: 'ui-onboarding-iframe',
   trackers: 0,
-  content: ({ trackers }) => html`
+  render: ({ trackers }) => html`
     <template layout="block">
       <ui-onboarding-card>
         <div layout="row items:start gap:2">

--- a/packages/ui/src/modules/onboarding/onboarding.js
+++ b/packages/ui/src/modules/onboarding/onboarding.js
@@ -43,7 +43,7 @@ export default define({
       return () => host.removeEventListener('navigate', cb);
     },
   },
-  content: ({ views }) => html`
+  render: ({ views }) => html`
     <template layout="grid height::100%">
       <ui-onboarding-layout>${views}</ui-onboarding-layout>
     </template>

--- a/packages/ui/src/modules/onboarding/opera-serp.js
+++ b/packages/ui/src/modules/onboarding/opera-serp.js
@@ -14,7 +14,7 @@ import { define, html, dispatch } from 'hybrids';
 export default define({
   tag: 'ui-onboarding-serp',
   href: '',
-  content: () => html`
+  render: () => html`
     <template layout="block overflow">
       <ui-onboarding-card layout="padding:2">
         <div layout="row items:start gap:2">

--- a/packages/ui/src/modules/onboarding/renew.js
+++ b/packages/ui/src/modules/onboarding/renew.js
@@ -14,7 +14,7 @@ import { define, html, dispatch } from 'hybrids';
 export default define({
   tag: 'ui-onboarding-renew',
   timestamp: 0,
-  content: ({ timestamp }) => html`
+  render: ({ timestamp }) => html`
     <template layout="block overflow">
       <ui-onboarding-card layout="padding:2">
         <div layout="row items:start gap:2">

--- a/packages/ui/src/modules/onboarding/short.js
+++ b/packages/ui/src/modules/onboarding/short.js
@@ -45,7 +45,7 @@ export default define({
       return () => host.removeEventListener('navigate', cb);
     },
   },
-  content: ({ views }) => html`
+  render: ({ views }) => html`
     <template layout="grid height::100%">
       <ui-onboarding-layout>${views}</ui-onboarding-layout>
     </template>

--- a/packages/ui/src/modules/onboarding/views/main.js
+++ b/packages/ui/src/modules/onboarding/views/main.js
@@ -23,7 +23,7 @@ export default define({
   [router.connect]: { stack: [Skip, Privacy, OutroSkip] },
   tag: 'ui-onboarding-main-view',
   renew: false,
-  content: ({ renew }) => html`
+  render: ({ renew }) => html`
     <template layout="grow column gap">
       <ui-onboarding-card>
         <div layout="column gap:5">

--- a/packages/ui/src/modules/onboarding/views/outro-skip.js
+++ b/packages/ui/src/modules/onboarding/views/outro-skip.js
@@ -15,7 +15,7 @@ import disabled from '../illustrations/disabled.js';
 
 export default define({
   tag: 'ui-onboarding-outro-skip-view',
-  content: () => html`
+  render: () => html`
     <template layout="block">
       <ui-onboarding-card>
         <section layout="block:center column gap:2">

--- a/packages/ui/src/modules/onboarding/views/outro-success.js
+++ b/packages/ui/src/modules/onboarding/views/outro-success.js
@@ -26,7 +26,7 @@ const PIN_EXTENSION_IMAGES = {
 export default define({
   tag: 'ui-onboarding-outro-success-view',
   platform: '',
-  content: ({ platform }) => html`
+  render: ({ platform }) => html`
     <template layout="column gap">
       <ui-onboarding-card>
         <section layout="block:center column gap:2">

--- a/packages/ui/src/modules/onboarding/views/short/main.js
+++ b/packages/ui/src/modules/onboarding/views/short/main.js
@@ -21,7 +21,7 @@ const TERMS_AND_CONDITIONS_URL = `https://www.${GHOSTERY_DOMAIN}/privacy/ghoster
 export default define({
   [router.connect]: { stack: [Privacy, OutroSkip] },
   tag: 'ui-onboarding-short-main-view',
-  content: () => html`
+  render: () => html`
     <template layout="grow column gap">
       <ui-onboarding-card>
         <div layout="column gap:5">

--- a/packages/ui/src/modules/onboarding/views/short/outro-skip.js
+++ b/packages/ui/src/modules/onboarding/views/short/outro-skip.js
@@ -18,7 +18,7 @@ const TERMS_AND_CONDITIONS_URL = `https://www.${GHOSTERY_DOMAIN}/privacy/ghoster
 
 export default define({
   tag: 'ui-onboarding-outro-short-skip-view',
-  content: () => html`
+  render: () => html`
     <template layout="block">
       <ui-onboarding-card>
         <section layout="block:center column gap:2">

--- a/packages/ui/src/modules/onboarding/views/skip.js
+++ b/packages/ui/src/modules/onboarding/views/skip.js
@@ -16,7 +16,7 @@ import OutroSkip from './outro-skip.js';
 export default define({
   [router.connect]: { dialog: true },
   tag: 'ui-onboarding-skip-dialog',
-  content: () => html`
+  render: () => html`
     <template layout="block">
       <ui-onboarding-dialog>
         <ui-text slot="header" type="headline-m">

--- a/packages/ui/src/modules/panel/components/action.js
+++ b/packages/ui/src/modules/panel/components/action.js
@@ -12,9 +12,9 @@
 import { html } from 'hybrids';
 
 export default {
-  active: false,
-  grouped: false,
-  disabled: false,
+  active: { value: false, reflect: true },
+  grouped: { value: false, reflect: true },
+  disabled: { value: false, reflect: true },
   render: () => html`
     <template layout="grid height:4.5">
       <ui-action><slot></slot></ui-action>

--- a/packages/ui/src/modules/panel/components/category.js
+++ b/packages/ui/src/modules/panel/components/category.js
@@ -20,7 +20,7 @@ import * as labels from '../../../utils/labels.js';
 export default {
   name: '',
   count: 0,
-  actionable: false,
+  actionable: { value: false, reflect: true },
   render: ({ name, count }) => html`
     <template layout="row gap items:center">
       <div id="pill" layout="size:12px:6px"></div>

--- a/packages/ui/src/modules/panel/components/list.js
+++ b/packages/ui/src/modules/panel/components/list.js
@@ -14,7 +14,7 @@ import * as labels from '../../../utils/labels.js';
 
 export default {
   name: '',
-  closed: false,
+  closed: { value: false, reflect: true },
   render: ({ name, closed }) => html`
     <template layout="column gap:1.5 padding:1:1.5">
       ${name &&

--- a/packages/ui/src/modules/panel/components/protection-status-icon.js
+++ b/packages/ui/src/modules/panel/components/protection-status-icon.js
@@ -13,7 +13,7 @@ import { html } from 'hybrids';
 
 export default {
   status: undefined, // expected type { type: 'block' | 'trust', website?: boolean }
-  content: ({ status }) => html`
+  render: ({ status }) => html`
     <template layout="contents">
       <ui-icon
         name="${status.type}-m"

--- a/packages/ui/src/modules/panel/components/stats.js
+++ b/packages/ui/src/modules/panel/components/stats.js
@@ -38,22 +38,20 @@ export default {
         {},
       ),
     ),
-  trackers: {
-    set: (host, trackers) =>
-      trackers &&
-      Object.entries(
-        trackers.reduce(
-          (categories, tracker) => ({
-            ...categories,
-            [tracker.category]: [
-              ...(categories[tracker.category] || []),
-              tracker,
-            ],
-          }),
-          {},
-        ),
+  trackers: (host, trackers) =>
+    trackers &&
+    Object.entries(
+      trackers.reduce(
+        (categories, tracker) => ({
+          ...categories,
+          [tracker.category]: [
+            ...(categories[tracker.category] || []),
+            tracker,
+          ],
+        }),
+        {},
       ),
-  },
+    ),
   paused: false,
   domain: '',
   wtmLink: ({ domain }) =>

--- a/packages/ui/src/modules/panel/components/switch-item.js
+++ b/packages/ui/src/modules/panel/components/switch-item.js
@@ -3,6 +3,7 @@ import { html } from 'hybrids';
 export default {
   active: {
     value: false,
+    reflect: true,
     observe(host, value) {
       if (!value) {
         host.setAttribute('tabindex', '-1');

--- a/packages/ui/src/modules/panel/components/switch.js
+++ b/packages/ui/src/modules/panel/components/switch.js
@@ -4,7 +4,7 @@ import SwitchItem from './switch-item.js';
 
 export default {
   height: {
-    value: undefined,
+    value: 0,
     observe(host, value, lastValue) {
       if (lastValue) {
         host.style.height = `${lastValue}px`;
@@ -26,7 +26,7 @@ export default {
   },
   items: children(SwitchItem),
   active: {
-    get: ({ items }) => items.find((item) => item.active),
+    value: ({ items }) => items.find((item) => item.active),
     observe(host) {
       requestAnimationFrame(() => {
         host.height = host.clientHeight;

--- a/packages/ui/src/modules/youtube/components/wall.js
+++ b/packages/ui/src/modules/youtube/components/wall.js
@@ -12,7 +12,7 @@
 import { html, dispatch } from 'hybrids';
 
 export default {
-  content: () => html`
+  render: () => html`
     <template layout="block overflow">
       <ui-onboarding-card layout="padding:2">
         <div layout="row items:start gap:2">


### PR DESCRIPTION
Fixes #1665 

Updates hybrids to `v9.0.0`:

* `content` -> `render`
* Adds `reflect: true` option to properties, which requires it
* Refactor object descriptors with `get`/`set` methods to use `value`

More info about the migration: https://hybrids.js.org/#/migration?id=v900