### PR TITLE
Clean up autoconsent config object

### DIFF
--- a/extension-manifest-v3/src/background/autoconsent.js
+++ b/extension-manifest-v3/src/background/autoconsent.js
@@ -31,13 +31,7 @@ async function initialize(msg, tab, frameId) {
           action: 'autoconsent',
           type: 'initResp',
           rules,
-          config: {
-            enabled: true,
-            autoAction: 'optOut',
-            disabledCmps: [],
-            enablePrehide: true,
-            detectRetries: 20,
-          },
+          config: {},
         },
         {
           frameId,


### PR DESCRIPTION
According to the source and docs for `autoconsent` library, the config object takes default values if they are not set, and it looks that we used only the defaults. 

I think it is safer to remove them, if in the future the defaults changes (in a good way).

Source: https://github.com/duckduckgo/autoconsent/blob/main/lib/utils.ts#L72

Default:
```js
{
    enabled: true,
    autoAction: 'optOut', // if falsy, the extension will wait for an explicit user signal before opting in/out
    disabledCmps: [],
    enablePrehide: true,
    enableCosmeticRules: true,
    detectRetries: 20,
    isMainWorld: false,
    prehideTimeout: 2000,
    logs: {...},
};
```

Our current config:
```js
{
  enabled: true,
  autoAction: 'optOut',
  disabledCmps: [],
  enablePrehide: true,
  detectRetries: 20,
}
```