### PR TITLE
Set tracker wheel default value to `false`

### DIFF
--- a/extension-manifest-v3/src/store/options.js
+++ b/extension-manifest-v3/src/store/options.js
@@ -54,9 +54,8 @@ const Options = {
   },
   experimentalFilters: false,
 
-  // Browser icon
-  // TODO: it should be enabled by default on Ghostery Private Browser only
-  trackerWheel: __PLATFORM__ === 'firefox' ? true : false,
+  // Browser toolbar icon
+  trackerWheel: false,
   ...(__PLATFORM__ !== 'safari' ? { trackerCount: true } : {}),
 
   // SERP


### PR DESCRIPTION
Fixes #1783

As we agreed with @chrmod, for now, we are going to set `false` as default for Tracker Wheel option. As this should be only set to `true` for Ghostery Browser on desktop (Android has native ghosty icon), we will figure out the best and simplest solution for that when a new version of the browser will be released.