### PR TITLE
fix: merge chromium-based browsers to one build

### DIFF
--- a/.github/workflows/artifact-upload.yml
+++ b/.github/workflows/artifact-upload.yml
@@ -39,31 +39,19 @@ jobs:
         run: npm run package -- --simple
       - name: Uncompress packages
         run: |
-          for PLATFORM in firefox chrome edge opera; do
+          for PLATFORM in firefox chromium; do
             mkdir web-ext-artifacts/ghostery-$PLATFORM
             unzip "web-ext-artifacts/ghostery-$PLATFORM.zip" -d "web-ext-artifacts/ghostery-$PLATFORM"
           done
-      - name: Upload Chrome build
+      - name: Upload Chromium build
         uses: actions/upload-artifact@v3
         with:
-          name: ghostery-chrome-${{ env.VERSION }}-${{ env.SHA }}
-          path: extension-manifest-v3/web-ext-artifacts/ghostery-chrome/*
+          name: ghostery-chromium-${{ env.VERSION }}-${{ env.SHA }}
+          path: extension-manifest-v3/web-ext-artifacts/ghostery-chromium/*
           if-no-files-found: error
       - name: Upload Firefox build
         uses: actions/upload-artifact@v3
         with:
           name: ghostery-firefox-${{ env.VERSION }}-${{ env.SHA }}
           path: extension-manifest-v3/web-ext-artifacts/ghostery-firefox/*
-          if-no-files-found: error
-      - name: Upload Edge build
-        uses: actions/upload-artifact@v3
-        with:
-          name: ghostery-edge-${{ env.VERSION }}-${{ env.SHA }}
-          path: extension-manifest-v3/web-ext-artifacts/ghostery-edge/*
-          if-no-files-found: error
-      - name: Upload Opera build
-        uses: actions/upload-artifact@v3
-        with:
-          name: ghostery-opera-${{ env.VERSION }}-${{ env.SHA }}
-          path: extension-manifest-v3/web-ext-artifacts/ghostery-opera/*
           if-no-files-found: error

--- a/.github/workflows/release-v3.yml
+++ b/.github/workflows/release-v3.yml
@@ -45,32 +45,12 @@ jobs:
           asset_name: ghostery-firefox-${{ env.VERSION }}.zip
           asset_content_type: application/gzip
 
-      - name: Upload Chrome build
+      - name: Upload Chromium build
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: extension-manifest-v3/web-ext-artifacts/ghostery-chrome.zip
-          asset_name: ghostery-chrome-${{ env.VERSION }}.zip
-          asset_content_type: application/gzip
-
-      - name: Upload Opera build
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: extension-manifest-v3/web-ext-artifacts/ghostery-opera.zip
-          asset_name: ghostery-opera-${{ env.VERSION }}.zip
-          asset_content_type: application/gzip
-
-      - name: Upload Edge build
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: extension-manifest-v3/web-ext-artifacts/ghostery-edge.zip
-          asset_name: ghostery-edge-${{ env.VERSION }}.zip
+          asset_path: extension-manifest-v3/web-ext-artifacts/ghostery-chromium.zip
+          asset_name: ghostery-chromium-${{ env.VERSION }}.zip
           asset_content_type: application/gzip

--- a/extension-manifest-v3/README.md
+++ b/extension-manifest-v3/README.md
@@ -19,12 +19,16 @@ npm start
 To develop extension for different target, add target name after the command:
 
 * Safari - `npm start safari`
-* Opera - `npm start opera`
 * Firefox - `npm start firefox`
 
 > The build script assumes that you are using macOS, and browsers are installed in the default locations.
 
 However, to test it in Safari browser, you will have to use Xcode. The project files are available in the `xcode` folder, but Apple's ecosystem is more complex. Fortunately, most changes can be tested reliably in Chrome.
+
+You can also specify the browser to use, for the `chromium` target:
+
+* Opera - `npm start -- --browser=opera`
+* Edge - `npm start -- --browser=edge`
 
 If you want to contribute, try to get it working in Chrome. Most of the time, your code will work in Safari, too.
 

--- a/extension-manifest-v3/scripts/build.js
+++ b/extension-manifest-v3/scripts/build.js
@@ -19,44 +19,26 @@ const options = {
 const argv = process.argv.slice(2).reduce(
   (acc, arg) => {
     if (arg.startsWith('--')) {
-      acc[arg.slice(2)] = true;
+      if (arg.includes('=')) {
+        const [key, value] = arg.slice(2).split('=');
+        acc[key] = value;
+      } else {
+        acc[arg.slice(2)] = true;
+      }
     } else {
       acc.target = arg;
     }
     return acc;
   },
-  { target: 'chrome' },
+  { target: 'chromium' },
 );
-
-const TARGET_MANIFEST_MAP = {
-  chrome: 'chromium',
-  opera: 'chromium',
-  edge: 'chromium',
-  firefox: 'firefox',
-  'safari-ios': 'safari-ios',
-  'safari-macos': 'safari-macos',
-};
-
-if (!TARGET_MANIFEST_MAP[argv.target]) {
-  throw new Error(
-    `Unknown target "${argv.target}". Supported targets: ${Object.keys(
-      TARGET_MANIFEST_MAP,
-    ).join(', ')}`,
-  );
-}
 
 const pkg = JSON.parse(readFileSync(resolve(pwd, 'package.json'), 'utf8'));
 
 // Get manifest from source directory
-console.log(`Reading manifest.${TARGET_MANIFEST_MAP[argv.target]}.json...`);
+console.log(`Reading manifest.${argv.target}.json...`);
 const manifest = JSON.parse(
-  readFileSync(
-    resolve(
-      options.srcDir,
-      `manifest.${TARGET_MANIFEST_MAP[argv.target]}.json`,
-    ),
-    'utf8',
-  ),
+  readFileSync(resolve(options.srcDir, `manifest.${argv.target}.json`), 'utf8'),
 );
 
 // Clear out Safari platform suffix
@@ -394,21 +376,20 @@ if (argv.watch) {
                 '/Applications/Firefox Nightly.app/Contents/MacOS/firefox-bin',
             };
             break;
-          case 'opera':
-            settings = {
-              target: 'chromium',
-              chromiumBinary: '/Applications/Opera.app/Contents/MacOS/Opera',
-            };
-            break;
-          case 'edge':
-            settings = {
-              target: 'chromium',
-              chromiumBinary:
-                '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
-            };
-            break;
-          default:
+          case 'chromium': {
             settings = { target: 'chromium' };
+
+            if (argv.browser === 'opera') {
+              settings.chromiumBinary =
+                '/Applications/Opera.app/Contents/MacOS/Opera';
+            } else if (argv.browser === 'edge') {
+              settings.chromiumBinary =
+                '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge';
+            }
+
+            break;
+          }
+          default:
             break;
         }
 

--- a/extension-manifest-v3/scripts/package.sh
+++ b/extension-manifest-v3/scripts/package.sh
@@ -15,7 +15,7 @@ done
 
 VERSION=$(node -p "require('./package.json').version")
 
-for PLATFORM in firefox chrome edge opera; do
+for PLATFORM in firefox chromium; do
   echo
   echo "##################################"
   echo "  Generating package for $PLATFORM"

--- a/extension-manifest-v3/src/background/custom-filters.js
+++ b/extension-manifest-v3/src/background/custom-filters.js
@@ -29,7 +29,7 @@ import CustomFilters from '/store/custom-filters.js';
 import { setup } from '/background/adblocker.js';
 
 const convert =
-  __PLATFORM__ !== 'safari' && __PLATFORM__ !== 'firefox'
+  __PLATFORM__ === 'chromium'
     ? createOffscreenConverter()
     : createDocumentConverter();
 
@@ -175,7 +175,7 @@ async function update(text, { trustedScriptlets }) {
 
   result.errors = errors;
 
-  if (__PLATFORM__ !== 'firefox') {
+  if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') {
     const dnrResult = await Promise.allSettled(
       [...networkFilters].map((filter) => convert(filter)),
     );

--- a/extension-manifest-v3/src/background/dnr.js
+++ b/extension-manifest-v3/src/background/dnr.js
@@ -11,7 +11,7 @@
 
 import { observe, ENGINES, isPaused } from '/store/options.js';
 
-if (__PLATFORM__ !== 'firefox') {
+if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') {
   const DNR_RESOURCES = chrome.runtime
     .getManifest()
     .declarative_net_request.rule_resources.filter(({ enabled }) => !enabled)

--- a/extension-manifest-v3/src/background/exceptions.js
+++ b/extension-manifest-v3/src/background/exceptions.js
@@ -28,7 +28,10 @@ chrome.storage.local.get(['exceptions']).then(({ exceptions: value }) => {
 chrome.storage.onChanged.addListener((records) => {
   if (records.exceptions) {
     exceptions = records.exceptions.newValue || {};
-    if (__PLATFORM__ !== 'firefox') updateFilters();
+
+    if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') {
+      updateFilters();
+    }
   }
 });
 
@@ -37,7 +40,7 @@ export function getException(id) {
 }
 
 const convert =
-  __PLATFORM__ !== 'safari' && __PLATFORM__ !== 'firefox'
+  __PLATFORM__ === 'chromium'
     ? createOffscreenConverter()
     : createDocumentConverter();
 
@@ -129,7 +132,7 @@ async function updateFilters() {
   console.info('[exceptions] DNR rules for filters updated successfully');
 }
 
-if (__PLATFORM__ !== 'firefox') {
+if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') {
   // Update exceptions filters every time TrackerDB updates
   engines.addChangeListener(engines.TRACKERDB_ENGINE, updateFilters);
 }

--- a/extension-manifest-v3/src/background/external.js
+++ b/extension-manifest-v3/src/background/external.js
@@ -14,7 +14,7 @@ import { store } from 'hybrids';
 import Session from '/store/session.js';
 import { MergedStats } from '/store/daily-stats.js';
 
-if (__PLATFORM__ !== 'safari') {
+if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'firefox') {
   // Listen for messages from Ghostery Search extension
   // https://github.com/ghostery/ghostery-search-extension/blob/main/src/background.js#L40
 

--- a/extension-manifest-v3/src/background/onboarding.js
+++ b/extension-manifest-v3/src/background/onboarding.js
@@ -11,6 +11,7 @@
 
 import { observe } from '/store/options.js';
 import { showOperaSerpNotification } from '/notifications/opera-serp.js';
+import { isOpera } from '/utils/browser-info.js';
 
 let done = false;
 
@@ -24,7 +25,7 @@ observe('onboarding', (onboarding) => {
   }
 });
 
-if (__PLATFORM__ === 'opera') {
+if (__PLATFORM__ === 'chromium' && isOpera()) {
   chrome.webNavigation.onCompleted.addListener((details) => {
     if (done && details.frameId === 0) {
       showOperaSerpNotification(details.tabId);

--- a/extension-manifest-v3/src/background/paused.js
+++ b/extension-manifest-v3/src/background/paused.js
@@ -64,7 +64,10 @@ observe('paused', async (paused, prevPaused) => {
   // The background process starts and runs for each tab, so we can assume
   // that this function is called before the user can change the paused state
   // in the panel or the settings page.
-  if (__PLATFORM__ !== 'firefox' && prevPaused) {
+  if (
+    (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') &&
+    prevPaused
+  ) {
     const removeRuleIds = (await chrome.declarativeNetRequest.getDynamicRules())
       .filter(({ id }) => id <= 3)
       .map(({ id }) => id);

--- a/extension-manifest-v3/src/background/reporting/index.js
+++ b/extension-manifest-v3/src/background/reporting/index.js
@@ -108,7 +108,7 @@ async function onLocationChange(details) {
 
 chrome.webNavigation.onCommitted.addListener(onLocationChange);
 
-if (__PLATFORM__ !== 'safari') {
+if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'firefox') {
   chrome.webNavigation.onHistoryStateUpdated.addListener(onLocationChange);
 }
 

--- a/extension-manifest-v3/src/background/reporting/webrequest-reporter.js
+++ b/extension-manifest-v3/src/background/reporting/webrequest-reporter.js
@@ -26,7 +26,7 @@ import urlReporter from './url-reporter.js';
 
 let webRequestReporter = null;
 
-if (__PLATFORM__ !== 'safari') {
+if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'firefox') {
   const webRequestPipeline = new WebRequestPipeline();
 
   // Important to call it in a first tick as it assigns chrome. listeners

--- a/extension-manifest-v3/src/background/stats.js
+++ b/extension-manifest-v3/src/background/stats.js
@@ -22,6 +22,7 @@ import { shouldSetDangerBadgeForTabId } from '/notifications/opera-serp.js';
 import AutoSyncingMap from '/utils/map.js';
 import { getMetadata, getUnidentifiedTracker } from '/utils/trackerdb.js';
 import Request from '/utils/request.js';
+import { isOpera } from '/utils/browser-info.js';
 
 import { getException } from './exceptions.js';
 
@@ -52,7 +53,7 @@ observe('terms', async (terms) => {
 async function refreshIcon(tabId) {
   const options = await store.resolve(Options);
 
-  if (__PLATFORM__ === 'opera' && options.terms) {
+  if (__PLATFORM__ === 'chromium' && isOpera() && options.terms) {
     shouldSetDangerBadgeForTabId(tabId).then((danger) => {
       setBadgeColor(danger ? '#f13436' /* danger-500 */ : undefined);
     });
