### PR TITLE
fix(adblocker): early execution of adblocker cosmetics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@duckduckgo/autoconsent": "^10.17.0",
         "@ghostery/adblocker": "^2.0.3",
         "@ghostery/adblocker-webextension": "^2.0.3",
-        "@ghostery/adblocker-webextension-cosmetics": "^2.0.3",
         "@github/relative-time-element": "^4.3.0",
         "@sentry/browser": "^8.36.0",
         "@whotracksme/reporting": "^5.1.29",
@@ -1051,16 +1050,6 @@
         "@ghostery/adblocker-content": "^2.0.3",
         "tldts-experimental": "^6.0.14",
         "webextension-polyfill": "^0.12.0"
-      }
-    },
-    "node_modules/@ghostery/adblocker-webextension-cosmetics": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-webextension-cosmetics/-/adblocker-webextension-cosmetics-2.0.3.tgz",
-      "integrity": "sha512-VrhbfLnX83TFMfJendYDER9vGw0MiZx1q+qOu1ReTpUMviui3smre8MLMR18ZuJuGAo8useHf3ESW6L9ZHwKug==",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@ghostery/adblocker-content": "^2.0.3",
-        "@ghostery/adblocker-extended-selectors": "^2.0.3"
       }
     },
     "node_modules/@ghostery/adblocker/node_modules/@types/chrome": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@duckduckgo/autoconsent": "^10.17.0",
     "@ghostery/adblocker": "^2.0.3",
     "@ghostery/adblocker-webextension": "^2.0.3",
-    "@ghostery/adblocker-webextension-cosmetics": "^2.0.3",
     "@github/relative-time-element": "^4.3.0",
     "@sentry/browser": "^8.36.0",
     "@whotracksme/reporting": "^5.1.29",

--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -221,7 +221,7 @@ async function injectScriptlets(scripts, tabId, frameId) {
   );
 }
 
-function injectCSS(styles, tabId, frameId) {
+function injectStyles(styles, tabId, frameId) {
   const target = { tabId };
 
   if (frameId !== undefined) {
@@ -288,7 +288,7 @@ async function injectCosmetics(details, config) {
     }
 
     if (cosmetics.styles) {
-      injectCSS(cosmetics.styles, tabId, frameId);
+      injectStyles(cosmetics.styles, tabId, frameId);
     }
   }
 
@@ -306,7 +306,7 @@ async function injectCosmetics(details, config) {
       getRulesFromHostname: false,
     });
 
-    injectCSS(styles, tabId);
+    injectStyles(styles, tabId);
   }
 }
 

--- a/src/content_scripts/adblocker-scriptlets.js
+++ b/src/content_scripts/adblocker-scriptlets.js
@@ -1,5 +1,0 @@
-// Should only be needed on Safari:
-// the tabId of the initial chrome.webNavigation.onCommitted
-// is not reliable. When opening bookmarks, it can happen that
-// the event is associated with a tabId of 0.
-chrome.runtime.sendMessage({ action: 'injectScriptlets' });

