### PR TITLE
Fix skip scriptlets in subframes of paused main frames

### DIFF
--- a/extension-manifest-v3/src/background/adblocker.js
+++ b/extension-manifest-v3/src/background/adblocker.js
@@ -21,7 +21,7 @@ import * as engines from '/utils/engines.js';
 import Request from './utils/request.js';
 import asyncSetup from './utils/setup.js';
 
-import { updateTabStats } from './stats.js';
+import { tabStats, updateTabStats } from './stats.js';
 
 let enabledEngines = [];
 let pausedHostnames = new Set();
@@ -276,7 +276,9 @@ ${scripts.join('\n\n')}}
 
 async function injectScriptlets(tabId, url) {
   const { hostname, domain } = parse(url);
-  if (!hostname || isPaused(hostname)) {
+  const tabHostname = tabStats.get(tabId)?.hostname;
+
+  if (!hostname || isPaused(hostname) || isPaused(tabHostname)) {
     return;
   }
 

--- a/extension-manifest-v3/src/manifest.safari-ios.json
+++ b/extension-manifest-v3/src/manifest.safari-ios.json
@@ -81,7 +81,8 @@
       "run_at": "document_start",
       "js": [
         "content_scripts/adblocker-scriptlets.js"
-      ]
+      ],
+      "all_frames": true
     },
     {
       "matches": ["http://*/*", "https://*/*"],

--- a/extension-manifest-v3/src/manifest.safari-macos.json
+++ b/extension-manifest-v3/src/manifest.safari-macos.json
@@ -81,7 +81,8 @@
       "run_at": "document_start",
       "js": [
         "content_scripts/adblocker-scriptlets.js"
-      ]
+      ],
+      "all_frames": true
     },
     {
       "matches": ["http://*/*", "https://*/*"],


### PR DESCRIPTION
* Adds `all_frames` to Safari mechanism of triggering scriptlets to unify the feature with Chromium-based browsers (which relay on event listeners in BG)
* Checks the main frame hostname if it is paused and skips the scriptlets if required