### PR TITLE
fix: unify adblocker engines update process

### DIFF
--- a/extension-manifest-v3/src/background/adblocker.js
+++ b/extension-manifest-v3/src/background/adblocker.js
@@ -22,7 +22,6 @@ import * as engines from '/utils/engines.js';
 import * as trackerdb from '/utils/trackerdb.js';
 import Request from '/utils/request.js';
 import asyncSetup from '/utils/setup.js';
-import { getMetadata } from '/utils/trackerdb.js';
 
 import { tabStats, updateTabStats } from './stats.js';
 import { getException } from './exceptions.js';
@@ -433,7 +432,7 @@ function isTrusted(request, type) {
     return false;
   }
 
-  const metadata = getMetadata(request);
+  const metadata = trackerdb.getMetadata(request);
 
   // Get exception for known tracker (metadata id) or
   // by the request hostname (unidentified tracker)

--- a/extension-manifest-v3/src/utils/engines.js
+++ b/extension-manifest-v3/src/utils/engines.js
@@ -176,16 +176,9 @@ async function loadFromFile(name) {
 
     saveToMemory(name, engine);
 
-    await saveToStorage(name)
-      .then(() =>
-        // After initial load from disk, schedule an update
-        // as it is done only once on the first run.
-        // After loading from disk, it should be loaded from the storage
-        update(name).catch(() => null),
-      )
-      .catch(() => {
-        console.error(`[engines] Failed to save engine "${name}" to storage`);
-      });
+    await saveToStorage(name).catch(() => {
+      console.error(`[engines] Failed to save engine "${name}" to storage`);
+    });
 
     return engine;
   } catch (e) {
@@ -252,7 +245,7 @@ export async function update(name) {
 
     const listURL = `https://${CDN_HOSTNAME}/adblocker/configs/${urlName}/allowed-lists.json`;
 
-    console.info(`[engines] Updating engine "${name}" from ${listURL}`);
+    console.info(`[engines] Updating engine "${name}..."`);
 
     const data = await fetch(listURL)
       .then(check)

--- a/extension-manifest-v3/src/utils/engines.js
+++ b/extension-manifest-v3/src/utils/engines.js
@@ -241,7 +241,7 @@ export async function update(name) {
       `[engines] Skipping update for engine "${name}" as the engine is not available`,
     );
 
-    return;
+    return false;
   }
 
   try {
@@ -313,7 +313,7 @@ export async function update(name) {
 
       console.info(`Engine "${name}" reloaded`);
 
-      return engine;
+      return true;
     }
 
     // At this point we know that no list needs to be removed anymore. What
@@ -419,9 +419,11 @@ export async function update(name) {
 
       // Save the new engine to storage
       saveToStorage(name);
+
+      return true;
     }
 
-    return engine;
+    return false;
   } catch (e) {
     console.error(`[engines] Failed to update engine "${name}"`, e);
     throw e;

--- a/extension-manifest-v3/src/utils/trackerdb.js
+++ b/extension-manifest-v3/src/utils/trackerdb.js
@@ -34,7 +34,7 @@ const categoryOrder = [
   'other',
 ];
 
-const setup = asyncSetup([engines.init(engines.TRACKERDB_ENGINE)]);
+export const setup = asyncSetup([engines.init(engines.TRACKERDB_ENGINE)]);
 
 export function getUnidentifiedTracker(hostname) {
   return {


### PR DESCRIPTION
A few minor fixes to the adblocker engines maintenance and update process:

* Avoids reloading the main engine when no engines were updated
* Simplifies the logic in `observe()` pattern, to make clear what when happens
* Protects `updateEngines` from calling the function before the update finishes, as there are multiple factors, which trigger the update

The update process was simplified and moved to one place. It is only triggered by the `updateEngines()` function. Also, the update is done only, if the user passes the onboarding, and then it saves the timestamp.