### PR TITLE
Better error message

### DIFF
--- a/extension-manifest-v3/scripts/build.js
+++ b/extension-manifest-v3/scripts/build.js
@@ -289,7 +289,7 @@ const buildPromise = build({
           const path = name.replace(resolve(pwd, '..'), '');
           if (path.length > 100 && !argv['no-filename-limit']) {
             throw new Error(
-              `Filename too long: ${path} (${path.length}) (pass --no-filename-limit to disable)`,
+              `Filename too long: ${path} (${path.length}) (pass --no-filename-limit to disable; for instance, "npm run build firefox -- --no-filename-limit")`,
             );
           }
 


### PR DESCRIPTION
Include an example to avoid the pitfall:

```
npm run build firefox -- --no-filename-limit   # correct
```
vs
```
npm run build firefox --no-filename-limit   # wrong: flag not set
```