### PR TITLE
Fix exceptions DNR rules update

### DIFF
--- a/extension-manifest-v3/src/background/dnr.js
+++ b/extension-manifest-v3/src/background/dnr.js
@@ -12,26 +12,26 @@
 import { observe, ENGINES, isPaused } from '/store/options.js';
 import { TRACKERDB_ENGINE } from '/utils/engines.js';
 
-const PAUSE_RULE_PRIORITY = 10000000;
-
-const ALL_RESOURCE_TYPES = [
-  'main_frame',
-  'sub_frame',
-  'stylesheet',
-  'script',
-  'image',
-  'font',
-  'object',
-  'xmlhttprequest',
-  'ping',
-  'media',
-  'websocket',
-  'webtransport',
-  'webbundle',
-  'other',
-];
-
 if (__PLATFORM__ !== 'firefox') {
+  const PAUSE_RULE_PRIORITY = 10000000;
+
+  const ALL_RESOURCE_TYPES = [
+    'main_frame',
+    'sub_frame',
+    'stylesheet',
+    'script',
+    'image',
+    'font',
+    'object',
+    'xmlhttprequest',
+    'ping',
+    'media',
+    'websocket',
+    'webtransport',
+    'webbundle',
+    'other',
+  ];
+
   const DNR_RESOURCES = chrome.runtime
     .getManifest()
     .declarative_net_request.rule_resources.filter(({ enabled }) => !enabled)
@@ -42,6 +42,7 @@ if (__PLATFORM__ !== 'firefox') {
   // to the value from the manifest.
   observe(async (options) => {
     const globalPause = isPaused(options);
+
     const ids = ENGINES.map(({ name, key }) => {
       return !globalPause && options.terms && options[key] ? name : '';
     }).filter((id) => id && DNR_RESOURCES.includes(id));
@@ -74,21 +75,30 @@ if (__PLATFORM__ !== 'firefox') {
           enableRulesetIds,
           disableRulesetIds,
         });
-        console.info('DNR - Lists successfully updated');
+        console.info('DNR: lists successfully updated');
       } catch (e) {
-        console.error(`DNR - Error while updating lists:`, e);
+        console.error(`DNR: error while updating lists:`, e);
       }
     }
   });
 
+  const getPauseRulesIds = async () => {
+    return (await chrome.declarativeNetRequest.getDynamicRules())
+      .filter(({ id }) => id <= 3)
+      .map(({ id }) => id);
+  };
+
   observe('paused', async (paused, prevPaused) => {
-    // Skip if hostnames has not changed
+    // The background process starts and runs for each tab, so we can assume
+    // that this function is called before the user can change the paused state
+    // in the panel or the settings page.
     if (!prevPaused) return;
 
-    const dynamicRules = await chrome.declarativeNetRequest.getDynamicRules();
     const hostnames = Object.keys(paused);
 
     if (hostnames.length) {
+      const removeRuleIds = await getPauseRulesIds();
+
       await chrome.declarativeNetRequest.updateDynamicRules({
         addRules:
           __PLATFORM__ === 'safari'
@@ -132,12 +142,17 @@ if (__PLATFORM__ !== 'firefox') {
                   },
                 },
               ],
-        removeRuleIds: dynamicRules.map(({ id }) => id),
+        removeRuleIds,
       });
-    } else if (dynamicRules.length) {
-      await chrome.declarativeNetRequest.updateDynamicRules({
-        removeRuleIds: __PLATFORM__ === 'safari' ? [1] : [1, 2, 3],
-      });
+    } else {
+      const removeRuleIds = await getPauseRulesIds();
+      if (removeRuleIds.length) {
+        await chrome.declarativeNetRequest.updateDynamicRules({
+          removeRuleIds,
+        });
+      }
     }
+
+    console.log('DNR: pause rules updated');
   });
 }

--- a/extension-manifest-v3/src/background/exceptions.js
+++ b/extension-manifest-v3/src/background/exceptions.js
@@ -11,7 +11,7 @@
 
 import { parseFilter } from '@cliqz/adblocker';
 
