### PR TITLE
Fix sending image src from setter

### DIFF
--- a/extension-manifest-v3/src/content_scripts/whotracksme/ghostery-whotracksme.js
+++ b/extension-manifest-v3/src/content_scripts/whotracksme/ghostery-whotracksme.js
@@ -11,13 +11,17 @@
  */
 (function () {
   function sendMessage(url) {
-    if (!url || url.startsWith('data:')) {
-      return;
+    try {
+      if (!url || url.startsWith('data:')) {
+        return;
+      }
+      window.postMessage(
+        `GhosteryTrackingDetection:${encodeURIComponent(url)}`,
+        '*',
+      );
+    } catch (e) {
+      console.error('Error while sending message:', e);
     }
-    window.postMessage(
-      `GhosteryTrackingDetection:${encodeURIComponent(url)}`,
-      '*',
-    );
   }
 
   let originalXHROpen = null;
@@ -71,8 +75,8 @@
       return originalImageSrc.get.call(this);
     },
     set: function (value) {
-      sendMessage(value);
       originalImageSrc.set.call(this, value);
+      sendMessage(this.src);
     },
     configurable: true,
   });


### PR DESCRIPTION
This is a critical fix for Safari, as we were sending the argument passed to the setter, which can be anything.

In the case where we found the bug, it was the `URL` instance (this is the correct behavior). However, our code tried to call `startsWith` method, which is only available on strings. 

The PR fixes the issue by sending the correct "processed" value from the `src` property. Also, for the sake of not breaking apps in the future, it adds the try/catch to it - if the function throws, the real page app code also throws.