### PR TITLE
chore(deps): set weekly update schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       - dependency-name: 'tldts-experimental'
     schedule:
       interval: 'daily'
+      time: '07:00'
     reviewers:
       - 'smalluban'
       - 'chrmod'
@@ -25,6 +26,7 @@ updates:
       - dependency-name: 'tldts-experimental'
     schedule:
       interval: 'weekly'
+      time: '07:00'
     reviewers:
       - 'smalluban'
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,23 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    directory: "/"
+    directory: '/'
     schedule:
-      interval: daily
-      time: "04:00"
+      interval: weekly
+      time: '06:00'
     open-pull-requests-limit: 99
     groups:
       wdio:
         patterns:
-          - "@wdio/*"
+          - '@wdio/*'
       adblocker:
         patterns:
-          - "@ghostery/adblocker*"
+          - '@ghostery/adblocker*'
       web-ext:
         patterns:
-          - "web-ext"
-          - "addon-linter"
+          - 'web-ext'
+          - 'addon-linter'
       eslint:
         patterns:
-          - "eslint*"
-          - "@eslint/*"
+          - 'eslint*'
+          - '@eslint/*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
       - dependency-name: 'tldts-experimental'
     schedule:
       interval: 'daily'
+    reviewers:
+      - 'smalluban'
+      - 'chrmod'
     open-pull-requests-limit: 99
     groups:
       adblocker:
@@ -22,6 +25,8 @@ updates:
       - dependency-name: 'tldts-experimental'
     schedule:
       interval: 'weekly'
+    reviewers:
+      - 'smalluban'
     groups:
       eslint:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,39 @@
 version: 2
 updates:
-  - package-ecosystem: npm
+  - package-ecosystem: 'npm'
     directory: '/'
+    allow:
+      - dependency-type: 'production'
+    ignore:
+      - dependency-name: 'tldts-experimental'
     schedule:
-      interval: weekly
-      time: '06:00'
+      interval: 'daily'
     open-pull-requests-limit: 99
     groups:
-      wdio:
-        patterns:
-          - '@wdio/*'
       adblocker:
         patterns:
           - '@ghostery/adblocker*'
-      web-ext:
-        patterns:
-          - 'web-ext'
-          - 'addon-linter'
+  - package-ecosystem: npm
+    directory: '/'
+    allow:
+      - dependency-type: 'development'
+      # 'tldts-experimental' updates frequently, but we need to keep it up to date
+      # for each release to the production, which happens at most once a week.
+      - dependency-name: 'tldts-experimental'
+    schedule:
+      interval: 'weekly'
+    groups:
       eslint:
         patterns:
           - 'eslint*'
           - '@eslint/*'
+      wdio:
+        patterns:
+          - '@wdio/*'
+      web-ext:
+        patterns:
+          - 'web-ext'
+          - 'addon-linter'
+    # Makes it possible to have another config. for the same dir.
+    # https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219
+    target-branch: main


### PR DESCRIPTION
We are flooded with compensating updates, like `tldsts`, which updates very often, but to production we deliver only the latest change before the release. I think there is no point to update deps that often. 

If there are internal deps, we can always update them by hand (like adblocker or reporting).

The weekly update should fit well with our current weekly release process.