@@ -342,7 +343,7 @@ if (__PLATFORM__ === 'safari') {
   });
 }
 
-if (__PLATFORM__ !== 'safari' && __PLATFORM__ !== 'firefox') {
+if (__PLATFORM__ === 'chromium') {
   // Gather stats for requests that are not main_frame
   chrome.webRequest.onBeforeRequest.addListener(
     (details) => {

--- a/extension-manifest-v3/src/pages/onboarding/index.js
+++ b/extension-manifest-v3/src/pages/onboarding/index.js
@@ -13,6 +13,7 @@ import { mount, html, store } from 'hybrids';
 import '@ghostery/ui/onboarding';
 
 import Options from '/store/options.js';
+import { getBrowserId } from '/utils/browser-info.js';
 
 async function updateOptions(host, event) {
   const success = event.type === 'success';
@@ -31,7 +32,7 @@ async function updateOptions(host, event) {
 mount(document.body, {
   render: () => html`
     <ui-onboarding
-      platform="${__PLATFORM__}"
+      platform="${getBrowserId()}"
       onsuccess="${updateOptions}"
       onskip="${updateOptions}"
     ></ui-onboarding>

--- a/extension-manifest-v3/src/pages/panel/store/notification.js
+++ b/extension-manifest-v3/src/pages/panel/store/notification.js
@@ -15,6 +15,7 @@ import Options from '/store/options.js';
 import Session from '/store/session.js';
 
 import { shouldShowOperaSerpAlert } from '/notifications/opera-serp.js';
+import { isOpera } from '/utils/browser-info';
 
 const NOTIFICATIONS = {
   terms: {
@@ -53,7 +54,11 @@ export default {
   url: '',
   action: '',
   [store.connect]: async () => {
-    if (__PLATFORM__ === 'opera' && (await shouldShowOperaSerpAlert())) {
+    if (
+      __PLATFORM__ === 'chromium' &&
+      isOpera() &&
+      (await shouldShowOperaSerpAlert())
+    ) {
       return NOTIFICATIONS.opera;
     }
 

--- a/extension-manifest-v3/src/pages/settings/components/devtools.js
+++ b/extension-manifest-v3/src/pages/settings/components/devtools.js
@@ -96,41 +96,40 @@ export default {
               </div>
             </div>
             <ui-line></ui-line>
-            ${__PLATFORM__ === 'chromium' ||
-            (__PLATFORM__ === 'safari' &&
-              html`
-                <div layout="column gap items:start" translate="no">
-                  <ui-text type="headline-s">Enabled DNR rulesets</ui-text>
-                  <ui-text type="body-xs" color="gray-400">
-                    The below list is not reactive to changes made in the
-                    extension - use refresh button
-                  </ui-text>
-                  <div layout="row gap">
-                    ${html.resolve(
-                      chrome.declarativeNetRequest
-                        .getEnabledRulesets()
-                        .then(
-                          (rules) => html`
-                            ${rules.map((r) => html`<ui-text>${r}</ui-text>`)}
-                            ${!rules.length &&
-                            html`<ui-text translate="no">
-                              No rulesets enabled...
-                            </ui-text>`}
-                          `,
-                        ),
-                    )}
-                  </div>
-                  <ui-button
-                    size="small"
-                    type="outline"
-                    onclick="${refresh}"
-                    layout="shrink:0"
-                  >
-                    <button>Refresh</button>
-                  </ui-button>
+            ${(__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') &&
+            html`
+              <div layout="column gap items:start" translate="no">
+                <ui-text type="headline-s">Enabled DNR rulesets</ui-text>
+                <ui-text type="body-xs" color="gray-400">
+                  The below list is not reactive to changes made in the
+                  extension - use refresh button
+                </ui-text>
+                <div layout="row gap">
+                  ${html.resolve(
+                    chrome.declarativeNetRequest
+                      .getEnabledRulesets()
+                      .then(
+                        (rules) => html`
+                          ${rules.map((r) => html`<ui-text>${r}</ui-text>`)}
+                          ${!rules.length &&
+                          html`<ui-text translate="no">
+                            No rulesets enabled...
+                          </ui-text>`}
+                        `,
+                      ),
+                  )}
                 </div>
-                <ui-line></ui-line>
-              `)}
+                <ui-button
+                  size="small"
+                  type="outline"
+                  onclick="${refresh}"
+                  layout="shrink:0"
+                >
+                  <button>Refresh</button>
+                </ui-button>
+              </div>
+              <ui-line></ui-line>
+            `}
           </section>
         `
       }

--- a/extension-manifest-v3/src/pages/settings/components/devtools.js
+++ b/extension-manifest-v3/src/pages/settings/components/devtools.js
@@ -96,40 +96,41 @@ export default {
               </div>
             </div>
             <ui-line></ui-line>
-            ${__PLATFORM__ !== 'firefox' &&
-            html`
-              <div layout="column gap items:start" translate="no">
-                <ui-text type="headline-s">Enabled DNR rulesets</ui-text>
-                <ui-text type="body-xs" color="gray-400">
-                  The below list is not reactive to changes made in the
-                  extension - use refresh button
-                </ui-text>
-                <div layout="row gap">
-                  ${html.resolve(
-                    chrome.declarativeNetRequest
-                      .getEnabledRulesets()
-                      .then(
-                        (rules) => html`
-                          ${rules.map((r) => html`<ui-text>${r}</ui-text>`)}
-                          ${!rules.length &&
-                          html`<ui-text translate="no">
-                            No rulesets enabled...
-                          </ui-text>`}
-                        `,
-                      ),
-                  )}
+            ${__PLATFORM__ === 'chromium' ||
+            (__PLATFORM__ === 'safari' &&
+              html`
+                <div layout="column gap items:start" translate="no">
+                  <ui-text type="headline-s">Enabled DNR rulesets</ui-text>
+                  <ui-text type="body-xs" color="gray-400">
+                    The below list is not reactive to changes made in the
+                    extension - use refresh button
+                  </ui-text>
+                  <div layout="row gap">
+                    ${html.resolve(
+                      chrome.declarativeNetRequest
+                        .getEnabledRulesets()
+                        .then(
+                          (rules) => html`
+                            ${rules.map((r) => html`<ui-text>${r}</ui-text>`)}
+                            ${!rules.length &&
+                            html`<ui-text translate="no">
+                              No rulesets enabled...
+                            </ui-text>`}
+                          `,
+                        ),
+                    )}
+                  </div>
+                  <ui-button
+                    size="small"
+                    type="outline"
+                    onclick="${refresh}"
+                    layout="shrink:0"
+                  >
+                    <button>Refresh</button>
+                  </ui-button>
                 </div>
-                <ui-button
-                  size="small"
-                  type="outline"
-                  onclick="${refresh}"
-                  layout="shrink:0"
-                >
-                  <button>Refresh</button>
-                </ui-button>
-              </div>
-              <ui-line></ui-line>
-            `}
+                <ui-line></ui-line>
+              `)}
           </section>
         `
       }

--- a/extension-manifest-v3/src/store/options.js
+++ b/extension-manifest-v3/src/store/options.js
@@ -12,8 +12,9 @@
 import { store } from 'hybrids';
 import { deleteDB } from 'idb';
 
-import { getUserOptions, setUserOptions } from '../utils/api.js';
-import { DEFAULT_REGIONS } from '../utils/regions.js';
+import { getUserOptions, setUserOptions } from '/utils/api.js';
+import { DEFAULT_REGIONS } from '/utils/regions.js';
+import { isOpera } from '/utils/browser-info.js';
 
 import Session from './session.js';
 import CustomFilters from './custom-filters.js';
@@ -80,7 +81,9 @@ const Options = {
     done: false,
     shownAt: 0,
     shown: 0,
-    ...(__PLATFORM__ === 'opera' ? { serpShownAt: 0, serpShown: 0 } : {}),
+    ...(__PLATFORM__ === 'chromium' && isOpera()
+      ? { serpShownAt: 0, serpShown: 0 }
+      : {}),
   },
   installDate: '',
 

--- a/extension-manifest-v3/src/utils/browser-info.js
+++ b/extension-manifest-v3/src/utils/browser-info.js
@@ -13,13 +13,13 @@ import Bowser from 'bowser';
 
 // we cache the UA as it used by many modules that need it on file load
 let ua;
-const getUA = () => {
+function getUA() {
   if (ua) {
     return ua;
   }
   ua = Bowser.parse(navigator.userAgent);
   return ua;
-};
+}
 
 async function getExtendedBrowserInfo() {
   try {
@@ -44,7 +44,7 @@ function getPlatformInfo() {
   return Promise.resolve(null);
 }
 
-const getOS = () => {
+function getOS() {
   const ua = getUA();
   const platform = ua.os?.name?.toLowerCase() || ''; // Make sure that undefined operating systems don't mess with stuff like .includes()
   if (platform.includes('mac')) {
@@ -63,33 +63,41 @@ const getOS = () => {
     return 'linux';
   }
   return 'other';
-};
+}
 
-const getBrowser = () => {
+function isAndroid() {
+  return getOS() === 'android';
+}
+
+function getBrowser() {
   const ua = getUA();
   return ua.browser.name.toLowerCase();
-};
+}
 
-const isAndroid = () => {
-  return getOS() === 'android';
-};
-
-const isFirefox = () => {
+function isFirefox() {
   const browser = getBrowser();
   return browser.includes('firefox');
-};
+}
 
-const isEdge = () => {
+function isEdge() {
   const browser = getBrowser();
   return browser.includes('edge');
-};
+}
 
-const getVersion = () => {
-  const ua = getUA();
-  return parseInt(ua.browser.version.toString(), 10); // convert to string for Chrome
-};
+export function isOpera() {
+  const browser = getBrowser();
+  return browser.includes('opera');
+}
 
-const getBrowserInfo = async () => {
+export function getBrowserId() {
+  if (isFirefox()) return 'firefox';
+  if (isEdge()) return 'edge';
+  if (isOpera()) return 'opera';
+
+  return 'chrome';
+}
+
+async function getBrowserInfo() {
   const BROWSER_INFO = {
     displayName: '',
     name: '',
@@ -130,10 +138,11 @@ const getBrowserInfo = async () => {
   BROWSER_INFO.os = getOS();
 
   // Set version property
-  BROWSER_INFO.version = getVersion();
+  BROWSER_INFO.version = parseInt(getUA().browser.version.toString(), 10); // convert to string for Chrome
 
   // Check for Ghostery browsers
   const browserInfo = await getExtendedBrowserInfo();
+
   if (browserInfo && browserInfo.name === 'Ghostery') {
     if (BROWSER_INFO.os === 'android') {
       BROWSER_INFO.displayName = 'Ghostery Android Browser';
@@ -154,16 +163,16 @@ const getBrowserInfo = async () => {
   }
 
   return BROWSER_INFO;
-};
+}
 
 let browserInfo;
-const cachedGetBrowserInfo = async () => {
+async function cachedGetBrowserInfo() {
   if (browserInfo) {
     return browserInfo;
   }
   browserInfo = await getBrowserInfo();
   return browserInfo;
-};
+}
 
 cachedGetBrowserInfo.isAndroid = isAndroid;
 cachedGetBrowserInfo.isFirefox = isFirefox;


### PR DESCRIPTION
Fixes #1866

* Removes separate `edge` and `opera` builds
* When it is most convenient changes `__PLATFORM__` checks to be opt-in
* Uses `isOpera()` util for the opera SERP notification feature