### PR TITLE
fix: `Pause on this site` main panel action & add revoke countdown

### DIFF
--- a/extension-manifest-v3/src/pages/panel/components/pause.js
+++ b/extension-manifest-v3/src/pages/panel/components/pause.js
@@ -77,7 +77,7 @@ export default {
         layout@390px="height:7"
         onclick="${!pauseList && dispatchAction}"
       >
-        <div id="label" layout="grow row center gap:0.5 shrink overflow">
+        <div id="label" layout="grow row center gap shrink overflow">
           <slot></slot>
         </div>
         <div

--- a/extension-manifest-v3/src/pages/panel/store/notification.js
+++ b/extension-manifest-v3/src/pages/panel/store/notification.js
@@ -44,15 +44,6 @@ const NOTIFICATIONS = {
     url: 'https://www.ghostery.com/blog/block-search-engine-ads-on-opera-guide?utm_source=gbe&utm_campaign=opera_serp',
     action: msg`Enable Ad Blocking Now`,
   },
-  globalPause: {
-    icon: 'pause',
-    type: '',
-    text: msg`Missing “Pause Ghostery”? You can find it in your privacy protection settings.`,
-    url: chrome.runtime.getURL(
-      '/pages/settings/index.html#@gh-settings-privacy',
-    ),
-    action: msg`Open Ghostery settings`,
-  },
 };
 
 export default {
@@ -67,11 +58,11 @@ export default {
     }
 
     if ((await store.resolve(Session)).contributor) {
-      return NOTIFICATIONS.globalPause;
+      return null;
     }
 
     return !(await store.resolve(Options)).terms
       ? NOTIFICATIONS.terms
-      : NOTIFICATIONS.globalPause;
+      : NOTIFICATIONS.contributor;
   },
 };

--- a/extension-manifest-v3/src/pages/panel/views/home.js
+++ b/extension-manifest-v3/src/pages/panel/views/home.js
@@ -103,7 +103,7 @@ export default {
   stats: store(TabStats),
   notification: store(Notification),
   paused: ({ options, stats }) =>
-    store.ready(options, stats) && !!options.paused[stats.hostname],
+    store.ready(options, stats) && options.paused[stats.hostname],
   globalPause: ({ options }) =>
     store.ready(options) && options.paused[GLOBAL_PAUSE_ID],
   render: ({ options, stats, notification, paused, globalPause }) => html`
@@ -163,15 +163,25 @@ export default {
                   name="${globalPause ? 'pause' : 'circle'}"
                   color="gh-panel-action"
                 ></ui-icon>
-                <ui-text
-                  type="label-m"
-                  color="gh-panel-action"
-                  layout="block:center"
-                >
-                  ${globalPause && msg`Ghostery is paused`}
-                  ${!globalPause &&
-                  (paused ? msg`Site is trusted` : msg`Trust this site`)}
-                </ui-text>
+                <div layout="column">
+                  <ui-text
+                    type="label-m"
+                    color="gh-panel-action"
+                    layout="block:center"
+                  >
+                    ${paused || globalPause
+                      ? msg`Ghostery is paused`
+                      : msg`Pause on this site`}
+                  </ui-text>
+                  ${((paused && !!paused.revokeAt) || globalPause) &&
+                  html`<ui-text type="body-xs" color="gh-panel-action">
+                    <ui-panel-revoke-at
+                      revokeAt="${globalPause
+                        ? globalPause.revokeAt
+                        : paused.revokeAt}"
+                    ></ui-panel-revoke-at>
+                  </ui-text>`}
+                </div>
               </gh-panel-pause>
             `
           : html`

--- a/extension-manifest-v3/src/pages/settings/components/protection-status.js
+++ b/extension-manifest-v3/src/pages/settings/components/protection-status.js
@@ -9,7 +9,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import { html, msg } from 'hybrids';
+import { html } from 'hybrids';
 
 export default {
   revokeAt: undefined,
@@ -23,19 +23,10 @@ export default {
           `
         : html`
             <gh-settings-badge type="warning" uppercase>
-              Trusted
+              Paused
             </gh-settings-badge>
             <ui-text color="gray-600" layout="grow">
-              ${revokeAt
-                ? html`${html`<relative-time
-                    date="${new Date(revokeAt)}"
-                    format="duration"
-                    format-style="narrow"
-                    precision="minute"
-                    lang="${chrome.i18n.getUILanguage()}"
-                  ></relative-time>`}
-                  left`
-                : msg`Always`}
+              <ui-panel-revoke-at revokeAt="${revokeAt}"></ui-panel-revoke-at>
             </ui-text>
           `}
     </template>

