### PR TITLE
Fix panel mobile layout

### DIFF
--- a/extension-manifest-v3/src/pages/panel/components/dialog.js
+++ b/extension-manifest-v3/src/pages/panel/components/dialog.js
@@ -61,9 +61,11 @@ export default {
             <a
               onclick="${animateOnClose}"
               href="${router.backUrl()}"
-              layout="size:3 padding:0.5"
+              layout="padding:2 margin:-2"
             >
-              <ui-icon name="close"></ui-icon>
+              <div layout="row center size:3">
+                <ui-icon name="close" layout="size:2"></ui-icon>
+              </div>
             </a>
           </ui-action>
         </section>
@@ -100,7 +102,7 @@ export default {
       border-bottom: 1px solid var(--ui-color-gray-200);
     }
 
-    a {
+    a > div {
       color: var(--ui-color-gray-600);
       background: var(--ui-color-gray-200);
       border-radius: 50%;

--- a/extension-manifest-v3/src/pages/panel/components/pause.js
+++ b/extension-manifest-v3/src/pages/panel/components/pause.js
@@ -73,6 +73,7 @@ export default {
         id="main"
         class="${{ active: pauseList, paused }}"
         layout="row center margin:1.5 height:6"
+        layout@390px="height:7"
         onclick="${!pauseList && dispatchAction}"
       >
         <div id="label" layout="grow row center gap:0.5 shrink overflow">

--- a/extension-manifest-v3/src/pages/panel/views/home.js
+++ b/extension-manifest-v3/src/pages/panel/views/home.js
@@ -181,6 +181,7 @@ export default {
                   type="${options.panel.statsType}"
                   ontypechange="${setStatsType}"
                   layout="margin:1:1.5"
+                  layout@390px="margin:1.5:1.5:2"
                 >
                   ${options.terms &&
                   html`
@@ -209,6 +210,7 @@ export default {
                     modified=${stats.trackersModified}
                     blocked=${stats.trackersBlocked}
                     layout="margin:bottom:1.5"
+                    layout@390px="padding:top padding:bottom:1.5 margin:bottom:2.5"
                   ></gh-panel-feedback>
                 `}
               `
@@ -233,6 +235,8 @@ export default {
           <ui-text
             class="${{ last: store.error(notification) }}"
             layout.last="padding:bottom:1.5"
+            layout@390px="padding:bottom"
+            layout.last@390px="padding:bottom:2.5"
             hidden="${globalPause}"
           >
             <a

--- a/extension-manifest-v3/src/pages/panel/views/navigation.js
+++ b/extension-manifest-v3/src/pages/panel/views/navigation.js
@@ -117,6 +117,7 @@ export default {
                       <a
                         href="${href}"
                         layout="block padding margin:0:1"
+                        layout@390px="padding:1.5:1"
                         onclick="${openTabWithUrl}"
                       >
                         <gh-panel-menu-item icon="${icon(session)}">

--- a/extension-manifest-v3/src/pages/settings/components/trackers-list.js
+++ b/extension-manifest-v3/src/pages/settings/components/trackers-list.js
@@ -21,14 +21,7 @@ export default {
   trusted: 0,
   blockedByDefault: false,
   open: { value: false, reflect: true },
-  render: ({
-    name,
-    description,
-    size,
-    adjusted,
-    open,
-    blockedByDefault,
-  }) => html`
+  render: ({ name, size, adjusted, open, blockedByDefault }) => html`
     <template layout="column gap:2 padding:1.5">
       <header layout="row items:center gap:1.5" layout@768px="gap:2">
         <ui-action>
@@ -48,23 +41,7 @@ export default {
               layout="size:5 padding"
             ></ui-panel-category-icon>
             <div layout="column gap:0.5">
-              <ui-text type="label-l">
-                ${labels.categories[name]}<ui-tooltip
-                  delay="0"
-                  autohide="5"
-                  wrap
-                  inline
-                >
-                  <span slot="content" layout="block width:200px">
-                    ${description}
-                  </span>
-                  <ui-icon
-                    name="info"
-                    color="gray-400"
-                    layout="margin:top:1px"
-                  ></ui-icon>
-                </ui-tooltip>
-              </ui-text>
+              <ui-text type="label-l">${labels.categories[name]}</ui-text>
               <div layout="column" layout@768px="row gap">
                 <ui-text type="body-s" color="gray-600" layout="width::90px">
                   Activities<span>:</span> ${size}

--- a/packages/ui/src/modules/global/components/tooltip.js
+++ b/packages/ui/src/modules/global/components/tooltip.js
@@ -109,6 +109,10 @@ export default {
       </div>
     </template>
   `.css`
+    @media (hover: none) {
+      #tooltip { display: none; }
+    }
+
     #tooltip {
       pointer-events: none;
       transform: translateX(-50%);

--- a/packages/ui/src/modules/panel/components/header.js
+++ b/packages/ui/src/modules/panel/components/header.js
@@ -15,6 +15,7 @@ export default {
   render: () => html`
     <template
       layout="grid:max|1|max items:center gap:2 height:6 padding:1.5 relative layer:100"
+      layout@390px="height:7 padding:2"
     >
       <div layout="row center width:3">
         <slot name="icon"></slot>


### PR DESCRIPTION
Surprisingly, the mobile panel is wider (we are using the full width of the device) than on the desktop (fixed width of 350px). The main constraint of the panel is its height, which on the desktop has 600px maximum. This is why we "shrank" the layout, making spacing small. As this looks fine on desktop, on mobile where there is a different dpi, the panel looks squeezed. 

I made a few small tweaks to the spacing, some fixes to hover states, and fixed the size of the "x" button on the panel dialogs (it was hard to reach on mobile).

Before / After (Firefox Android - Zenphone 10 - 5.9' device)

<img src="https://github.com/ghostery/ghostery-extension/assets/1906677/7a3d1ca8-d4f3-4443-9e2e-98021adcbcaa" width="300">
<img src="https://github.com/ghostery/ghostery-extension/assets/1906677/ce71ac38-fba9-425a-9ed1-cad795aaa7b4" width="300">

<img src="https://github.com/ghostery/ghostery-extension/assets/1906677/6f07e3a5-4e2c-4e5d-ad51-472894efe0d2" width="300">
<img src="https://github.com/ghostery/ghostery-extension/assets/1906677/f6920375-32d5-419f-b4f5-48b22c8c77e9" width="300">




