### PR TITLE
Add option "--no-filename-limit"

### DIFF
--- a/extension-manifest-v3/scripts/build.js
+++ b/extension-manifest-v3/scripts/build.js
@@ -287,8 +287,8 @@ const buildPromise = build({
             .replace('_virtual', 'virtual');
 
           const path = name.replace(resolve(pwd, '..'), '');
-          if (path.length > 100) {
-            throw new Error(`Filename too long: ${path} (${path.length})`);
+          if (path.length > 100 && !argv['no-filename-limits']) {
+            throw new Error(`Filename too long: ${path} (${path.length}) (pass --no-filename-limit to disable)`);
           }
 
           return name;


### PR DESCRIPTION
To bypass the maximum filename restriction when using "npm link" locally.