### PR TITLE
Allow redirect rule from another engine to overwrite blocking rule

### DIFF
--- a/extension-manifest-v3/src/background/adblocker.js
+++ b/extension-manifest-v3/src/background/adblocker.js
@@ -501,7 +501,6 @@ if (__PLATFORM__ === 'firefox') {
             } else if (match === true) {
               request.blocked = true;
               result = { cancel: true };
-              break;
             }
           }
         }


### PR DESCRIPTION
Redirect rules must have higher priority over the blocking rules. Currently, we have multiple engines, so if the redirect rule is in the next engine, we cannot skip processing the engines, when the blocking rule is found.