### PR TITLE
fix(adblocker): match logic between onHeadersReceived and onBeforeRequest

### DIFF
--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -469,7 +469,7 @@ if (__PLATFORM__ === 'firefox') {
       if (details.tabId < 0 || details.type === 'main_frame') return;
 
       if (setup.pending) {
-        console.error('[adblocker] not ready for network blocking');
+        console.error('[adblocker] not ready for network requests blocking');
         return;
       }
 
@@ -500,8 +500,10 @@ if (__PLATFORM__ === 'firefox') {
 
   chrome.webRequest.onHeadersReceived.addListener(
     (details) => {
+      if (details.tabId < 0 || details.type === 'main_frame') return;
+
       if (setup.pending) {
-        console.error('[adblocker] not ready for network modification');
+        console.error('[adblocker] not ready for network headers modification');
         return;
       }
 


### PR DESCRIPTION
This PR matches the logic of the `onHeadersReceived` listener with the `onBeforeRequest`.

https://github.com/ghostery/ghostery-extension/blob/075cdd43ac816d48337e62ee0eec8d7b2f6eac31/src/background/adblocker.js#L469

The issue was found with the managed state of the extension. Requests to update the engines generate error logs, as there is no way that the engine is ready yet.

<img width="748" alt="Zrzut ekranu 2024-11-3 o 17 34 24" src="https://github.com/user-attachments/assets/185eb5e5-2cf5-4549-b54d-8f0b7de425c4">
