### PR TITLE
Set Firefox min version for support current background script config

### DIFF
--- a/extension-manifest-v3/src/manifest.firefox.json
+++ b/extension-manifest-v3/src/manifest.firefox.json
@@ -84,7 +84,7 @@
     "gecko_android": {},
     "gecko": {
       "id": "firefox@ghostery.com",
-      "strict_min_version": "102.0"
+      "strict_min_version": "112.0"
     }
   }
 }


### PR DESCRIPTION
Bumps min version to 112, as we use `background.type` field in the extension manifest