### PR TITLE
Ad-blocking: better DNR rulesets for Safari

### DIFF
--- a/scripts/download-engines.js
+++ b/scripts/download-engines.js
@@ -105,9 +105,7 @@ const DNR = {
   'dnr-ads': 'ads',
   'dnr-tracking': 'tracking',
   'dnr-annoyances': 'annoyances',
-  'dnr-ios': 'safari',
   'dnr-fixes': 'fixes',
-  'dnr-fixes-safari': 'fixes-safari',
   ...REGIONAL_ENGINES,
 };
 

--- a/src/manifest.safari-ios.json
+++ b/src/manifest.safari-ios.json
@@ -46,12 +46,17 @@
       {
         "id": "ads",
         "enabled": false,
-        "path": "rule_resources/dnr-safari.json"
+        "path": "rule_resources/dnr-ads.json"
+      },
+      {
+        "id": "annoyances",
+        "enabled": false,
+        "path": "rule_resources/dnr-annoyances.json"
       },
       {
         "id": "fixes",
         "enabled": false,
-        "path": "rule_resources/dnr-fixes-safari.json"
+        "path": "rule_resources/dnr-fixes.json"
       }
     ]
   },

--- a/src/manifest.safari-ios.json
+++ b/src/manifest.safari-ios.json
@@ -123,7 +123,7 @@
   "content_security_policy": "script-src 'self'",
   "browser_specific_settings": {
     "safari": {
-      "strict_min_version": "16.4"
+      "strict_min_version": "17.0"
     }
   }
 }

--- a/src/manifest.safari-macos.json
+++ b/src/manifest.safari-macos.json
@@ -46,12 +46,17 @@
       {
         "id": "ads",
         "enabled": false,
-        "path": "rule_resources/dnr-safari.json"
+        "path": "rule_resources/dnr-ads.json"
+      },
+      {
+        "id": "annoyances",
+        "enabled": false,
+        "path": "rule_resources/dnr-annoyances.json"
       },
       {
         "id": "fixes",
         "enabled": false,
-        "path": "rule_resources/dnr-fixes-safari.json"
+        "path": "rule_resources/dnr-fixes.json"
       }
     ]
   },

--- a/src/manifest.safari-macos.json
+++ b/src/manifest.safari-macos.json
@@ -123,7 +123,7 @@
   "content_security_policy": "script-src 'self'",
   "browser_specific_settings": {
     "safari": {
-      "strict_min_version": "16.4"
+      "strict_min_version": "17.0"
     }
   }
 }

--- a/src/utils/dnr-converter-safari.js
+++ b/src/utils/dnr-converter-safari.js
@@ -1,3 +1,14 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
 export function convert(r) {
   const rule = structuredClone(r);
   if (rule.action.type === 'modifyHeaders' || rule.action.type === 'redirect') {

--- a/src/utils/dnr-converter-safari.js
+++ b/src/utils/dnr-converter-safari.js
@@ -1,0 +1,43 @@
+export function convert(r) {
+  const rule = structuredClone(r);
+  if (rule.action.type === 'modifyHeaders' || rule.action.type === 'redirect') {
+    throw new Error(
+      'action types modifyHeaders and redirect require declarativeNetRequestWithHostAccess permission and <all_urls> host permission',
+    );
+  }
+
+  if (
+    rule.action.type === 'allowAllRequests' &&
+    (!rule.condition.resourceTypes ||
+      rule.condition.resourceTypes.length !== 1 ||
+      rule.condition.resourceTypes[0] !== 'main_frame')
+  ) {
+    throw new Error(
+      'action type allowAllRequests is only allowed for resourceType main_frame',
+    );
+  }
+
+  // Safari does not support initiatorDomains
+  if (rule.condition.initiatorDomains) {
+    const domains = rule.condition.initiatorDomains;
+    delete rule.condition.initiatorDomains;
+    rule.condition.domains = [
+      ...(rule.condition.domains || []),
+      ...domains,
+      ...domains.map((domain) => `*.${domain}`),
+    ];
+  }
+
+  // Safari does not support excludedInitiatorDomains
+  if (rule.condition.excludedInitiatorDomains) {
+    const domains = rule.condition.excludedInitiatorDomains;
+    delete rule.condition.excludedInitiatorDomains;
+    rule.condition.excludedDomains = [
+      ...(rule.condition.excludedDomains || []),
+      ...domains,
+      ...domains.map((domain) => `*.${domain}`),
+    ];
+  }
+
+  return rule;
+}

--- a/xcode/Ghostery.xcodeproj/project.pbxproj
+++ b/xcode/Ghostery.xcodeproj/project.pbxproj
@@ -1058,7 +1058,7 @@
 				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleLightContent;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1097,7 +1097,7 @@
 				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleLightContent;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
surpasses https://github.com/ghostery/ghostery-extension/pull/1943

Removed compatibility rules are no longer required as Safari ignores incompatibilities silently so the support for those features is now correct.