### PR TITLE
Fix UI for the protection status dialog

### DIFF
--- a/extension-manifest-v3/src/pages/panel/views/protection-status.js
+++ b/extension-manifest-v3/src/pages/panel/views/protection-status.js
@@ -13,19 +13,14 @@ function toggleDomain({ stats, tracker }) {
   );
 }
 
-function updateStatus(host, event) {
-  const value = event.target.value;
-  const exception = host.tracker.exception;
-
-  store.set(
-    exception,
-    store.ready(exception) &&
-      value === host.tracker.blockedByDefault &&
-      !exception.blockedDomains.length &&
-      !exception.trustedDomains.length
-      ? null
-      : { blocked: value },
-  );
+function toggleBlocked({ tracker, blocked, status }) {
+  if (!status.website && store.ready(tracker.exception)) {
+    store.set(tracker.exception, null);
+  } else {
+    store.set(tracker.exception, {
+      blocked: !blocked,
+    });
+  }
 }
 
 export default {
@@ -38,13 +33,11 @@ export default {
     store.ready(tracker.exception)
       ? tracker.exception.blocked
       : tracker.blockedByDefault,
-  blockedOnSite: ({ stats, tracker }) =>
-    store.ready(tracker.exception) &&
-    tracker.exception.blockedDomains.includes(stats.hostname),
-  allowedOnSite: ({ stats, tracker }) =>
-    store.ready(tracker.exception) &&
-    tracker.exception.trustedDomains.includes(stats.hostname),
-  render: ({ stats, tracker, blocked, blockedOnSite, allowedOnSite }) => html`
+  status: ({ stats, tracker }) =>
+    store.ready(tracker.exception)
+      ? tracker.exception.getDomainStatus(stats.hostname)
+      : { type: tracker.blockedByDefault ? 'block' : 'trust' },
+  render: ({ stats, tracker, blocked, status }) => html`
     <template layout="column">
       <gh-panel-dialog>
         <div
@@ -61,44 +54,61 @@ export default {
         </ui-text>
         ${(store.ready(tracker.exception) || store.error(tracker.exception)) &&
         html`
-          <div layout="column gap:3">
-            <div layout="column gap">
-              <div layout="block:center grow">
-                <ui-text type="label-l">Protection status</ui-text>
-                <ui-text type="body-m" color="gray-500">
-                  For all websites
+          <div layout="column gap:2">
+            <div layout="column items:center gap:0.5">
+              <ui-text type="body-s">Protection status</ui-text>
+              <div layout="row items:center gap:0.5">
+                <ui-icon
+                  name="${status.type}-m"
+                  color="gray-600"
+                  layout="size:2"
+                ></ui-icon>
+                <ui-text type="label-m">
+                  ${status.website
+                    ? (status.type === 'trust' &&
+                        msg`Trusted on this website`) ||
+                      (status.type === 'block' && msg`Blocked on this website`)
+                    : (status.type === 'trust' &&
+                        msg`Trusted on all websites`) ||
+                      (status.type === 'block' && msg`Blocked on all websites`)}
                 </ui-text>
               </div>
-              <ui-panel-protection-status-toggle
-                layout="self:center"
-                value="${blocked}"
-                tooltip
-                onchange="${updateStatus}"
-              ></ui-panel-protection-status-toggle>
             </div>
-            <gh-panel-card type="info">
-              <ui-text type="label-s" color="primary-700" layout="row gap:0.5">
-                <ui-icon name="info-filled"></ui-icon>
-                ${msg`Our recommendation for this activity`}:
-                ${tracker.blockedByDefault ? msg`Blocked` : msg`Trusted`}
-              </ui-text>
-            </gh-panel-card>
-            <gh-panel-card layout="grid">
+            <div layout="column margin:1:1:0">
               <ui-toggle
-                value="${blocked ? allowedOnSite : blockedOnSite}"
-                onchange="${toggleDomain}"
-                layout="margin:top:0.5"
+                value="${blocked !== tracker.blockedByDefault}"
+                onchange="${toggleBlocked}"
                 no-label
               >
                 <div layout="grow">
                   <ui-text type="label-m">
                     <!-- Add domain as exception -->
-                    Add ${stats.hostname} as exception
+                    ${tracker.blockedByDefault
+                      ? msg`Trust on all websites`
+                      : msg`Block on all websites`}
                   </ui-text>
                   <ui-text type="body-s" color="gray-500">
+                    Add an exception for all websites
+                  </ui-text>
+                </div>
+              </ui-toggle>
+            </div>
+            <ui-line></ui-line>
+            <gh-panel-card layout="column gap">
+              <ui-toggle
+                value="${status.website}"
+                onchange="${toggleDomain}"
+                no-label
+              >
+                <div layout="grow">
+                  <ui-text type="label-m">
                     ${blocked
                       ? msg`Trust on this website`
                       : msg`Block on this website`}
+                  </ui-text>
+                  <ui-text type="body-s" color="gray-500">
+                    <!-- Add domain as an exception -->
+                    Add ${stats.hostname} as an exception
                   </ui-text>
                 </div>
               </ui-toggle>

--- a/extension-manifest-v3/src/pages/panel/views/protection-status.js
+++ b/extension-manifest-v3/src/pages/panel/views/protection-status.js
@@ -46,12 +46,21 @@ export default {
         ></div>
         <ui-text slot="header" type="label-l">${tracker.name}</ui-text>
 
-        <ui-text slot="header" type="body-s" color="gray-600">
-          ${tracker.company &&
-          tracker.company !== tracker.name &&
-          tracker.company + ' •'}
-          ${labels.categories[tracker.category]}
-        </ui-text>
+        <div
+          slot="header"
+          layout="center row items:center gap overflow margin:0.5:0:0:0"
+        >
+          <ui-panel-category-icon
+            name="${tracker.category}"
+            layout="size:2.5"
+          ></ui-panel-category-icon>
+          <ui-text slot="header" type="body-s" color="gray-600">
+            ${tracker.company &&
+            tracker.company !== tracker.name &&
+            tracker.company + ' •'}
+            ${labels.categories[tracker.category]}
+          </ui-text>
+        </div>
         ${(store.ready(tracker.exception) || store.error(tracker.exception)) &&
         html`
           <div layout="column gap:2">
@@ -88,7 +97,7 @@ export default {
                       : msg`Block on all websites`}
                   </ui-text>
                   <ui-text type="body-s" color="gray-500">
-                    Add an exception for all websites
+                    Add exception
                   </ui-text>
                 </div>
               </ui-toggle>

--- a/extension-manifest-v3/src/pages/panel/views/tracker-details.js
+++ b/extension-manifest-v3/src/pages/panel/views/tracker-details.js
@@ -64,12 +64,21 @@ export default {
         ></div>
         <ui-text slot="header" type="label-l">${tracker.name}</ui-text>
 
-        <ui-text slot="header" type="body-s" color="gray-600">
-          ${tracker.company &&
-          tracker.company !== tracker.name &&
-          tracker.company + ' •'}
-          ${labels.categories[tracker.category]}
-        </ui-text>
+        <div
+          slot="header"
+          layout="center row items:center gap overflow margin:0.5:0:0:0"
+        >
+          <ui-panel-category-icon
+            name="${tracker.category}"
+            layout="size:2.5"
+          ></ui-panel-category-icon>
+          <ui-text slot="header" type="body-s" color="gray-600">
+            ${tracker.company &&
+            tracker.company !== tracker.name &&
+            tracker.company + ' •'}
+            ${labels.categories[tracker.category]}
+          </ui-text>
+        </div>
         ${options.terms &&
         html`
           <div layout="grid:1|max gap">

--- a/extension-manifest-v3/src/pages/panel/views/tracker-details.js
+++ b/extension-manifest-v3/src/pages/panel/views/tracker-details.js
@@ -9,7 +9,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import { html, router, store } from 'hybrids';
+import { html, msg, router, store } from 'hybrids';
 import * as labels from '@ghostery/ui/labels';
 
 import Options from '/store/options.js';
@@ -100,13 +100,13 @@ export default {
                     >
                       ${status.website
                         ? (status.type === 'trust' &&
-                            html`Trusted on this website`) ||
+                            msg`Trusted on this website`) ||
                           (status.type === 'block' &&
-                            html`Blocked on this website`)
+                            msg`Blocked on this website`)
                         : (status.type === 'trust' &&
-                            html`Trusted on all websites`) ||
+                            msg`Trusted on all websites`) ||
                           (status.type === 'block' &&
-                            html`Blocked on all websites`)}
+                            msg`Blocked on all websites`)}
                     </ui-text>
                   </a>
                 </ui-panel-action>`}


### PR DESCRIPTION
Updates the UI for the protection status dialog in the panel.

The copy is WIP, feel free to update, for example the description below the global toggle:
> Add exception to all websites

<img width="371" alt="Zrzut ekranu 2024-07-19 o 16 29 59" src="https://github.com/user-attachments/assets/69eac644-7da5-4f9e-9bee-4e57f990fd8e">
<img width="363" alt="Zrzut ekranu 2024-07-19 o 16 29 43" src="https://github.com/user-attachments/assets/4a3e23dc-1fa2-476e-997b-b45353374eb0">
