### PR TITLE
Fix v8 migration data & uninstall URL

### DIFF
--- a/extension-manifest-v3/src/background/telemetry.js
+++ b/extension-manifest-v3/src/background/telemetry.js
@@ -77,6 +77,7 @@ chrome.runtime.onMessage.addListener((msg) => {
 (async () => {
   const storage = await loadStorage();
   const { version, debug } = chrome.runtime.getManifest();
+
   telemetry = new Telemetry({
     METRICS_BASE_URL: debug
       ? 'https://staging-d.ghostery.com'
@@ -98,11 +99,6 @@ chrome.runtime.onMessage.addListener((msg) => {
     log('Telemetry recordUTMs() error', error);
   }
 
-  if (JUST_INSTALLED) {
-    telemetry.setUninstallUrl();
-
-    telemetry.ping('install');
-  } else {
-    telemetry.ping('active');
-  }
+  telemetry.ping(JUST_INSTALLED ? 'install' : 'active');
+  telemetry.setUninstallUrl();
 })();

--- a/extension-manifest-v3/src/store/options.js
+++ b/extension-manifest-v3/src/store/options.js
@@ -301,9 +301,9 @@ async function migrateFromV8() {
         'paused',
         'installDate',
       ]);
-    }
 
-    console.info(`Options: successfully migrated options from v8`, options);
+      console.info(`Options: successfully migrated options from v8`, options);
+    }
 
     return options;
   } catch (e) {

--- a/extension-manifest-v3/src/store/options.js
+++ b/extension-manifest-v3/src/store/options.js
@@ -282,6 +282,15 @@ async function migrateFromV8() {
         'hpnv2',
       ].forEach((name) => deleteDB(name).catch(() => {}));
 
+      // Bring back metrics and UTMs
+      await chrome.storage.local.set({
+        metrics: storage.metrics,
+        utms: {
+          utm_campaign: storage.utm_campaign,
+          utm_source: storage.utm_source,
+        },
+      });
+
       // Set options by hand to make sure, that
       // paused side effects are triggered
       await Options[store.connect].set(undefined, options, [


### PR DESCRIPTION
* Fixes issue when v8 migrates to v10 and metrics are cleared, so the install ping signal can be sent again
* Fixes setting the uninstall URL - it looks like on Firefox it's cleared after the extension update. However it should be updated each time the metrics update, as for now, it keeps the oldest (the very first one) version.

There are overlapping bugs, but the current v10.4.1 on Firefox is likely to send another install ping signal, but then the uninstall URL is correctly updated, or it does not send an install signal, but the uninstall URL won't be set correctly.