### PR TITLE
Ghostery 10: minimium Firefox version

### DIFF
--- a/extension-manifest-v3/src/manifest.firefox.json
+++ b/extension-manifest-v3/src/manifest.firefox.json
@@ -90,7 +90,8 @@
   ],
   "browser_specific_settings": {
 		"gecko": {
-			"id": "firefox@ghostery.com"
+			"id": "firefox@ghostery.com",
+      "strict_min_version": "102.0"
 		}
 	}
 }


### PR DESCRIPTION
Due to usage of `chrome.scripting` the min version of Firefox has to be bumped 
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/executeScript