### PR TITLE
fix(panel): add meta for dark mode in Safari macOS

### DIFF
--- a/src/pages/panel/index.html
+++ b/src/pages/panel/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width" />
     <title>Ghostery panel</title>
     <script type="module" src="./index.js"></script>
+    <meta content="light dark" name="color-scheme" />
   </head>
   <body tabindex="0"></body>
 </html>


### PR DESCRIPTION
Fixes the issue on Safari macOS where without the meta, the extension panel CSS does not respect the `(prefers-color-scheme: dark)`.

<img width="366" alt="Zrzut ekranu 2024-10-24 o 09 22 36" src="https://github.com/user-attachments/assets/51fbb4f5-26fe-4bee-813c-65aecc270c0d">
