### PR TITLE
Avoid inconsistent "double-trust" state in the detailed protection view

### DIFF
--- a/extension-manifest-v3/src/pages/panel/views/protection-status.js
+++ b/extension-manifest-v3/src/pages/panel/views/protection-status.js
@@ -5,7 +5,7 @@ import * as labels from '@ghostery/ui/labels';
 import TabStats from '/store/tab-stats.js';
 import { toggleExceptionDomain } from '/store/tracker-exception.js';
 
-function toggleDomain({ stats, tracker }) {
+function toggleTrackerBlockedOnThisWebsite({ tracker, stats }) {
   toggleExceptionDomain(
     tracker.exception,
     stats.hostname,
@@ -13,14 +13,10 @@ function toggleDomain({ stats, tracker }) {
   );
 }
 
-function toggleBlocked({ tracker, blocked, status }) {
-  if (!status.website && store.ready(tracker.exception)) {
-    store.set(tracker.exception, null);
-  } else {
-    store.set(tracker.exception, {
-      blocked: !blocked,
-    });
-  }
+function toggleTrackerBlockedOnAllWebsites({ tracker, blocked }) {
+  store.set(tracker.exception, {
+    blocked: !blocked,
+  });
 }
 
 export default {
@@ -86,7 +82,7 @@ export default {
             <div layout="column margin:1:1:0">
               <ui-toggle
                 value="${blocked !== tracker.blockedByDefault}"
-                onchange="${toggleBlocked}"
+                onchange="${toggleTrackerBlockedOnAllWebsites}"
                 no-label
               >
                 <div layout="grow">
@@ -106,7 +102,7 @@ export default {
             <gh-panel-card layout="column gap">
               <ui-toggle
                 value="${status.website}"
-                onchange="${toggleDomain}"
+                onchange="${toggleTrackerBlockedOnThisWebsite}"
                 no-label
               >
                 <div layout="grow">


### PR DESCRIPTION
Background: see https://github.com/ghostery/ghostery-extension/issues/1773, where the UI can get in an inconsistent state that requires another action get out of again.

For each tracker and each domain, there are two states:
* the tracker is blocked/trusted on the domain ("this website")
* the tracker is globally blocked/trusted ("all websites")

where "blocked/trust" is being defined as being the opposite of the default that would otherwise come into effect. This change simplifies the state transition by updating them individually. Interweaving them opens the question how the transition in the 4 state graph should be and at the same time avoiding inconsistent states like before (and also being able to reach all states).
    
Keeping them separated, which also avoid the problems, looks like the most intuitive approach.

fixes https://github.com/ghostery/ghostery-extension/issues/1773