### PR TITLE
Release v10.3.12-1 (Safari migration)

### DIFF
--- a/extension-manifest-v3/package.json
+++ b/extension-manifest-v3/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ghostery/extension-manifest-v3",
   "private": true,
-  "version": "10.3.11",
+  "version": "10.3.12",
   "type": "module",
   "scripts": {
     "download-engines": "node scripts/download-engines/index.js",

--- a/extension-manifest-v3/src/manifest.safari-ios.json
+++ b/extension-manifest-v3/src/manifest.safari-ios.json
@@ -123,7 +123,7 @@
   "content_security_policy" : {},
   "browser_specific_settings": {
     "safari": {
-      "strict_min_version": "15.4"
+      "strict_min_version": "16.4"
     }
   }
 }

--- a/extension-manifest-v3/src/manifest.safari-macos.json
+++ b/extension-manifest-v3/src/manifest.safari-macos.json
@@ -123,7 +123,7 @@
   "content_security_policy" : {},
   "browser_specific_settings": {
     "safari": {
-      "strict_min_version": "15.4"
+      "strict_min_version": "16.4"
     }
   }
 }

--- a/extension-manifest-v3/xcode/Ghostery.xcodeproj/project.pbxproj
+++ b/extension-manifest-v3/xcode/Ghostery.xcodeproj/project.pbxproj
@@ -571,7 +571,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1300;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1540;
 				TargetAttributes = {
 					468E428A2701F84A008B5792 = {
 						CreatedOnToolsVersion = 13.0;
@@ -886,11 +886,12 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 178;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -948,11 +949,12 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 178;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -961,7 +963,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MARKETING_VERSION = 10.3.11;
+				MARKETING_VERSION = 10.3.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -974,12 +976,12 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
-				DEVELOPMENT_TEAM = HPY23A294X;
+				DEVELOPMENT_TEAM = T3NRR7XMGG;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (Extension)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Ghostery – Privacy Ad Blocker Extension";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -990,7 +992,7 @@
 					"-framework",
 					SafariServices,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.ghostery.lite.extension;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ghostery.extension.safari;
 				PRODUCT_NAME = "Ghostery – Privacy Ad Blocker Extension";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1005,12 +1007,12 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
-				DEVELOPMENT_TEAM = HPY23A294X;
+				DEVELOPMENT_TEAM = T3NRR7XMGG;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (Extension)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Ghostery – Privacy Ad Blocker Extension";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1021,7 +1023,7 @@
 					"-framework",
 					SafariServices,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.ghostery.lite.extension;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ghostery.extension.safari;
 				PRODUCT_NAME = "Ghostery – Privacy Ad Blocker Extension";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1040,15 +1042,17 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
-				DEVELOPMENT_TEAM = HPY23A294X;
+				DEVELOPMENT_TEAM = T3NRR7XMGG;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (App)/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "Ghostery – Privacy Ad Blocker";
+				INFOPLIST_KEY_CFBundleDisplayName = Ghostery;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleLightContent;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1060,7 +1064,7 @@
 					"-framework",
 					WebKit,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.ghostery.lite;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ghostery.extension;
 				PRODUCT_NAME = "Ghostery – Privacy Ad Blocker";
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1077,15 +1081,17 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
-				DEVELOPMENT_TEAM = HPY23A294X;
+				DEVELOPMENT_TEAM = T3NRR7XMGG;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "iOS (App)/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "Ghostery – Privacy Ad Blocker";
+				INFOPLIST_KEY_CFBundleDisplayName = Ghostery;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleLightContent;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1097,7 +1103,7 @@
 					"-framework",
 					WebKit,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.ghostery.lite;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ghostery.extension;
 				PRODUCT_NAME = "Ghostery – Privacy Ad Blocker";
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1116,7 +1122,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = HPY23A294X;
+				DEVELOPMENT_TEAM = T3NRR7XMGG;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "macOS (Extension)/Info.plist";
@@ -1133,7 +1139,7 @@
 					"-framework",
 					SafariServices,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.ghostery.lite.extension;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ghostery.extension.safari;
 				PRODUCT_NAME = "Ghostery – Privacy Ad Blocker Extension";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -1151,7 +1157,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = HPY23A294X;
+				DEVELOPMENT_TEAM = T3NRR7XMGG;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "macOS (Extension)/Info.plist";
@@ -1168,7 +1174,7 @@
 					"-framework",
 					SafariServices,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.ghostery.lite.extension;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ghostery.extension.safari;
 				PRODUCT_NAME = "Ghostery – Privacy Ad Blocker Extension";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -1187,9 +1193,9 @@
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = HPY23A294X;
+				DEVELOPMENT_TEAM = T3NRR7XMGG;
 				ENABLE_HARDENED_RUNTIME = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "macOS (App)/Info.plist";
@@ -1209,7 +1215,7 @@
 					"-framework",
 					WebKit,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.ghostery.lite;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ghostery.extension;
 				PRODUCT_NAME = "Ghostery – Privacy Ad Blocker";
 				SDKROOT = macosx;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1226,10 +1232,10 @@
 				CODE_SIGN_ENTITLEMENTS = "macOS (App)/Ghostery – Privacy Ad Blocker.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = HPY23A294X;
-				ENABLE_HARDENED_RUNTIME = NO;
+				DEVELOPMENT_TEAM = T3NRR7XMGG;
+				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "macOS (App)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Ghostery – Privacy Ad Blocker";
@@ -1248,7 +1254,7 @@
 					"-framework",
 					WebKit,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.ghostery.lite;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ghostery.extension;
 				PRODUCT_NAME = "Ghostery – Privacy Ad Blocker";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;

--- a/extension-manifest-v3/xcode/Ghostery.xcodeproj/xcshareddata/xcschemes/Ghostery – Privacy Ad Blocker (iOS).xcscheme
+++ b/extension-manifest-v3/xcode/Ghostery.xcodeproj/xcshareddata/xcschemes/Ghostery – Privacy Ad Blocker (iOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1540"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/extension-manifest-v3/xcode/Ghostery.xcodeproj/xcshareddata/xcschemes/Ghostery – Privacy Ad Blocker (macOS).xcscheme
+++ b/extension-manifest-v3/xcode/Ghostery.xcodeproj/xcshareddata/xcschemes/Ghostery – Privacy Ad Blocker (macOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1540"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/extension-manifest-v3/xcode/iOS (App)/Info.plist
+++ b/extension-manifest-v3/xcode/iOS (App)/Info.plist
@@ -23,7 +23,5 @@
 			</array>
 		</dict>
 	</dict>
-	<key>UIStatusBarStyle</key>
-	<string>UIStatusBarStyleLightContent</string>
 </dict>
 </plist>

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,7 @@
     },
     "extension-manifest-v3": {
       "name": "@ghostery/extension-manifest-v3",
-      "version": "10.3.11",
+      "version": "10.3.12",
       "license": "MPL-2.0",
       "dependencies": {
         "@cliqz/adblocker": "^1.27.11",


### PR DESCRIPTION
* iOS App renamed to `Ghostery`
* Minimal Safari version bumped to `16.4` and macOS to `12` - the oldest version, which supports Safari 16.4

No code change in the extension. We can release this version only to iOS/macOS.