### PR TITLE
Fixes the error when opening a new tab

### DIFF
--- a/extension-manifest-v3/src/background/adblocker.js
+++ b/extension-manifest-v3/src/background/adblocker.js
@@ -276,9 +276,12 @@ ${scripts.join('\n\n')}}
 
 async function injectScriptlets(tabId, url) {
   const { hostname, domain } = parse(url);
-  const tabHostname = tabStats.get(tabId)?.hostname;
+  if (!hostname || isPaused(hostname)) {
+    return;
+  }
 
-  if (!hostname || isPaused(hostname) || isPaused(tabHostname)) {
+  const tabHostname = tabStats.get(tabId)?.hostname;
+  if (tabHostname && isPaused(tabHostname)) {
     return;
   }
 


### PR DESCRIPTION
```
adblocker.js:56 Uncaught (in promise)
TypeError: Cannot read properties of undefined (reading 'replace')
    at isPaused (ablocker.js:56:34)
    at injectScriptlets (adblocker.js:277:42)
    at adblocker.js:319:5
 ```

refs https://github.com/ghostery/ghostery-extension/pull/1711