--- a/src/content_scripts/adblocker.js
+++ b/src/content_scripts/adblocker.js
@@ -84,7 +84,7 @@ const observer = new MutationObserver((mutations) => {
         if (mutation.attributeName === 'class') {
           mutation.target.classList.forEach((c) => addSelector('classes', c));
         } else if (mutation.attributeName === 'id') {
-          addSelector('ids', mutation.target.id);
+          addSelector('ids', mutation.target.getAttribute('id'));
         } else if (mutation.attributeName === 'href') {
           addSelector('hrefs', mutation.target.href);
         }
@@ -107,7 +107,7 @@ const observer = new MutationObserver((mutations) => {
                 el.classList.forEach((c) => addSelector('classes', c));
               }
 
-              addSelector('ids', el.id);
+              addSelector('ids', el.getAttribute('id'));
               addSelector('hrefs', el.href);
             }
 

--- a/src/content_scripts/adblocker.js
+++ b/src/content_scripts/adblocker.js
@@ -26,7 +26,7 @@ function debounce(fn, { waitFor, maxWait }) {
   };
 
   return () => {
-    if (maxWaitTimer === undefined) {
+    if (maxWait > 0 && maxWaitTimer === undefined) {
       maxWaitTimer = setTimeout(run, maxWait);
     }
     clearTimeout(delayedTimer);

--- a/src/content_scripts/adblocker.js
+++ b/src/content_scripts/adblocker.js
@@ -86,7 +86,7 @@ const observer = new MutationObserver((mutations) => {
         } else if (mutation.attributeName === 'id') {
           addSelector('ids', mutation.target.getAttribute('id'));
         } else if (mutation.attributeName === 'href') {
-          addSelector('hrefs', mutation.target.href);
+          addSelector('hrefs', mutation.target.getAttribute('href'));
         }
         break;
       }
@@ -108,7 +108,7 @@ const observer = new MutationObserver((mutations) => {
               }
 
               addSelector('ids', el.getAttribute('id'));
-              addSelector('hrefs', el.href);
+              addSelector('hrefs', el.getAttribute('href'));
             }
 
             el = treeWalker.nextNode();

--- a/src/manifest.safari.json
+++ b/src/manifest.safari.json
@@ -74,12 +74,6 @@
       "all_frames": true
     },
     {
-      "js": ["content_scripts/adblocker-scriptlets.js"],
-      "matches": ["http://*/*", "https://*/*"],
-      "run_at": "document_start",
-      "all_frames": true
-    },
-    {
       "js": ["content_scripts/autoconsent.js"],
       "matches": ["http://*/*", "https://*/*"],
       "run_at": "document_start",

--- a/tests/e2e/spec/main.spec.js
+++ b/tests/e2e/spec/main.spec.js
@@ -48,8 +48,9 @@ describe('Main Features', function () {
     });
   });
 
-  describe('Ad-Blocking', function () {
+  describe.only('Ad-Blocking', function () {
     const SELECTOR = 'ad-slot';
+    const DYNAMIC_SELECTOR = '#player-ads';
 
     it('does not block ads on a page', async function () {
       await setPrivacyToggle('ad-blocking', false);
@@ -62,6 +63,26 @@ describe('Main Features', function () {
 
       await browser.url(PAGE_URL);
       await expect($(SELECTOR)).not.toBeDisplayed();
+    });
+
+    it('blocks dynamic ads on a page', async function () {
+      await setPrivacyToggle('ad-blocking', true);
+
+      await browser.url(PAGE_URL);
+
+      await browser.execute(function (selector) {
+        const adSlot = document.createElement('div');
+
+        adSlot.id = selector.slice(1);
+        adSlot.style.width = '300px';
+        adSlot.style.height = '250px';
+        adSlot.style.backgroundColor = 'yellow';
+
+        document.body.appendChild(adSlot);
+      }, DYNAMIC_SELECTOR);
+
+      await expect($(DYNAMIC_SELECTOR)).toExist();
+      await expect($(DYNAMIC_SELECTOR)).not.toBeDisplayed();
     });
   });
 

--- a/tests/e2e/spec/main.spec.js
+++ b/tests/e2e/spec/main.spec.js
@@ -48,7 +48,7 @@ describe('Main Features', function () {
     });
   });
 
-  describe.only('Ad-Blocking', function () {
+  describe('Ad-Blocking', function () {
     const SELECTOR = 'ad-slot';
     const DYNAMIC_SELECTOR = '#player-ads';
 


### PR DESCRIPTION
## Background of the changes

Currently the `dist/content_scripts/adblocker.js` has 736 lines of code, which over 90% is not used.

We do the following logic at the start-up of the content script (implicitly by calling `injectCosmetics()` from `'@ghostery/adblocker-webextension-cosmetics'`):

```js
getCosmeticsFilters({ lifecycle: 'start', ids: [], classes: [], hrefs: [] }).then((response) => 
handleResponseFromBackground(window, response));
```

Our code always responds with an empty object `{}` so the whole logic behind `handleResponseFromBackground` is not needed.

## New execution logic

Because the first initial call for cosmetics is made without any information from the page, we can call for them upfront using `onCommitted` listener. Also, we can merge calls for scriptlets and styles to only one `engine.getCosmeticFilters()`, and use both results (styles and scripts) for injection.

## Listen to DOM updates

The logic from `adblocker-webextension-cosmetics'` was rewritten as close as possible to the original logic. Still, as the `DOMMonitor` is for a general usage, there is a lot of logic, which can be simplified. After all, the idea is to catch all of the "new" classes, ids, and hrefs, that are added to the page.

## Safari `onCommitted` bug

I carefully checked if the bug still exists, and after testing on macOS (18.0.1), iOS - iPad 17.5 (simulator), iPhone 17.5 (physical device) - I can prove that opening page from bookmarks or pasting the URL in the new tab executes `onCommitted` callback correctly. I cannot reproduce a situation where the listener is not called...

If the above is right, we can remove from Safari the need for:
* Additional call to the BG from the content script
* A race condition for executing scriptlets

## Injecting styles

The injection of styles can be simplified to use only the `chrome.scripting.insertCSS` - all supported browsers have that API.