-import { getTracker, isCategoryBlockedByDefault } from '../utils/trackerdb.js';
+import * as trackerdb from '../utils/trackerdb.js';
 
 import {
   createDocumentConverter,
@@ -67,12 +67,14 @@ async function convertExceptionsToFilters(exceptions) {
   const filters = [];
 
   for (const exception of Object.values(exceptions)) {
-    const pattern = (await getTracker(exception.id)) || {
+    const pattern = (await trackerdb.getTracker(exception.id)) || {
       domains: [exception.id],
       filters: [],
     };
 
-    const blockedByDefault = isCategoryBlockedByDefault(pattern.category);
+    const blockedByDefault = trackerdb.isCategoryBlockedByDefault(
+      pattern.category,
+    );
 
     const blockFilters = pattern.filters.map((filter) => parseFilter(filter));
 
@@ -108,38 +110,6 @@ async function convertExceptionsToFilters(exceptions) {
   return filters;
 }
 
-let exceptions = {};
-
-chrome.storage.local.get(['exceptions']).then((result) => {
-  exceptions = result.exceptions || {};
-});
-
-chrome.storage.onChanged.addListener(async (changes) => {
-  if (!changes['exceptions']) {
-    return;
-  }
-
-  exceptions = changes['exceptions'].newValue || {};
-
-  const filters = await convertExceptionsToFilters(exceptions);
-
-  const networkFilters = [];
-  const cosmeticFilters = [];
-
-  for (const filter of filters) {
-    if (filter.isNetworkFilter()) {
-      networkFilters.push(filter.toString());
-    } else if (filter.isCosmeticFilter()) {
-      cosmeticFilters.push(filter.toString());
-    }
-  }
-  if (__PLATFORM__ !== 'firefox') {
-    await updateDNRRules(networkFilters);
-  }
-
-  console.info('Exceptions - Filters updated successfully');
-});
-
 async function updateDNRRules(networkFilters) {
   const dnrRules = [];
   for (const filter of networkFilters) {
@@ -162,8 +132,39 @@ async function updateDNRRules(networkFilters) {
   const removeRuleIds = (await chrome.declarativeNetRequest.getDynamicRules())
     .filter(({ id }) => id >= 2000000)
     .map(({ id }) => id);
+
   await chrome.declarativeNetRequest.updateDynamicRules({
     addRules,
     removeRuleIds,
   });
 }
+
+async function updateFilters() {
+  const { exceptions = {} } = await chrome.storage.local.get(['exceptions']);
+  const filters = await convertExceptionsToFilters(exceptions);
+
+  const networkFilters = [];
+  const cosmeticFilters = [];
+
+  for (const filter of filters) {
+    if (filter.isNetworkFilter()) {
+      networkFilters.push(filter.toString());
+    } else if (filter.isCosmeticFilter()) {
+      cosmeticFilters.push(filter.toString());
+    }
+  }
+
+  if (__PLATFORM__ !== 'firefox') {
+    await updateDNRRules(networkFilters);
+  }
+
+  console.info('Exceptions: filters updated successfully');
+}
+
+// Update exceptions filters every time exceptions change
+chrome.storage.onChanged.addListener(async (changes) => {
+  if (changes['exceptions']) updateFilters();
+});
+
+// Update exceptions filters every time TrackerDB updates
+trackerdb.addUpdateListener(updateFilters);

--- a/extension-manifest-v3/src/store/options.js
+++ b/extension-manifest-v3/src/store/options.js
@@ -48,7 +48,7 @@ const Options = {
   blockAnnoyances: true,
 
   // Browser icon
-  trackerWheel: __PLATFORM__ !== 'firefox',
+  trackerWheel: __PLATFORM__ !== 'firefox' ? true : false,
   ...(__PLATFORM__ !== 'safari' ? { trackerCount: true } : {}),
 
   // SERP

--- a/extension-manifest-v3/src/utils/dnr-converter.js
+++ b/extension-manifest-v3/src/utils/dnr-converter.js
@@ -31,8 +31,10 @@ export function createDocumentConverter() {
     iframe.setAttribute('src', 'https://ghostery.github.io/urlfilter2dnr/');
     iframe.setAttribute('style', 'display: none;');
 
-    documentConverter = new Promise((resolve) => {
+    documentConverter = new Promise((resolve, reject) => {
       iframe.addEventListener('load', () => resolve(iframe));
+      iframe.addEventListener('error', reject);
+
       document.head.appendChild(iframe);
     });
 

--- a/extension-manifest-v3/src/utils/trackerdb.js
+++ b/extension-manifest-v3/src/utils/trackerdb.js
@@ -206,3 +206,7 @@ export async function getCategories() {
       (a, b) => categoryOrder.indexOf(a.key) - categoryOrder.indexOf(b.key),
     );
 }
+
+export function addUpdateListener(fn) {
+  engines.addUpdateListener(engines.TRACKERDB_ENGINE, fn);
+}


### PR DESCRIPTION
Trusting the website was removinfg the exception DNR rules, as there was not filter on the ids to be updated (before the exceptions it was just fine).

Reproduce bug path:

1. Open any page with a tracker from essential category and add global exception to block that tracker
2. Trust and untrust the page
3. Look at the tracker urls - they are not blocked (but they should)

The bug is about clearing rules, which blocked the tracker when exception was added.

The PR fixes the issue by:
1. Filter the ids for general DNR rulesets
2. Add `addUpdateListener` pattern to watch when TrackerDB changes, so then we must update exceptions (the filters might have changed)

The fix also will fix current broken state of the users by the 2nd point - as those users with less than hour (1 hour is a scheduled update of engines) the filters will be reloaded.
