### PR TITLE
fix: fallback to storage.local when IndexedDB is corrupted

### DIFF
--- a/extension-manifest-v3/src/manifest.firefox.json
+++ b/extension-manifest-v3/src/manifest.firefox.json
@@ -14,6 +14,7 @@
     "webNavigation",
     "webRequest",
     "webRequestBlocking",
+    "unlimitedStorage",
     "http://*/*",
     "https://*/*",
     "ws://*/*",

--- a/extension-manifest-v3/src/utils/engines.js
+++ b/extension-manifest-v3/src/utils/engines.js
@@ -143,6 +143,11 @@ async function saveToStorage(name) {
       await table.delete(name);
     }
 
+    if (__PLATFORM__ === 'firefox') {
+      // Clear out the fallback local storage if the engine is saved to the IDB
+      chrome.storage.local.set({ [`engines:${name}`]: null });
+    }
+
     await tx.done;
   } catch (e) {
     if (__PLATFORM__ === 'firefox') {

--- a/extension-manifest-v3/src/utils/engines.js
+++ b/extension-manifest-v3/src/utils/engines.js
@@ -94,7 +94,9 @@ async function loadFromStorage(name) {
       .then((db) => {
         const tx = db.transaction('engines');
         const table = tx.objectStore('engines');
-        return table.get(name);
+        return table.get(name).then((result) => {
+          return tx.done.then(() => result);
+        });
       })
       .catch((e) => {
         // Suppress the private browsing mode in Firefox
@@ -138,6 +140,8 @@ async function saveToStorage(name) {
     } else {
       await table.delete(name);
     }
+
+    await tx.done;
   } catch (e) {
     if (__PLATFORM__ === 'firefox') {
       const key = `engines:${name}`;


### PR DESCRIPTION
Relates to https://github.com/ghostery/ghostery-extension/issues/1837

Fixes the issue for engines with corrupted IndexedDB in Firefox when history is globally disabled or private browsing is turned on globally.

It adds a fallback for the eninges to be stored in `chrome.storage.local`. As Firefox supports saving UnitArrays, the implementation is stratgh forward. 

I tried few different approaches, but I think only two may apply - hardcoded fallback for Firefox for all users, or use "in-time" detection for each engine.

The first solution makes Firefox again a different, which I would like to avoid - we should keep the code the same as much as possible. Also, only a small group of users are affected by the Firefox bug.

The detection outside of the function and using a flag is hazardous. As the IndexedDB error message comes in asynchronius way, we cannot avoid a race condition, so the `loadFromStorage` function might be called before we set the flag. 

The last argument is about how the `getDB()` already works. It saves the opened session to the database in `getDB.current` - as this is done only once, for the each access to the database, after it's once rejected, it rejects immeditelly. 