### PR TITLE
Feedback from $replace filters

### DIFF
--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -522,6 +522,8 @@ if (__PLATFORM__ === 'firefox') {
       }
 
       if (htmlFilters.length !== 0) {
+        request.modified = true;
+        updateTabStats(details.tabId, [request]);
         filterRequestHTML(
           chrome.webRequest.filterResponseData,
           request,

--- a/src/background/stats.js
+++ b/src/background/stats.js
@@ -163,6 +163,8 @@ function pushTabStats(stats, requests) {
       if (savedRequest) {
         savedRequest.blocked = savedRequest.blocked || request.blocked;
         tracker.blocked = tracker.blocked || savedRequest.blocked;
+        savedRequest.modified = savedRequest.modified || request.modified;
+        tracker.modified = tracker.modified || savedRequest.modified;
       } else {
         tracker.requestsCount = (tracker.requestsCount || 0) + 1;
         tracker.blocked = tracker.blocked || request.blocked;


### PR DESCRIPTION
On Firefox were we can run `$replace` filters, we can marked affected requests as `modified`.
<img width="352" alt="Screenshot 2024-09-26 at 16 31 54" src="https://github.com/user-attachments/assets/80bb4001-2dac-44c2-8bb2-873c419ed6ad">

Steps for reproduce: 
* go to youtube.com
* open any video
* open ghostery panel - there should be one request modified on youtube tracker