### PR TITLE
Force update engines when experimental filters have changed

### DIFF
--- a/extension-manifest-v3/src/utils/engines.js
+++ b/extension-manifest-v3/src/utils/engines.js
@@ -40,6 +40,10 @@ const ENV = new Map([
 
 observe('experimentalFilters', (experimentalFilters) => {
   ENV.set('env_experimental', experimentalFilters);
+
+  // As engines on the server might have new filters, we need to update them
+  updateAll().catch(() => null);
+
   for (const engine of engines.values()) {
     engine.updateEnv(ENV);
   }


### PR DESCRIPTION
There might be a case, where a user turns on the experimental filters, but they won't work as expected. This will happen if the user is in the 60-minute window between automatic updates of the engines.

To fix the issue we need to force the update.