--- a/extension-manifest-v3/src/pages/settings/views/privacy.js
+++ b/extension-manifest-v3/src/pages/settings/views/privacy.js
@@ -101,18 +101,9 @@ export default {
                 ${globalPauseRevokeAt &&
                 html`
                   <ui-text type="body-s" color="gray-600">
-                    ${html`
-                      <ui-text type="body-s" ellipsis
-                        ><relative-time
-                          date="${new Date(globalPauseRevokeAt)}"
-                          format="duration"
-                          format-style="narrow"
-                          precision="minute"
-                          lang="${chrome.i18n.getUILanguage()}"
-                        ></relative-time
-                      ></ui-text>
-                    `}
-                    left
+                    <ui-panel-revoke-at
+                      revokeAt="${globalPauseRevokeAt}"
+                    ></ui-panel-revoke-at>
                   </ui-text>
                 `}
               </div>

--- a/extension-manifest-v3/src/pages/settings/views/websites.js
+++ b/extension-manifest-v3/src/pages/settings/views/websites.js
@@ -10,7 +10,6 @@
  */
 
 import { html, msg, store, router } from 'hybrids';
-import '@github/relative-time-element';
 
 import Options, { GLOBAL_PAUSE_ID } from '/store/options.js';
 import TrackerException from '/store/tracker-exception.js';

--- a/packages/ui/src/modules/panel/components/protection-status-toggle.js
+++ b/packages/ui/src/modules/panel/components/protection-status-toggle.js
@@ -1,3 +1,14 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
 import { dispatch, html } from 'hybrids';
 
 function updateValue(value) {

--- a/packages/ui/src/modules/panel/components/revoke-at.js
+++ b/packages/ui/src/modules/panel/components/revoke-at.js
@@ -1,0 +1,29 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { html } from 'hybrids';
+import '@github/relative-time-element';
+
+export default {
+  // add 1 minute to the revokeAt time to ensure the relative-time element displays the correct duration
+  revokeAt: (host, value) => value && new Date(value),
+  render: ({ revokeAt }) =>
+    revokeAt
+      ? html`${html`<relative-time
+          date="${new Date(revokeAt)}"
+          format="duration"
+          format-style="narrow"
+          precision="minute"
+          lang="${chrome.i18n.getUILanguage()}"
+        ></relative-time>`}
+        left`
+      : html`Always`,
+};

--- a/packages/ui/src/modules/panel/styles.css
+++ b/packages/ui/src/modules/panel/styles.css
@@ -67,6 +67,7 @@ html {
   --ui-font-body-l: 400 16px / 20px var(--ui-font-family);
   --ui-font-body-m: 400 14px / 18px var(--ui-font-family);
   --ui-font-body-s: 400 12px / 16px var(--ui-font-family);
+  --ui-font-body-xs: 400 11px / 14px var(--ui-font-family);
 
   --ui-font-button-m: var(--ui-font-label-m);
   --ui-font-button-s: 600 14px / 24px var(--ui-font-family);


### PR DESCRIPTION
* Reverts `Trust this website` to `Pause on this website`
* Reverts the status badge for website from `Trusted` to `Paused`
* Adds a countdown to the panel pause button
* Removes the "Global pause" notification