### PR TITLE
Open the privacy policy in onboarding in a new tab

### DIFF
--- a/src/pages/onboarding/views/main.js
+++ b/src/pages/onboarding/views/main.js
@@ -12,7 +12,7 @@
 import { define, html, msg, router } from 'hybrids';
 import { GHOSTERY_DOMAIN } from '/utils/urls.js';
 
-import Privacy from './privacy.js';
+import Privacy, { PRIVACY_POLICY_URL } from './privacy.js';
 import Skip from './skip.js';
 import Success from './success.js';
 
@@ -47,8 +47,8 @@ export default define({
         <ui-text type="body-s" underline>
           ${msg.html`
               Information about web trackers, add-on health and performance telemetry will be shared in accordance with our <a href="${
-                __PLATFORM__ === 'firefox'
-                  ? 'https://addons.mozilla.org/firefox/addon/ghostery/privacy/'
+                __PLATFORM__ !== 'safari'
+                  ? PRIVACY_POLICY_URL
                   : router.url(Privacy)
               }" target="_blank" rel="noreferrer">Privacy Policy</a>, advancing privacy protection for the Ghostery community. | 'add-on' means 'browser extension'
             `}

--- a/src/pages/onboarding/views/privacy.js
+++ b/src/pages/onboarding/views/privacy.js
@@ -11,9 +11,17 @@
 
 import { define, html, router } from 'hybrids';
 
-const PRIVACY_POLICY_URL = `https://www.${
-  chrome.runtime.getManifest().debug ? 'ghosterystage' : 'ghostery'
-}.com/privacy-policy`;
+function getPrivacyPolicySource() {
+  if (__PLATFORM__ === 'firefox') {
+    return 'https://addons.mozilla.org/firefox/addon/ghostery/privacy/';
+  }
+  if (chrome.runtime.getManifest().debug) {
+    return 'https://www.ghosterystage.com/privacy-policy';
+  }
+  return 'https://www.ghostery.com/privacy-policy';
+}
+
+export const PRIVACY_POLICY_URL = getPrivacyPolicySource();
 
 function scrollToAnchor(host, event) {
   let anchor = event.target;


### PR DESCRIPTION
Always open the privacy policy in onboarding in a new tab like on Firefox. Leaving it only on Safari, because it is mandated by their policies.

This effectively changes Chromium-based browsers. The URL itself is unchanged (https://www.ghostery.com/privacy-policy), but it opens in a new tab.