### PR TITLE
Ad-blocking: improve scriptlet injection

### DIFF
--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -205,11 +205,9 @@ function adblockerInjectStylesWebExtension(
 }
 
 // copied from https://github.com/cliqz-oss/adblocker/blob/0bdff8559f1c19effe278b8982fb8b6c33c9c0ab/packages/adblocker-webextension/adblocker.ts#L297
-async function injectCosmetics(msg, sender) {
-  try {
-    setup.pending && (await setup.pending);
-  } catch (e) {
-    console.error(`[adblocker] Error while setup cosmetic filters: ${e}`);
+function injectCosmetics(msg, sender) {
+  if (setup.pending) {
+    console.warn(`[adblocker] not ready for cosmetic injection`);
     return;
   }
 
@@ -385,6 +383,11 @@ async function executeScriptlets(tabId, frameId, scripts) {
 }
 
 function injectScriptlets(tabId, frameId, url) {
+  if (setup.pending) {
+    console.warn('[adblocker] not ready for scriptlet injection');
+    return;
+  }
+
   const { hostname, domain } = parse(url);
   if (!hostname || isPaused(options, hostname)) {
     return;
@@ -467,9 +470,7 @@ if (__PLATFORM__ === 'firefox') {
       if (details.tabId < 0 || details.type === 'main_frame') return;
 
       if (setup.pending) {
-        console.error(
-          '[adblocker] Error while processing network request - adblocker not ready yet',
-        );
+        console.warn('[adblocker] not ready for network blocking');
         return;
       }
 
@@ -501,9 +502,7 @@ if (__PLATFORM__ === 'firefox') {
   chrome.webRequest.onHeadersReceived.addListener(
     (details) => {
       if (setup.pending) {
-        console.error(
-          '[adblocker] Error while processing headers - adblocker not ready yet',
-        );
+        console.warn('[adblocker] not ready for network modification');
         return;
       }
 

--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -458,13 +458,11 @@ function isTrusted(request, type) {
 
 if (__PLATFORM__ === 'firefox') {
   chrome.webRequest.onBeforeRequest.addListener(
-    async (details) => {
+    (details) => {
       if (details.tabId < 0 || details.type === 'main_frame') return;
 
-      try {
-        setup.pending && (await setup.pending);
-      } catch (e) {
-        console.error('[adblocker] not ready for network blocking', e);
+      if (setup.pending) {
+        console.error('[adblocker] not ready for network blocking');
         return;
       }
 
@@ -494,11 +492,9 @@ if (__PLATFORM__ === 'firefox') {
   );
 
   chrome.webRequest.onHeadersReceived.addListener(
-    async (details) => {
-      try {
-        setup.pending && (await setup.pending);
-      } catch (e) {
-        console.error('[adblocker] not ready for network modification', e);
+    (details) => {
+      if (setup.pending) {
+        console.error('[adblocker] not ready for network modification');
         return;
       }
 

--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -233,7 +233,7 @@ function injectCosmetics(msg, sender) {
   // Because of this, we specify `allFrames: true` when injecting them so
   // that we do not need to perform this operation for sub-frames.
   if (frameId === 0 && msg.lifecycle === 'start') {
-    const { active, styles } = engine.getCosmeticsFilters({
+    const { styles } = engine.getCosmeticsFilters({
       domain,
       hostname,
       url,
@@ -250,10 +250,6 @@ function injectCosmetics(msg, sender) {
       getRulesFromHostname: false,
     });
 
-    if (active === false) {
-      return;
-    }
-
     genericStyles.push(styles);
   }
 
@@ -263,7 +259,7 @@ function injectCosmetics(msg, sender) {
   // ids and hrefs observed in the DOM. MutationObserver is also used to
   // make sure we can react to changes.
   {
-    const { active, styles } = engine.getCosmeticsFilters({
+    const { styles } = engine.getCosmeticsFilters({
       domain,
       hostname,
       url,
@@ -281,10 +277,6 @@ function injectCosmetics(msg, sender) {
       // This will be done every time we get information about DOM mutation
       getRulesFromDOM: msg.lifecycle === 'dom-update',
     });
-
-    if (active === false) {
-      return;
-    }
 
     specificStyles.push(styles);
     specificFrameId = frameId;

--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -205,9 +205,11 @@ function adblockerInjectStylesWebExtension(
 }
 
 // copied from https://github.com/cliqz-oss/adblocker/blob/0bdff8559f1c19effe278b8982fb8b6c33c9c0ab/packages/adblocker-webextension/adblocker.ts#L297
-function injectCosmetics(msg, sender) {
-  if (setup.pending) {
-    console.warn(`[adblocker] not ready for cosmetic injection`);
+async function injectCosmetics(msg, sender) {
+  try {
+    setup.pending && (await setup.pending);
+  } catch (e) {
+    console.error('[adblocker] not ready for cosmetic injection', e);
     return;
   }
 
@@ -301,11 +303,7 @@ function injectCosmetics(msg, sender) {
 
 chrome.runtime.onMessage.addListener((msg, sender) => {
   if (msg.action === 'getCosmeticsFilters') {
-    injectCosmetics(msg, sender).catch((e) =>
-      console.error(
-        `[adblocker] Error while processing cosmetics filters: ${e}`,
-      ),
-    );
+    injectCosmetics(msg, sender);
   }
 
   return false;
@@ -374,9 +372,11 @@ async function executeScriptlets(tabId, frameId, scripts) {
   );
 }
 
-function injectScriptlets(tabId, frameId, url) {
-  if (setup.pending) {
-    console.warn('[adblocker] not ready for scriptlet injection');
+async function injectScriptlets(tabId, frameId, url) {
+  try {
+    setup.pending && (await setup.pending);
+  } catch (e) {
+    console.error('[adblocker] not ready for scriptlet injection', e);
     return;
   }
 
@@ -458,11 +458,13 @@ function isTrusted(request, type) {
 
 if (__PLATFORM__ === 'firefox') {
   chrome.webRequest.onBeforeRequest.addListener(
-    (details) => {
+    async (details) => {
       if (details.tabId < 0 || details.type === 'main_frame') return;
 
-      if (setup.pending) {
-        console.warn('[adblocker] not ready for network blocking');
+      try {
+        setup.pending && (await setup.pending);
+      } catch (e) {
+        console.error('[adblocker] not ready for network blocking', e);
         return;
       }
 
@@ -492,9 +494,11 @@ if (__PLATFORM__ === 'firefox') {
   );
 
   chrome.webRequest.onHeadersReceived.addListener(
-    (details) => {
-      if (setup.pending) {
-        console.warn('[adblocker] not ready for network modification');
+    async (details) => {
+      try {
+        setup.pending && (await setup.pending);
+      } catch (e) {
+        console.error('[adblocker] not ready for network modification', e);
         return;
       }
 


### PR DESCRIPTION
Surpasses: #1972 

Specifically at Safari < 18, scriptlets were not injected fast enough to block ads on some pages. This PR ensures that scritplet injection is sync. Additionally, on Safari we use two different triggering methods (content script message and webNavigation) to trigger the injection, but we ensure that scriptlets are injected only once. 

Related code was cleaned up from obsolete comments and dead paths.