### PR TITLE
Fix stats requests urls

### DIFF
--- a/extension-manifest-v3/src/pages/panel/components/copy.js
+++ b/extension-manifest-v3/src/pages/panel/components/copy.js
@@ -6,16 +6,20 @@ function copy(host) {
 }
 
 export default {
-  render: () => html`
+  value: (host) => host.textContent.trim(),
+  render: ({ value }) => html`
     <template layout="contents">
       <ui-action>
         <button onclick="${copy}" layout="block padding margin:-1">
-          <div layout="row content:space-between items:center gap:0.5">
-            <ui-text type="body-s" color="gray-600" ellipsis>
-              <slot></slot>
-            </ui-text>
-            <ui-icon name="copy" layout="shrink:0"></ui-icon>
-          </div>
+          <ui-tooltip position="bottom" delay="0.5" autohide="0">
+            <div layout="row content:space-between items:center gap:0.5">
+              <ui-text id="full" type="body-s" color="gray-600" ellipsis>
+                <slot></slot>
+              </ui-text>
+              <ui-icon name="copy" layout="shrink:0"></ui-icon>
+            </div>
+            <div slot="content" id="tooltip">${value}</div>
+          </ui-tooltip>
         </button>
       </ui-action>
     </template>
@@ -24,7 +28,14 @@ export default {
       color: var(--ui-color-gray-400);
     }
 
-    @media (hover: hover) and (pointer: fine) {
+    #tooltip {
+      width: max-content;
+      max-width: 80vw;
+      text-wrap: wrap;
+      word-break: break-all;
+    }
+
+    @media (hover: hover) {
       button:hover ui-text, button:hover ui-icon {
         --ui-text-color: var(--ui-color-primary-700);
         color: var(--ui-color-primary-700);


### PR DESCRIPTION
Fixes #1730

I kept the hard limit of a number of requests to avoid memory leaks. For example, it takes just a few minutes on the youtube.com tab to grab more than 500+ request URLs in stats (once after just 2-3 minutes of navigation on YT I had 78 unique blocked requests). As there are users, who have a lot of open tabs, it is not safe to not limit requests.

Additionally, I added a helpful tooltip over the URL to show the full text of it when hovering.

<img width="344" alt="Zrzut ekranu 2024-07-9 o 15 48 14" src="https://github.com/ghostery/ghostery-extension/assets/1906677/14c520ec-c366-4165-aa48-9f3bd24277e6">
