### PR TITLE
Clean up `ui-panel-list` usage, as slot header was removed

### DIFF
--- a/packages/ui/src/modules/panel/components/stats.js
+++ b/packages/ui/src/modules/panel/components/stats.js
@@ -187,10 +187,6 @@ export default {
                   layout:last-of-type="margin:bottom:0.5"
                   layout:first-of-type="margin:top:0.5"
                 >
-                  <div slot="header" layout="row items:center gap">
-                    <ui-text type="label-s">${trackers.length}</ui-text>
-                  </div>
-
                   <section id="content" layout="column gap:0.5">
                     ${trackers.map(
                       (tracker) =>


### PR DESCRIPTION
#1757 removed slot `header` from `ui-panel-list`, so we should remove usage of that slot.

https://github.com/ghostery/ghostery-extension/pull/1757/files#diff-b8bd77af70106c6ebb0939650973ab7ce56c208b291e1c7b56bd6ba42c5ae98bL29