### PR TITLE
feat: add script for testing update process

### DIFF
--- a/extension-manifest-v3/package.json
+++ b/extension-manifest-v3/package.json
@@ -8,6 +8,7 @@
     "download-whotracksme-bloomfilter": "node scripts/download-whotracksme-bloomfilter.js",
     "build": "node scripts/build.js",
     "start": "npm run build -- --watch",
+    "start:update": "./scripts/update.sh",
     "licenses": "license-report --config=../.license-report-config.json > dist/licenses.html",
     "lint": "eslint src/",
     "test": "node --test && npm run lint",

--- a/extension-manifest-v3/scripts/build.js
+++ b/extension-manifest-v3/scripts/build.js
@@ -372,6 +372,7 @@ if (argv.watch) {
           case 'firefox':
             settings = {
               target: 'firefox-desktop',
+              devtools: true,
               firefoxBinary:
                 '/Applications/Firefox Nightly.app/Contents/MacOS/firefox-bin',
             };

--- a/extension-manifest-v3/scripts/update.sh
+++ b/extension-manifest-v3/scripts/update.sh
@@ -1,0 +1,37 @@
+# The script will download the latest tag, unzip it, and run the extension.
+# Then it will wait for the user to press enter, rebuild the extension from
+# the current branch, and finally kill the browser.
+#
+# Usage:
+#   ./scripts/update.sh [target=chromium] [tag=latest]
+#
+# Supported targets: chromium, firefox
+#
+
+target="${1:-chromium}"
+tag=${2:-$(git describe --tags `git rev-list --tags --max-count=1`)}
+version=${tag:1}
+
+webExtTarget=$target
+if [ $webExtTarget == "firefox" ]; then
+  webExtTarget="firefox-desktop"
+fi
+
+# Rebuild from latest tag
+echo "Downloading and unzipping the latest tag: $tag"
+rm -rf ./dist ./dist.zip
+curl -L -o dist.zip "https://github.com/ghostery/ghostery-extension/releases/download/$tag/ghostery-$target-$version.zip"
+unzip dist.zip -d ./dist
+rm dist.zip
+
+../node_modules/.bin/web-ext run --target=$webExtTarget --no-reload --devtools >/dev/null &
+pid=$!
+
+read -p "Booting up the target browser. Press enter to rebuild from source.."
+
+# Rebuild from source
+echo "Rebuilding from source: $currentBranch"
+npm run build $target
+
+read -p "Rebuilding done. Press enter to kill the browser..."
+kill -2 $pid


### PR DESCRIPTION
```bash
npm run start:update
```

The PR adds a helpful script for testing the behavior of the extension when it is updated. In short, the script:
1. Takes a build from GitHub
2. Unzip it in /dist
3. Runs the web-ext 
4. Waits for the user action to re-build from the source

It allows installation and onboarding of the production build, and then when needed automatically re-build the extension with the current source code.