### PR TITLE
fix(options): Run observers parallel

### DIFF
--- a/src/utils/options-observer.js
+++ b/src/utils/options-observer.js
@@ -23,7 +23,7 @@ function isOptionEqual(a, b) {
   );
 }
 
-const observers = new Set();
+const observers = [];
 let setup = null;
 
 export function addListener(...args) {
@@ -52,9 +52,8 @@ export function addListener(...args) {
       if (isOptionEqual(value, prevValue)) return;
 
       try {
-        console.group(`[options] "${fn.name || property}" observer`);
+        console.debug(`[options] Executing "${fn.name || property}" observer`);
         await fn(value, prevValue);
-        console.groupEnd();
         resolve();
       } catch (e) {
         reject(e);
@@ -62,7 +61,7 @@ export function addListener(...args) {
       }
     };
 
-    observers.add(wrapper);
+    observers.push(wrapper);
   });
 }
 
@@ -72,20 +71,22 @@ export async function waitForIdle() {
 }
 
 export async function execute(options, prevOptions) {
-  if (observers.size === 0) return;
+  if (observers.length === 0) return;
 
   const queue = Promise.allSettled([...queues]).then(async () => {
-    console.debug(`[options] Run observers (start)`);
+    console.debug(`[options] Start observers...`);
 
-    for (const fn of observers) {
-      try {
-        await fn(options, prevOptions);
-      } catch (e) {
-        console.error(`Error while executing observer: `, e);
-      }
-    }
+    await Promise.all(
+      observers.map(async (fn) => {
+        try {
+          await fn(options, prevOptions);
+        } catch (e) {
+          console.error(`Error while executing observer: `, e);
+        }
+      }),
+    );
 
-    console.debug(`[options] Run observers (end)`);
+    console.debug(`[options] Observers finished...`);
     queues.delete(queue);
   });
 


### PR DESCRIPTION
With the latest change introducing the `OptionsObserver`, the listeners are called one by one. Mostly, it is not an issue, but it may interfer with `asyncSetup` if one of the listener will wait more than 10 seconds.

For example, in Safari updating DNR rules take a lot of time, which made next listeners not setup correctly on the first start-up.

This PR changes that to call them changin a wait of one by one to wait for all to finish.