### PR TITLE
fix: clean up temporary code pointed with todo comments

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -137,20 +137,6 @@ export async function session() {
 
   let accessToken = await getCookie('access_token');
 
-  // Fix for Safari wrong implementation of getCookie/setCookie
-  // (See above fix starting in line 29. In short we were setting a cookie with
-  // a far future expiration date, so the access_token expired, but it was still
-  // in user's browser).
-  // TODO: The below code can be removed after a reasonable amount of time
-  // where most of the users have updated to the fixed version
-  if (
-    __PLATFORM__ === 'safari' &&
-    accessToken &&
-    new Date(accessToken.expirationDate).getFullYear() > 2050
-  ) {
-    accessToken = undefined;
-  }
-
   try {
     if (!accessToken) {
       const refreshToken = await getCookie('refresh_token');

--- a/src/utils/map.js
+++ b/src/utils/map.js
@@ -77,12 +77,6 @@ export default class AutoSyncingMap {
     // and log it. A potential improvement could be to treat the
     // in-memory map as the source of truth in that scenario.)
     this._pending = new Promise((resolve, reject) => {
-      // Migration to session storage
-      // TODO: Remove this code after a few releases
-      if (chrome.storage.session) {
-        chrome.storage.local.remove(this.storageKey);
-      }
-
       storage.get([this.storageKey], (result) => {
         if (chrome.runtime.lastError) {
           reject(chrome.runtime.lastError);


### PR DESCRIPTION
We have to keep two other TODOs to clean up, as the Firefox is still on 10.4.3, and `options.installDate` and clean up of `regional-filters` engine is not yet on production there.