### PR TITLE
Disable tracker wheel

### DIFF
--- a/extension-manifest-v3/src/store/options.js
+++ b/extension-manifest-v3/src/store/options.js
@@ -55,7 +55,8 @@ const Options = {
   experimentalFilters: false,
 
   // Browser icon
-  trackerWheel: __PLATFORM__ !== 'firefox' ? true : false,
+  // TODO: it should be enabled by default on Ghostery Private Browser only
+  trackerWheel: __PLATFORM__ === 'firefox' ? true : false,
   ...(__PLATFORM__ !== 'safari' ? { trackerCount: true } : {}),
 
   // SERP


### PR DESCRIPTION
Reverts https://github.com/ghostery/ghostery-extension/pull/1733

In all browsers, but Firefox, the Tracker Wheel should be disabled by default.