### PR TITLE
fix: add missing allowed extensions for redirect resources

### DIFF
--- a/extension-manifest-v3/scripts/download-engines/index.js
+++ b/extension-manifest-v3/scripts/download-engines/index.js
@@ -169,6 +169,8 @@ const allowedResourceExtensions = [
   'xml',
   'txt',
   'json',
+  'png',
+  'gif',
   'empty',
 ];
 


### PR DESCRIPTION
refs [ghostery/urlfilter2dnr@`ba96754` (#17)](https://github.com/ghostery/urlfilter2dnr/pull/17/commits/ba967542183d9e3be885e1f494622d1a4ab7ab5b)