### PR TITLE
Refactor `paused` option to use `store.record()`

### DIFF
--- a/extension-manifest-v2/package.json
+++ b/extension-manifest-v2/package.json
@@ -52,7 +52,7 @@
     "foundation-sites": "^6.6.2",
     "ghostery-common": "^1.3.16",
     "history": "^4.10.1",
-    "hybrids": "^9.0.0",
+    "hybrids": "^9.1.0",
     "linkedom": "^0.16.11",
     "moment": "^2.29.1",
     "prop-types": "^15.6.2",

--- a/extension-manifest-v3/package.json
+++ b/extension-manifest-v3/package.json
@@ -42,7 +42,7 @@
     "@ghostery/ui": "^1.0.0",
     "@github/relative-time-element": "^4.3.0",
     "@whotracksme/reporting": "^5.1.17",
-    "hybrids": "^9.0.0",
+    "hybrids": "^9.1.0",
     "idb": "^7.1.1",
     "jwt-decode": "^4.0.0",
     "tldts-experimental": "^6.0.19"

--- a/extension-manifest-v3/src/background/autoconsent.js
+++ b/extension-manifest-v3/src/background/autoconsent.js
@@ -14,19 +14,15 @@ import { snippets } from '@duckduckgo/autoconsent/lib/eval-snippets';
 import { parse } from 'tldts-experimental';
 import { store } from 'hybrids';
 
