### PR TITLE
Disable autoconsent cosmetic injection

### DIFF
--- a/extension-manifest-v3/src/background/autoconsent.js
+++ b/extension-manifest-v3/src/background/autoconsent.js
@@ -31,7 +31,9 @@ async function initialize(msg, tab, frameId) {
           action: 'autoconsent',
           type: 'initResp',
           rules,
-          config: {},
+          config: {
+            enableCosmeticRules: false,
+          },
         },
         {
           frameId,


### PR DESCRIPTION
refs https://github.com/ghostery/broken-page-reports/issues/826

Autoconsent now enables cosmetic rules by default and it seems like this change can cause conflicts when creating exceptions. This is because their injections are done by style tag creation. This PR toggles off the style injections coming from autoconsent.

The breakage on `docs.spring.io` shows how this actually can be a problem because we may not override the style tag contents.

```html
<style id="autoconsent-css-rules">#modal-1 div[data-micromodal-close] { display: none !important; z-index: -1 !important; pointer-events: none !important; } </style>
```

By toggling the switch off, we solves
1. cosmetic injection conflicts (as we're already shipping EL cookies)
2. cosmetic exceptions/overrides cannot be applied due to style tag contents