### PR TITLE
Telemetry: send active faster and remove upgrade signals

### DIFF
--- a/extension-manifest-v3/src/background/telemetry/index.js
+++ b/extension-manifest-v3/src/background/telemetry/index.js
@@ -113,6 +113,9 @@ chrome.runtime.onMessage.addListener((msg) => {
     log('Telemetry recordUTMs() error', error);
   }
 
-  telemetry.ping(JUST_INSTALLED ? 'install' : 'active');
+  if (JUST_INSTALLED) {
+    telemetry.ping('install');
+  }
+  telemetry.ping('active');
   telemetry.setUninstallUrl();
 })();

--- a/extension-manifest-v3/src/background/telemetry/metrics.js
+++ b/extension-manifest-v3/src/background/telemetry/metrics.js
@@ -61,7 +61,6 @@ export const FREQUENCY_TYPES = ['all', ...Object.keys(FREQUENCIES)];
 export const CRITICAL_METRICS = [
   'install',
   'install_complete',
-  'upgrade',
   'active',
   'engaged',
   'uninstall',
@@ -150,9 +149,6 @@ class Metrics {
         break;
       case 'install_complete':
         this._recordInstallComplete();
-        break;
-      case 'upgrade':
-        this._recordUpgrade();
         break;
       case 'active':
         this._recordActive();
@@ -599,17 +595,6 @@ class Metrics {
       this.ping(type);
     });
     delete this.ping_set;
-  }
-
-  /**
-   * Record Upgrade event
-   * @private
-   */
-  _recordUpgrade() {
-    // set install_all on upgrade too
-    this.storage.install_all = Date.now();
-    this.saveStorage(this.storage);
-    this._sendReq('upgrade');
   }
 
   /**


### PR DESCRIPTION
From what I can tell, the `active` signal was only send on subsequent service worker startup. In practice, it should not make much difference, but in principle it should be send as soon as possible. 
Additionally, `upgrade` signal is no longer is use, so the was removed from the code.