### PR TITLE
fix(regional-filters): generate DNR rulesets for Chromium

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -141,6 +141,17 @@ cpSync(
 if (manifest.declarative_net_request?.rule_resources) {
   let rulesCount = 0;
 
+  // Add regional DNR rules to Chromium
+  if (argv.target === 'chromium') {
+    REGIONS.forEach((region) => {
+      manifest.declarative_net_request.rule_resources.push({
+        id: `lang-${region}`,
+        enabled: false,
+        path: `rule_resources/dnr-lang-${region}.json`,
+      });
+    });
+  }
+
   manifest.declarative_net_request.rule_resources.forEach(({ path }) => {
     const dir = dirname(path);
     const file = basename(path);

--- a/src/manifest.chromium.json
+++ b/src/manifest.chromium.json
@@ -64,61 +64,6 @@
         "id": "fixes",
         "enabled": false,
         "path": "rule_resources/dnr-fixes.json"
-      },
-      {
-        "id": "lang-ar",
-        "enabled": false,
-        "path": "rule_resources/dnr-lang-ar.json"
-      },
-      {
-        "id": "lang-de",
-        "enabled": false,
-        "path": "rule_resources/dnr-lang-de.json"
-      },
-      {
-        "id": "lang-el",
-        "enabled": false,
-        "path": "rule_resources/dnr-lang-el.json"
-      },
-      {
-        "id": "lang-fr",
-        "enabled": false,
-        "path": "rule_resources/dnr-lang-fr.json"
-      },
-      {
-        "id": "lang-hu",
-        "enabled": false,
-        "path": "rule_resources/dnr-lang-hu.json"
-      },
-      {
-        "id": "lang-it",
-        "enabled": false,
-        "path": "rule_resources/dnr-lang-it.json"
-      },
-      {
-        "id": "lang-ja",
-        "enabled": false,
-        "path": "rule_resources/dnr-lang-ja.json"
-      },
-      {
-        "id": "lang-ko",
-        "enabled": false,
-        "path": "rule_resources/dnr-lang-ko.json"
-      },
-      {
-        "id": "lang-pl",
-        "enabled": false,
-        "path": "rule_resources/dnr-lang-pl.json"
-      },
-      {
-        "id": "lang-ru",
-        "enabled": false,
-        "path": "rule_resources/dnr-lang-ru.json"
-      },
-      {
-        "id": "lang-tr",
-        "enabled": false,
-        "path": "rule_resources/dnr-lang-tr.json"
       }
     ]
   },


### PR DESCRIPTION
We have updated regional filter supported langauges a few times, but we forgot to update the manifest, where the DNR rulests were set by hand. As the result, the latest added regions have only cosmetics.

This PR makes the list auto-generated from the regional filters source of truth - `stc/utils/regions.js`.