### PR TITLE
fix(engines): remove unused storage keys for Firefox fallback

### DIFF
--- a/src/utils/engines.js
+++ b/src/utils/engines.js
@@ -145,16 +145,18 @@ async function saveToStorage(name) {
 
     if (__PLATFORM__ === 'firefox') {
       // Clear out the fallback local storage if the engine is saved to the IDB
-      chrome.storage.local.set({ [`engines:${name}`]: null });
+      chrome.storage.local.remove([`engines:${name}`]);
     }
 
     await tx.done;
   } catch (e) {
     if (__PLATFORM__ === 'firefox') {
       const key = `engines:${name}`;
-      const data = engine ? { [key]: serialized } : { [key]: null };
-
-      return chrome.storage.local.set(data);
+      if (engine) {
+        return chrome.storage.local.set({ [key]: serialized });
+      } else {
+        return chrome.storage.local.remove([key]);
+      }
     }
 
     throw e;


### PR DESCRIPTION
Setting `null` or `undefined` still keeps they keys defined in the storage local. 

As this happens always to clean up the Firefox fallback, every Firefox user is affected, and have unused keys defined.