### PR TITLE
Support trusted types

### DIFF
--- a/extension-manifest-v3/src/background/adblocker.js
+++ b/extension-manifest-v3/src/background/adblocker.js
@@ -245,30 +245,23 @@ ${scripts.join('\n\n')}}
   // wrapper to break the "isolated world" so that the patching operates
   // on the website, not on the content script's isolated environment.
   function codeRunningInContentScript(code, nonce) {
-    let script;
-    try {
-      script = document.createElement('script');
-      let content = decodeURIComponent(code);
-      if (nonce) {
-        const trustedTypePolicy = window.trustedTypes.createPolicy(
-          `ghostery-${Math.round(Math.random() * 1000000)}`,
-          {
-            createScript: (string) =>
-              !string || string.slice(13, 13 + nonce.length) === nonce
-                ? string
-                : null,
-          },
-        );
-        content = trustedTypePolicy.createScript(content);
-      }
-      script.textContent = content;
-      (document.head || document.documentElement).appendChild(script);
-    } catch (ex) {
-      console.error('Failed to run script', ex);
+    const script = document.createElement('script');
+    let content = decodeURIComponent(code);
+    if (nonce) {
+      const trustedTypePolicy = window.trustedTypes.createPolicy(
+        `ghostery-${Math.round(Math.random() * 1000000)}`,
+        {
+          createScript: (string) =>
+            !string || string.slice(13, 13 + nonce.length) === nonce
+              ? string
+              : null,
+        },
+      );
+      content = trustedTypePolicy.createScript(content);
     }
-    if (script) {
-      script.remove();
-    }
+    script.textContent = content;
+    (document.head || document.documentElement).appendChild(script);
+    script.remove();
   }
 
   chrome.scripting.executeScript(


### PR DESCRIPTION
Fix for the Chrome permission on pages that use Trusted Types:
```
VM16:6 This document requires 'TrustedScript' assignment. This script element was modified without use of TrustedScript assignment.
VM16:6 This document requires 'TrustedScript' assignment. An HTMLScriptElement was directly modified and will not be executed.
VM16:14 This document requires 'TrustedScript' assignment.
VM16:14 
 Uncaught 
TypeError: Failed to set the 'textContent' property on 'Node': This document requires 'TrustedScript' assignment.
    at codeRunningInContentScript (<anonymous>:14:26)
    at <anonymous>:16:5
```