### PR TITLE
feat: use scripting.ExecutionWorld enum for executeScript world

### DIFF
--- a/extension-manifest-v3/src/background/adblocker.js
+++ b/extension-manifest-v3/src/background/adblocker.js
@@ -349,7 +349,7 @@ ${scripts.join('\n\n')}}
   chrome.scripting.executeScript(
     {
       injectImmediately: true,
-      world: __PLATFORM__ === 'firefox' ? undefined : 'MAIN',
+      world: chrome.scripting.ExecutionWorld.MAIN,
       target: {
         tabId,
         allFrames: true,

--- a/extension-manifest-v3/src/background/adblocker.js
+++ b/extension-manifest-v3/src/background/adblocker.js
@@ -349,7 +349,10 @@ ${scripts.join('\n\n')}}
   chrome.scripting.executeScript(
     {
       injectImmediately: true,
-      world: chrome.scripting.ExecutionWorld?.MAIN || 'MAIN',
+      world:
+        chrome.scripting.ExecutionWorld?.MAIN ?? __PLATFORM__ === 'firefox'
+          ? undefined
+          : 'MAIN',
       target: {
         tabId,
         allFrames: true,

--- a/extension-manifest-v3/src/background/adblocker.js
+++ b/extension-manifest-v3/src/background/adblocker.js
@@ -350,9 +350,8 @@ ${scripts.join('\n\n')}}
     {
       injectImmediately: true,
       world:
-        chrome.scripting.ExecutionWorld?.MAIN ?? __PLATFORM__ === 'firefox'
-          ? undefined
-          : 'MAIN',
+        chrome.scripting.ExecutionWorld?.MAIN ??
+        (__PLATFORM__ === 'firefox' ? undefined : 'MAIN'),
       target: {
         tabId,
         allFrames: true,

--- a/extension-manifest-v3/src/background/adblocker.js
+++ b/extension-manifest-v3/src/background/adblocker.js
@@ -349,7 +349,7 @@ ${scripts.join('\n\n')}}
   chrome.scripting.executeScript(
     {
       injectImmediately: true,
-      world: chrome.scripting.ExecutionWorld.MAIN,
+      world: chrome.scripting.ExecutionWorld?.MAIN || 'MAIN',
       target: {
         tabId,
         allFrames: true,

--- a/extension-manifest-v3/src/background/autoconsent.js
+++ b/extension-manifest-v3/src/background/autoconsent.js
@@ -52,7 +52,10 @@ async function evalCode(snippetId, id, tabId, frameId) {
       tabId,
       frameIds: [frameId],
     },
-    world: chrome.scripting.ExecutionWorld?.MAIN ?? 'MAIN',
+    world:
+      chrome.scripting.ExecutionWorld?.MAIN || __PLATFORM__ === 'firefox'
+        ? undefined
+        : 'MAIN',
     func: snippets[snippetId],
   });
 

--- a/extension-manifest-v3/src/background/autoconsent.js
+++ b/extension-manifest-v3/src/background/autoconsent.js
@@ -53,9 +53,8 @@ async function evalCode(snippetId, id, tabId, frameId) {
       frameIds: [frameId],
     },
     world:
-      chrome.scripting.ExecutionWorld?.MAIN || __PLATFORM__ === 'firefox'
-        ? undefined
-        : 'MAIN',
+      chrome.scripting.ExecutionWorld?.MAIN ??
+      (__PLATFORM__ === 'firefox' ? undefined : 'MAIN'),
     func: snippets[snippetId],
   });
 

--- a/extension-manifest-v3/src/background/autoconsent.js
+++ b/extension-manifest-v3/src/background/autoconsent.js
@@ -52,7 +52,7 @@ async function evalCode(snippetId, id, tabId, frameId) {
       tabId,
       frameIds: [frameId],
     },
-    world: chrome.scripting.ExecutionWorld.MAIN,
+    world: chrome.scripting.ExecutionWorld?.MAIN ?? 'MAIN',
     func: snippets[snippetId],
   });
 

--- a/extension-manifest-v3/src/background/autoconsent.js
+++ b/extension-manifest-v3/src/background/autoconsent.js
@@ -52,7 +52,7 @@ async function evalCode(snippetId, id, tabId, frameId) {
       tabId,
       frameIds: [frameId],
     },
-    world: __PLATFORM__ === 'firefox' ? undefined : 'MAIN',
+    world: chrome.scripting.ExecutionWorld.MAIN,
     func: snippets[snippetId],
   });
 

--- a/extension-manifest-v3/src/background/serp.js
+++ b/extension-manifest-v3/src/background/serp.js
@@ -44,7 +44,7 @@ chrome.webNavigation.onCommitted.addListener((details) => {
         chrome.scripting.executeScript(
           {
             injectImmediately: true,
-            world: chrome.scripting.ExecutionWorld.ISOLATED,
+            world: chrome.scripting.ExecutionWorld?.ISOLATED ?? 'ISOLATED',
             target: {
               tabId: details.tabId,
             },

--- a/extension-manifest-v3/src/background/serp.js
+++ b/extension-manifest-v3/src/background/serp.js
@@ -44,7 +44,7 @@ chrome.webNavigation.onCommitted.addListener((details) => {
         chrome.scripting.executeScript(
           {
             injectImmediately: true,
-            world: 'ISOLATED',
+            world: chrome.scripting.ExecutionWorld.ISOLATED,
             target: {
               tabId: details.tabId,
             },


### PR DESCRIPTION
This fixes the autoconsent and scriptlet breakages on Firefox version greater than 127 where the scripting.ExecutionWorld.MAIN was implemented. See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/ExecutionWorld for more information. From Firefox version 128, the value of undefined given to world property of executeScript's first argument will fallback to ISOLATED.

The use of scripting.ExecutionWorld enum for world argument is better than defining in literal since we don't need to test if browser supports the execution world of MAIN. Unless browser supports MAIN world execution, the value will fallback to undefined which is safe.

---

fixes https://github.com/ghostery/broken-page-reports/issues/834
fixes https://github.com/ghostery/broken-page-reports/issues/837
fixes https://github.com/ghostery/broken-page-reports/issues/838
fixes https://github.com/ghostery/broken-page-reports/issues/839
fixes https://github.com/ghostery/broken-page-reports/issues/846
fixes https://github.com/ghostery/broken-page-reports/issues/845