### PR TITLE
Eslint ignore rule_resources

### DIFF
--- a/extension-manifest-v3/.eslintignore
+++ b/extension-manifest-v3/.eslintignore
@@ -1,1 +1,1 @@
-/src/vendor/*
+/src/rule_resources


### PR DESCRIPTION
Some of the redirect assets where linted which was causing `npm run lint` to fail locally

```

/Users/chrmod/Projects/github.com/ghostery/ghostery-extension/extension-manifest-v3/src/rule_resources/redirects/popads-dummy.js
  1:10  error  Replace `(){"use·strict";delete·window.PopAds;delete·window.popns;Object.defineProperties(window,{PopAds:{value:{}},popns:{value:{}}})})();` with `·()·{⏎··'use·strict';⏎··delete·window.PopAds;⏎··delete·window.popns;⏎··Object.defineProperties(window,·{⏎····PopAds:·{·value:·{}·},⏎····popns:·{·value:·{}·},⏎··});⏎})();⏎`  prettier/prettier
```