### PR TITLE
Fix the TrackerDB metainformation domain lookup

### DIFF
--- a/extension-manifest-v3/src/utils/trackerdb.js
+++ b/extension-manifest-v3/src/utils/trackerdb.js
@@ -58,7 +58,7 @@ export function getMetadata(request) {
 
   // No match for the pattern, try to get metadata from the domain
   if (matches.length === 0) {
-    matches = engine.metadata.fromDomain(request.domain);
+    matches = engine.metadata.fromDomain(request.hostname);
   }
 
   // No match for the domain, try to get metadata for blocked or modified requests


### PR DESCRIPTION
Include also the subdomain information when doing a TrackerDB lookup.

For instance, the request to
`https://global.ketchcdn.com/web/v3/config/avant/website_smart_tag/boot.js` has
hostname=global.ketchcdn.com and domain=ketchcdn.com

The current TrackerDB entry is for "global.ketchcdn.com", so the lookup by domain does not return a result. The adblocker implementation will still do a lookup for the parent domain. So, it will also try out "ketchcdn.com". Because of that, there should be no need to fallback to the (parent) domain in the extension.

Test page: https://www.avantassessment.com/

This is the lookup code in the adblocker: https://github.com/ghostery/adblocker/blob/5f04d7ae0cdbdfd569ed8a9bcd14cf916f026aa1/packages/adblocker/src/engine/metadata.ts#L173

It will start with the most specific subdomain and work its way up. So, the caller can safely pass the subdomain; it will still do the lookup for the parent.