-import Options, { isGlobalPaused } from '/store/options.js';
+import Options, { isPaused } from '/store/options.js';
 
 async function initialize(msg, tab, frameId) {
   const options = await store.resolve(Options);
-  const { terms, blockAnnoyances, paused } = options;
-
-  const pureHostname = tab.url && parse(tab.url).hostname.replace(/^www\./, '');
 
   if (
-    !isGlobalPaused(options) &&
-    terms &&
-    blockAnnoyances &&
-    (!pureHostname || !paused.some(({ id }) => id === pureHostname))
+    options.terms &&
+    options.blockAnnoyances &&
+    !isPaused(options, tab.url ? parse(tab.url).hostname : '')
   ) {
     try {
       chrome.tabs.sendMessage(

--- a/extension-manifest-v3/src/background/dnr.js
+++ b/extension-manifest-v3/src/background/dnr.js
@@ -9,7 +9,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import { observe, ENGINES, isGlobalPaused } from '/store/options.js';
+import { observe, ENGINES, isPaused } from '/store/options.js';
 import { TRACKERDB_ENGINE } from '/utils/engines.js';
 
 const PAUSE_RULE_PRIORITY = 10000000;
@@ -40,8 +40,8 @@ if (__PLATFORM__ !== 'firefox') {
   // Ensure that DNR rulesets are equal to those from options.
   // eg. when web extension updates, the rulesets are reset
   // to the value from the manifest.
-  observe(null, async (options) => {
-    const globalPause = isGlobalPaused(options);
+  observe(async (options) => {
+    const globalPause = isPaused(options);
     const ids = ENGINES.map(({ name, key }) => {
       return !globalPause && options.terms && options[key] ? name : '';
     }).filter((id) => id && DNR_RESOURCES.includes(id));
@@ -86,10 +86,9 @@ if (__PLATFORM__ !== 'firefox') {
     if (!prevPaused) return;
 
     const dynamicRules = await chrome.declarativeNetRequest.getDynamicRules();
+    const hostnames = Object.keys(paused);
 
-    if (paused.length) {
-      const hostnames = paused.map(({ id }) => id);
-
+    if (hostnames.length) {
       await chrome.declarativeNetRequest.updateDynamicRules({
         addRules:
           __PLATFORM__ === 'safari'

--- a/extension-manifest-v3/src/background/onboarding.js
+++ b/extension-manifest-v3/src/background/onboarding.js
@@ -21,7 +21,7 @@ const NOTIFICATION_TRACKERS_THRESHOLD = 10;
 let done = false;
 let shownAt = 0;
 
-observe(null, (options) => {
+observe((options) => {
   ({ done, shownAt } = options.onboarding);
 
   if (!done && !shownAt) {

--- a/extension-manifest-v3/src/background/serp.js
+++ b/extension-manifest-v3/src/background/serp.js
@@ -16,7 +16,7 @@ import {
 } from '@ghostery/trackers-preview/background';
 import css from '@ghostery/trackers-preview/content_scripts/styles.css?raw';
 
-import Options, { isGlobalPaused } from '/store/options.js';
+import Options, { isPaused } from '/store/options.js';
 
 const SERP_URL_REGEXP =
   /^https:[/][/][^/]*[.]google[.][a-z]+([.][a-z]+)?[/]search/;
@@ -38,7 +38,7 @@ chrome.webNavigation.onCommitted.addListener((details) => {
 
         if (options.wtmSerpReport)
           files.push('/content_scripts/trackers-preview.js');
-        if (!isGlobalPaused(options) && options.serpTrackingPrevention)
+        if (!isPaused(options) && options.serpTrackingPrevention)
           files.push('/content_scripts/prevent-serp-tracking.js');
 
         chrome.scripting.executeScript(

--- a/extension-manifest-v3/src/background/stats.js
+++ b/extension-manifest-v3/src/background/stats.js
@@ -15,7 +15,7 @@ import { getOffscreenImageData } from '@ghostery/ui/wheel';
 import { order } from '@ghostery/ui/categories';
 
 import DailyStats from '/store/daily-stats.js';
-import Options, { isGlobalPaused, observe } from '/store/options.js';
+import Options, { isPaused, observe } from '/store/options.js';
 
 import { shouldSetDangerBadgeForTabId } from '/notifications/opera-serp.js';
 import AutoSyncingMap from '/utils/map.js';
@@ -58,10 +58,7 @@ async function refreshIcon(tabId) {
   const stats = tabStats.get(tabId);
   if (!stats) return;
 
-  const inactive =
-    isGlobalPaused(options) ||
-    !options.terms ||
-    options.paused.some(({ id }) => id === stats.hostname);
+  const inactive = !options.terms || isPaused(options, stats.hostname);
 
   const data = {};
   if (options.trackerWheel && stats.trackers.length > 0) {

--- a/extension-manifest-v3/src/content_scripts/youtube.js
+++ b/extension-manifest-v3/src/content_scripts/youtube.js
@@ -11,6 +11,7 @@
 
 import { showIframe, closeIframe } from '@ghostery/ui/iframe';
 import detectWall from '@ghostery/ui/youtube/wall';
+import { isPaused } from '/store/options';
 
 async function isFeatureDisabled() {
   const { options, youtubeDontAsk } = await chrome.storage.local.get([
@@ -21,10 +22,10 @@ async function isFeatureDisabled() {
   if (
     // User's choice to not show the wall
     youtubeDontAsk ||
-    // Terms not accepted or paused domain
+    // Terms not accepted or paused
     !options ||
     !options.terms ||
-    options.paused.some(({ id }) => id.includes('youtube.com'))
+    isPaused(options, 'youtube.com')
   ) {
     return true;
   }

--- a/extension-manifest-v3/src/pages/panel/views/tracker-details.js
+++ b/extension-manifest-v3/src/pages/panel/views/tracker-details.js
@@ -54,8 +54,7 @@ export default {
     tracker.category !== 'unidentified' &&
     `https://www.ghostery.com/whotracksme/trackers/${tracker.id}`,
   paused: ({ options, stats }) =>
-    store.ready(options, stats) &&
-    options.paused.find(({ id }) => id === stats.hostname),
+    store.ready(options, stats) && !!options.paused[stats.hostname],
   render: ({ tracker, status, wtmUrl, paused, options }) => html`
     <template layout="column">
       <gh-panel-dialog>

--- a/extension-manifest-v3/src/pages/settings/views/privacy.js
+++ b/extension-manifest-v3/src/pages/settings/views/privacy.js
@@ -25,21 +25,13 @@ function toggleNeverConsent({ options }) {
 function updateGlobalPause({ options }, value, lastValue) {
   if (lastValue === undefined) return;
 
-  if (!value) {
-    store.set(options, {
-      paused: options.paused.filter((p) => p.id !== GLOBAL_PAUSE_ID),
-    });
-  } else if (!options.paused.find((p) => p.id === GLOBAL_PAUSE_ID)) {
-    store.set(options, {
-      paused: [
-        ...options.paused,
-        {
-          id: GLOBAL_PAUSE_ID,
-          revokeAt: Date.now() + 24 * 60 * 60 * 1000,
-        },
-      ],
-    });
-  }
+  store.set(options, {
+    paused: {
+      [GLOBAL_PAUSE_ID]: value
+        ? { revokeAt: Date.now() + 24 * 60 * 60 * 1000 }
+        : null,
+    },
+  });
 }
 
 export default {
@@ -52,8 +44,7 @@ export default {
   },
   globalPauseRevokeAt: {
     value: ({ options }) =>
-      store.ready(options) &&
-      options.paused.find((p) => p.id === GLOBAL_PAUSE_ID)?.revokeAt,
+      store.ready(options) && options.paused[GLOBAL_PAUSE_ID]?.revokeAt,
     observe: (host, value) => {
       host.globalPause = value;
     },

--- a/extension-manifest-v3/src/pages/settings/views/website-details.js
+++ b/extension-manifest-v3/src/pages/settings/views/website-details.js
@@ -45,7 +45,7 @@ function removeDomain(tracker) {
 
 function revokePaused({ options, domain }) {
   store.set(options, {
-    paused: options.paused.filter((p) => p.id !== domain),
+    paused: { [domain]: null },
   });
 }
 
@@ -66,7 +66,7 @@ export default {
   },
   options: store(Options),
   paused: ({ options, domain }) =>
-    (store.ready(options) && options.paused.find((p) => p.id === domain)) || {},
+    (store.ready(options) && options.paused[domain]) || {},
   render: ({ domain, trackers, paused }) => html`
     <template layout="contents">
       <gh-settings-page-layout layout="gap:4">

--- a/extension-manifest-v3/src/pages/settings/views/websites-add.js
+++ b/extension-manifest-v3/src/pages/settings/views/websites-add.js
@@ -20,18 +20,14 @@ async function add({ options, hostname, pauseType }, event) {
   router.resolve(
     event,
     store.submit(hostname).then(({ value }) => {
-      if (options.paused.some((p) => p.id === value)) {
-        return;
-      }
+      if (options.paused[value]) return;
 
       return store.set(options, {
-        paused: [
-          ...options.paused,
-          {
-            id: value,
+        paused: {
+          [value]: {
             revokeAt: pauseType && Date.now() + 60 * 60 * 1000 * pauseType,
           },
-        ],
+        },
       });
     }),
   );

--- a/extension-manifest-v3/src/pages/settings/views/websites.js
+++ b/extension-manifest-v3/src/pages/settings/views/websites.js
@@ -30,9 +30,7 @@ function revoke(host, item) {
     }
   }
 
-  store.set(host.options, {
-    paused: host.options.paused.filter((p) => p.id !== item.id),
-  });
+  store.set(host.options, { paused: { [item.id]: null } });
 }
 
 function revokeCallback(item) {
@@ -48,7 +46,6 @@ export default {
   [router.connect]: { stack: [WebsiteDetails, WebsitesAdd] },
   options: store(Options),
   query: '',
-  paused: ({ options }) => (store.ready(options) ? options.paused : []),
   exceptions: () => {
     const exceptions = store.get([TrackerException]);
     if (!store.ready(exceptions)) return [];
@@ -70,7 +67,14 @@ export default {
 
     return [...domains.entries()];
   },
-  websites: ({ paused, exceptions, query }) => {
+  websites: ({ options, exceptions, query }) => {
+    const paused = store.ready(options)
+      ? Object.entries(options.paused).map(([id, { revokeAt }]) => ({
+          id,
+          revokeAt,
+        }))
+      : [];
+
     query = query.toLowerCase().trim();
 
     return [

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "foundation-sites": "^6.6.2",
         "ghostery-common": "^1.3.16",
         "history": "^4.10.1",
-        "hybrids": "^9.0.0",
+        "hybrids": "^9.1.0",
         "linkedom": "^0.16.11",
         "moment": "^2.29.1",
         "prop-types": "^15.6.2",
@@ -119,7 +119,7 @@
         "@ghostery/ui": "^1.0.0",
         "@github/relative-time-element": "^4.3.0",
         "@whotracksme/reporting": "^5.1.17",
-        "hybrids": "^9.0.0",
+        "hybrids": "^9.1.0",
         "idb": "^7.1.1",
         "jwt-decode": "^4.0.0",
         "tldts-experimental": "^6.0.19"
@@ -10066,9 +10066,9 @@
       }
     },
     "node_modules/hybrids": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/hybrids/-/hybrids-9.0.0.tgz",
-      "integrity": "sha512-BEwhBvhJlUB3cKJJbnrKrsdr871T1VC/tDL5Umeuoy4DWz9ssJNldgYot4QP8zHPPxUlUpGv+41QYq9m4kzQ5g==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hybrids/-/hybrids-9.1.0.tgz",
+      "integrity": "sha512-4l9+/c/MZzgou94yz6vfUo+ZYCmKJ/lC5DFxmbfbAheujdvscya3zj+NeLQ1+Cwa5hLPGPxuUkdAIYeMwkgjvw==",
       "bin": {
         "hybrids": "cli/index.js"
       },
@@ -16424,13 +16424,10 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.0.tgz",
-      "integrity": "sha512-bfJaPTuEiTYBu+ulDaeQ0F+uLmlfFkMgXj4cbwfuMSjgObGMzb55FMMbDvbRU0fAHZ4sLGkz2mKwcMg8Dvm8Ww==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      }
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
     },
     "node_modules/path-to-regexp": {
       "version": "1.8.0",
@@ -21222,7 +21219,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/libs": "^1.0.0",
-        "hybrids": "^9.0.0"
+        "hybrids": "^9.1.0"
       }
     }
   }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,6 +21,6 @@
   },
   "dependencies": {
     "@ghostery/libs": "^1.0.0",
-    "hybrids": "^9.0.0"
+    "hybrids": "^9.1.0"
   }
 }


### PR DESCRIPTION
* Uses `store.record()` for `options.paused`
* Simplifies checking if the domain is paused or there is a global pause by one `isPaused()` function
* No more generating keys from options
* Updates hybrids to `v9.1.0`