### PR TITLE
Fix WTM tracker wheel default options value

### DIFF
--- a/extension-manifest-v3/src/store/options.js
+++ b/extension-manifest-v3/src/store/options.js
@@ -46,7 +46,7 @@ const Options = {
   blockAnnoyances: true,
 
   // Browser icon
-  trackerWheel: __PLATFORM__ === 'safari',
+  trackerWheel: __PLATFORM__ !== 'firefox',
   ...(__PLATFORM__ !== 'safari' ? { trackerCount: true } : {}),
 
   // SERP


### PR DESCRIPTION
The default tracker wheel value was set to `false` only for the existing users from v8 to v10. 

As only Firefox is left and the majority of users on other platforms migrated, the value can be brought back to the correct value. 

This change only affects new installations.