### PR TITLE
Fix resolving options in another contexts

### DIFF
--- a/extension-manifest-v3/src/store/options.js
+++ b/extension-manifest-v3/src/store/options.js
@@ -126,14 +126,12 @@ const Options = {
             : options,
       });
 
-      sync(options, keys)
-        .then(() =>
-          // Send update message to another contexts (background page / panel / options)
-          chrome.runtime.sendMessage({
-            action: UPDATE_OPTIONS_ACTION_NAME,
-          }),
-        )
-        .catch(() => null);
+      // Send update message to another contexts (background page / panel / options)
+      chrome.runtime.sendMessage({
+        action: UPDATE_OPTIONS_ACTION_NAME,
+      });
+
+      sync(options, keys).catch(() => null);
 
       return options;
     },


### PR DESCRIPTION
Fixes resolving to the obsolete version of the options in other contexts, as we were not waiting until the update message was sent when options were updated.