### PR TITLE
fix: global pause must overwrite block DNR rules

### DIFF
--- a/extension-manifest-v3/src/background/paused.js
+++ b/extension-manifest-v3/src/background/paused.js
@@ -10,12 +10,30 @@
  */
 
 import { store } from 'hybrids';
-import Options, { observe } from '/store/options.js';
+import Options, { observe, GLOBAL_PAUSE_ID } from '/store/options.js';
 
 // Pause / unpause hostnames
 const PAUSED_ALARM_PREFIX = 'options:revoke';
+const PAUSED_RULE_PRIORITY = 10000000;
 
-observe('paused', async (paused) => {
+const ALL_RESOURCE_TYPES = [
+  'main_frame',
+  'sub_frame',
+  'stylesheet',
+  'script',
+  'image',
+  'font',
+  'object',
+  'xmlhttprequest',
+  'ping',
+  'media',
+  'websocket',
+  'webtransport',
+  'webbundle',
+  'other',
+];
+
+observe('paused', async (paused, prevPaused) => {
   const alarms = (await chrome.alarms.getAll()).filter(({ name }) =>
     name.startsWith(PAUSED_ALARM_PREFIX),
   );
@@ -41,6 +59,78 @@ observe('paused', async (paused) => {
           when: revokeAt,
         });
       });
+  }
+
+  // The background process starts and runs for each tab, so we can assume
+  // that this function is called before the user can change the paused state
+  // in the panel or the settings page.
+  if (__PLATFORM__ !== 'firefox' && prevPaused) {
+    const removeRuleIds = (await chrome.declarativeNetRequest.getDynamicRules())
+      .filter(({ id }) => id <= 3)
+      .map(({ id }) => id);
+
+    const hostnames = Object.keys(paused);
+
+    let globalPause = false;
+    if (hostnames.includes(GLOBAL_PAUSE_ID)) {
+      globalPause = true;
+    }
+
+    if (hostnames.length) {
+      await chrome.declarativeNetRequest.updateDynamicRules({
+        addRules:
+          __PLATFORM__ === 'safari'
+            ? [
+                {
+                  id: 1,
+                  priority: PAUSED_RULE_PRIORITY,
+                  action: { type: 'allow' },
+                  condition: {
+                    domains: globalPause
+                      ? undefined
+                      : hostnames.map((d) => `*${d}`),
+                    urlFilter: '*',
+                  },
+                },
+              ]
+            : [
+                {
+                  id: 1,
+                  priority: PAUSED_RULE_PRIORITY,
+                  action: { type: 'allow' },
+                  condition: {
+                    initiatorDomains: globalPause ? undefined : hostnames,
+                    resourceTypes: ALL_RESOURCE_TYPES,
+                  },
+                },
+                {
+                  id: 2,
+                  priority: PAUSED_RULE_PRIORITY,
+                  action: { type: 'allow' },
+                  condition: {
+                    requestDomains: globalPause ? undefined : hostnames,
+                    resourceTypes: ALL_RESOURCE_TYPES,
+                  },
+                },
+                {
+                  id: 3,
+                  priority: PAUSED_RULE_PRIORITY,
+                  action: { type: 'allowAllRequests' },
+                  condition: {
+                    initiatorDomains: globalPause ? undefined : hostnames,
+                    resourceTypes: ['main_frame', 'sub_frame'],
+                  },
+                },
+              ],
+        removeRuleIds,
+      });
+      console.log('DNR: pause rules updated');
+    } else if (removeRuleIds.length) {
+      await chrome.declarativeNetRequest.updateDynamicRules({
+        removeRuleIds,
+      });
+      console.log('DNR: pause rules updated');
+    }
   }
 });
 


### PR DESCRIPTION
On chromium when global pause is used, there are still DNR rules that blocks requests from added exceptions (blocked). 

This PR fixes the issue by removing the `domains` or `initiatorDomains` condition from pause rule making it global.