### PR TITLE
fix: match resources type with backend

### DIFF
--- a/scripts/download-engines.js
+++ b/scripts/download-engines.js
@@ -179,14 +179,14 @@ const resources = await fetch(
 });
 
 for (const redirect of resources.redirects) {
-  const outputPath = resolve(TARGET_PATH, 'redirects', redirect.names[0]);
+  const outputPath = resolve(TARGET_PATH, 'redirects', redirect.name);
 
-  if (redirect.encoding === 'base64') {
+  if (redirect.contentType.includes('base64')) {
     writeFileSync(
       outputPath,
-      Buffer.from(redirect.content, 'base64').toString('binary'),
+      Buffer.from(redirect.body, 'base64').toString('binary'),
     );
   } else {
-    writeFileSync(outputPath, redirect.content);
+    writeFileSync(outputPath, redirect.body);
   }
 }


### PR DESCRIPTION
The resources scheme in the backend changed and this PR reflects it into ghostery-extension.

refs https://cdn.ghostery.com/adblocker/resources/ublock-resources-json/2a905504f8511ba5256a9b8cbc9680e49c17073a0f6da6355b775a571aed9c92/list.txt