### PR TITLE
Prevent from throwing when fetching metadata for blobs

### DIFF
--- a/extension-manifest-v3/src/utils/trackerdb.js
+++ b/extension-manifest-v3/src/utils/trackerdb.js
@@ -97,6 +97,9 @@ export function getMetadata(request) {
   }
 
   if (matches.length === 0) {
+    // Blobs and data URLs don't have hostnames
+    if (!request.hostname) return null;
+
     exception = store.get(TrackerException, request.hostname);
 
     if (!store.ready(exception) && !request.blocked && !request.modified) {


### PR DESCRIPTION
Found on Safari on `ghostery.com` where a local blob is created (I suspect the rive animation library) and BG throws an error for non-existing exception (the hostname is an empty string).