### PR TITLE
fix: fallback `sender.url` on Safari

### DIFF
--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -214,7 +214,14 @@ async function injectCosmetics(msg, sender) {
   }
 
   // Extract hostname from sender's URL
-  const { url = '', frameId } = sender;
+  const { frameId } = sender;
+  let url = sender.url;
+
+  // Try `sender.tab.url` as a fallback when Safari preloads a website
+  if (!url || url === 'about:blank') {
+    url = sender.tab.url;
+  }
+
   const parsed = parse(url);
   const hostname = parsed.hostname || '';
   const domain = parsed.domain || '';

--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -215,8 +215,7 @@ async function injectCosmetics(msg, sender) {
 
   // Extract hostname from sender's URL
   const { frameId } = sender;
-  const { url } = sender.tab;
-
+  const url = sender.tab?.url || sender.url;
   const parsed = parse(url);
   const hostname = parsed.hostname || '';
   const domain = parsed.domain || '';

--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -215,12 +215,7 @@ async function injectCosmetics(msg, sender) {
 
   // Extract hostname from sender's URL
   const { frameId } = sender;
-  let url = sender.url;
-
-  // Try `sender.tab.url` as a fallback when Safari preloads a website
-  if (!url || url === 'about:blank') {
-    url = sender.tab.url;
-  }
+  const { url } = sender.tab;
 
   const parsed = parse(url);
   const hostname = parsed.hostname || '';


### PR DESCRIPTION
fixes https://github.com/ghostery/ghostery-extension/issues/1995
refs https://github.com/ghostery/broken-page-reports/issues/935
refs https://github.com/ghostery/adblocker/issues/4396