### PR TITLE
fix(sync): move options sync to background process

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -24,6 +24,7 @@ import './serp.js';
 
 import './helpers.js';
 import './external.js';
+import './sync.js';
 
 import './reporting/index.js';
 import './telemetry/index.js';

--- a/src/background/session.js
+++ b/src/background/session.js
@@ -8,49 +8,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
-import { store } from 'hybrids';
-
-import Options, { sync } from '/store/options.js';
-import Session, { UPDATE_SESSION_ACTION_NAME } from '/store/session.js';
-
+import { UPDATE_SESSION_ACTION_NAME } from '/store/session.js';
 import { HOME_PAGE_URL, ACCOUNT_PAGE_URL } from '/utils/api.js';
-
-// Trigger options sync every one day
-const ALARM_SYNC_OPTIONS = 'session:sync:options';
-const ALARM_SYNC_OPTIONS_RATE = 1 * 60 * 24; // 1 day in minutes
-
-// Try to check cookies every 30 days if the user is still logged in
-const ALARM_UPDATE_SESSION = 'session:update';
-const ALARM_UPDATE_SESSION_DELAY = 1000 * 60 * 24 * 30; // 30 days in milliseconds
-
-async function syncOptions() {
-  sync(await store.resolve(Options));
-}
 
 // Observe cookie changes (login/logout actions)
 chrome.webNavigation.onDOMContentLoaded.addListener(async ({ url = '' }) => {
   if (url === HOME_PAGE_URL || url.includes(ACCOUNT_PAGE_URL)) {
-    const { user } = await store.resolve(Session);
-
-    if (user) {
-      if (!(await chrome.alarms.get(ALARM_SYNC_OPTIONS))) {
-        chrome.alarms.create(ALARM_SYNC_OPTIONS, {
-          periodInMinutes: ALARM_SYNC_OPTIONS_RATE,
-        });
-      }
-
-      if (!(await chrome.alarms.get(ALARM_UPDATE_SESSION))) {
-        chrome.alarms.create(ALARM_UPDATE_SESSION, {
-          when: Date.now() + ALARM_UPDATE_SESSION_DELAY,
-        });
-      }
-    } else {
-      chrome.alarms.clear(ALARM_SYNC_OPTIONS);
-      chrome.alarms.clear(ALARM_UPDATE_SESSION);
-    }
-
-    syncOptions();
-
     // Send message to update session in other contexts
     chrome.runtime
       .sendMessage({ action: UPDATE_SESSION_ACTION_NAME })
@@ -58,27 +21,5 @@ chrome.webNavigation.onDOMContentLoaded.addListener(async ({ url = '' }) => {
       // when the background process starts, but there is no other content script or
       // extension page, which could receive a message.
       .catch(() => null);
-  }
-});
-
-chrome.alarms.onAlarm.addListener(async ({ name }) => {
-  switch (name) {
-    case ALARM_SYNC_OPTIONS:
-      syncOptions();
-      break;
-    case ALARM_UPDATE_SESSION: {
-      const { user } = await store.resolve(Session);
-
-      if (!user) {
-        chrome.alarms.clear(ALARM_UPDATE_SESSION);
-      } else {
-        chrome.alarms.create(ALARM_UPDATE_SESSION, {
-          when: Date.now() + ALARM_UPDATE_SESSION_DELAY,
-        });
-      }
-      break;
-    }
-    default:
-      break;
   }
 });

--- a/src/background/sync.js
+++ b/src/background/sync.js
@@ -12,126 +12,113 @@ import { store } from 'hybrids';
 
 import Options, { SYNC_OPTIONS } from '/store/options.js';
 import Session from '/store/session.js';
+
 import { getUserOptions, setUserOptions } from '/utils/api.js';
 import * as OptionsObserver from '/utils/options-observer.js';
 import { HOME_PAGE_URL, ACCOUNT_PAGE_URL } from '/utils/api.js';
+import debounce from '/utils/debounce.js';
 
-async function sync(options, prevOptions) {
-  if (sync.pending) {
-    console.warn('[sync] Sync already in progress...');
-    return;
-  }
-
-  try {
-    sync.pending = true;
-
-    // Do not sync if revision is set or terms and sync options are false
-    if (!options.terms || !options.sync) {
-      return;
-    }
-
-    const { user } = await store.resolve(Session);
-
-    // If user is not logged in, clean up options revision and return
-    if (!user) {
-      if (options.revision !== 0) {
-        store.set(Options, { revision: 0 });
-      }
-      return;
-    }
-
-    const keys =
-      prevOptions &&
-      SYNC_OPTIONS.filter(
-        (key) => !OptionsObserver.isOptionEqual(options[key], prevOptions[key]),
-      );
-
-    // If options update, set revision to "dirty" state
-    if (keys && options.revision > 0) {
-      // Updated keys are not synchronized
-      if (keys.length === 0) return;
-
-      options = await store.set(Options, { revision: options.revision * -1 });
-    }
-
-    const serverOptions = await getUserOptions();
-
-    // Server has newer options - merge with local options
-    // The try/catch block is used to prevent failure of updating local options
-    // with server options with obsolete structure
+const syncOptions = debounce(
+  async function (options, prevOptions) {
     try {
-      if (serverOptions.revision > Math.abs(options.revision)) {
-        console.info(
-          '[sync] Merging server options with revision:',
-          serverOptions.revision,
-        );
-        const values = SYNC_OPTIONS.reduce(
-          (acc, key) => {
-            if (
-              !keys?.includes(key) &&
-              hasOwnProperty.call(serverOptions, key)
-            ) {
-              acc[key] = serverOptions[key];
-            }
+      // Skip if revision has changed
+      if (prevOptions && options.revision !== prevOptions.revision) return;
 
-            return acc;
-          },
-          { revision: serverOptions.revision },
+      // Clean up if sync should be disabled
+      if (
+        !options.terms ||
+        !options.sync ||
+        !(await store.resolve(Session)).user
+      ) {
+        if (options.revision !== 0) {
+          store.set(Options, { revision: 0 });
+        }
+        return;
+      }
+
+      const keys =
+        prevOptions &&
+        SYNC_OPTIONS.filter(
+          (key) =>
+            !OptionsObserver.isOptionEqual(options[key], prevOptions[key]),
         );
 
-        options = await store.set(Options, values);
+      // If options update, set revision to "dirty" state
+      if (keys && options.revision > 0) {
+        // Updated keys are not on the list of synced options
+        if (keys.length === 0) return;
+
+        options = await store.set(Options, { revision: options.revision * -1 });
+      }
+
+      const serverOptions = await getUserOptions();
+
+      // Server has newer options - merge with local options
+      // The try/catch block is used to prevent failure of updating local options
+      // with server options with obsolete structure
+      try {
+        if (serverOptions.revision > Math.abs(options.revision)) {
+          console.info(
+            '[sync] Merging server options with revision:',
+            serverOptions.revision,
+          );
+          const values = SYNC_OPTIONS.reduce(
+            (acc, key) => {
+              if (
+                !keys?.includes(key) &&
+                hasOwnProperty.call(serverOptions, key)
+              ) {
+                acc[key] = serverOptions[key];
+              }
+
+              return acc;
+            },
+            { revision: serverOptions.revision },
+          );
+
+          options = await store.set(Options, values);
+        }
+      } catch (e) {
+        console.error(`[sync] Error while merging server options: `, e);
+      }
+
+      // Set options or update:
+      // * No revision on server - initial sync
+      // * Keys are passed - options update
+      // * Revision is negative - local options are dirty (not synced)
+      if (!serverOptions.revision || keys?.length || options.revision < 0) {
+        const { revision } = await setUserOptions(
+          SYNC_OPTIONS.reduce(
+            (acc, key) => {
+              if (hasOwnProperty.call(options, key)) {
+                acc[key] = options[key];
+              }
+              return acc;
+            },
+            { revision: serverOptions.revision + 1 },
+          ),
+        );
+
+        // Update local revision
+        await store.set(Options, { revision });
+        console.info('[sync] Options synced with revision:', revision);
       }
     } catch (e) {
-      console.error(`[sync] Error while merging server options: `, e);
+      console.error(`[sync] Error while syncing options: `, e);
     }
-
-    // Set options or update:
-    // * No revision on server - initial sync
-    // * Keys are passed - options update
-    // * Revision is negative - local options are dirty (not synced)
-    if (!serverOptions.revision || keys || options.revision < 0) {
-      console.info('[sync] Syncing options with updated keys:', keys);
-      const { revision } = await setUserOptions(
-        SYNC_OPTIONS.reduce(
-          (acc, key) => {
-            if (hasOwnProperty.call(options, key)) {
-              acc[key] = options[key];
-            }
-            return acc;
-          },
-          { revision: serverOptions.revision + 1 },
-        ),
-      );
-
-      // Update local revision
-      await store.set(Options, { revision });
-      console.info('[sync] Options synced with revision:', revision);
-    }
-  } catch (e) {
-    console.error(`[sync] Error while syncing options: `, e);
-  } finally {
-    sync.pending = false;
-  }
-}
+  },
+  // Avoid syncing twice with fast toggling an option
+  { waitFor: 200 },
+);
 
 // Sync options on startup and when options change
-OptionsObserver.addListener(function syncOptions(options, prevOptions) {
-  // Sync options on startup
-  if (!prevOptions) {
-    sync(options);
-  }
-
-  // Sync options when options change (skip on revision change)
-  else if (options.revision === prevOptions.revision) {
-    sync(options, prevOptions);
-  }
-});
+OptionsObserver.addListener(syncOptions);
 
 // Sync options when a user logs in/out directly
 // from the ghostery.com page (not from the settings page)
 chrome.webNavigation.onDOMContentLoaded.addListener(async ({ url = '' }) => {
   if (url === HOME_PAGE_URL || url.includes(ACCOUNT_PAGE_URL)) {
-    store.resolve(Options).then((options) => sync(options));
+    store.resolve(Options).then((options) => syncOptions(options));
   }
 });
 
@@ -139,6 +126,6 @@ chrome.webNavigation.onDOMContentLoaded.addListener(async ({ url = '' }) => {
 // to force sync options when opened
 chrome.runtime.onMessage.addListener((msg) => {
   if (msg.action === 'syncOptions') {
-    store.resolve(Options).then((options) => sync(options));
+    store.resolve(Options).then((options) => syncOptions(options));
   }
 });

--- a/src/background/sync.js
+++ b/src/background/sync.js
@@ -112,7 +112,9 @@ const syncOptions = debounce(
 );
 
 // Sync options on startup and when options change
-OptionsObserver.addListener(syncOptions);
+OptionsObserver.addListener(function sync(options, prevOptions) {
+  syncOptions(options, prevOptions);
+});
 
 // Sync options when a user logs in/out directly
 // from the ghostery.com page (not from the settings page)

--- a/src/background/sync.js
+++ b/src/background/sync.js
@@ -1,0 +1,144 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+import { store } from 'hybrids';
+
+import Options, { SYNC_OPTIONS } from '/store/options.js';
+import Session from '/store/session.js';
+import { getUserOptions, setUserOptions } from '/utils/api.js';
+import * as OptionsObserver from '/utils/options-observer.js';
+import { HOME_PAGE_URL, ACCOUNT_PAGE_URL } from '/utils/api.js';
+
+async function sync(options, prevOptions) {
+  if (sync.pending) {
+    console.warn('[sync] Sync already in progress...');
+    return;
+  }
+
+  try {
+    sync.pending = true;
+
+    // Do not sync if revision is set or terms and sync options are false
+    if (!options.terms || !options.sync) {
+      return;
+    }
+
+    const { user } = await store.resolve(Session);
+
+    // If user is not logged in, clean up options revision and return
+    if (!user) {
+      if (options.revision !== 0) {
+        store.set(Options, { revision: 0 });
+      }
+      return;
+    }
+
+    const keys =
+      prevOptions &&
+      SYNC_OPTIONS.filter(
+        (key) => !OptionsObserver.isOptionEqual(options[key], prevOptions[key]),
+      );
+
+    // If options update, set revision to "dirty" state
+    if (keys && options.revision > 0) {
+      // Updated keys are not synchronized
+      if (keys.length === 0) return;
+
+      options = await store.set(Options, { revision: options.revision * -1 });
+    }
+
+    const serverOptions = await getUserOptions();
+
+    // Server has newer options - merge with local options
+    // The try/catch block is used to prevent failure of updating local options
+    // with server options with obsolete structure
+    try {
+      if (serverOptions.revision > Math.abs(options.revision)) {
+        console.info(
+          '[sync] Merging server options with revision:',
+          serverOptions.revision,
+        );
+        const values = SYNC_OPTIONS.reduce(
+          (acc, key) => {
+            if (
+              !keys?.includes(key) &&
+              hasOwnProperty.call(serverOptions, key)
+            ) {
+              acc[key] = serverOptions[key];
+            }
+
+            return acc;
+          },
+          { revision: serverOptions.revision },
+        );
+
+        options = await store.set(Options, values);
+      }
+    } catch (e) {
+      console.error(`[sync] Error while merging server options: `, e);
+    }
+
+    // Set options or update:
+    // * No revision on server - initial sync
+    // * Keys are passed - options update
+    // * Revision is negative - local options are dirty (not synced)
+    if (!serverOptions.revision || keys || options.revision < 0) {
+      console.info('[sync] Syncing options with updated keys:', keys);
+      const { revision } = await setUserOptions(
+        SYNC_OPTIONS.reduce(
+          (acc, key) => {
+            if (hasOwnProperty.call(options, key)) {
+              acc[key] = options[key];
+            }
+            return acc;
+          },
+          { revision: serverOptions.revision + 1 },
+        ),
+      );
+
+      // Update local revision
+      await store.set(Options, { revision });
+      console.info('[sync] Options synced with revision:', revision);
+    }
+  } catch (e) {
+    console.error(`[sync] Error while syncing options: `, e);
+  } finally {
+    sync.pending = false;
+  }
+}
+
+// Sync options on startup and when options change
+OptionsObserver.addListener(function syncOptions(options, prevOptions) {
+  // Sync options on startup
+  if (!prevOptions) {
+    sync(options);
+  }
+
+  // Sync options when options change (skip on revision change)
+  else if (options.revision === prevOptions.revision) {
+    sync(options, prevOptions);
+  }
+});
+
+// Sync options when a user logs in/out directly
+// from the ghostery.com page (not from the settings page)
+chrome.webNavigation.onDOMContentLoaded.addListener(async ({ url = '' }) => {
+  if (url === HOME_PAGE_URL || url.includes(ACCOUNT_PAGE_URL)) {
+    store.resolve(Options).then((options) => sync(options));
+  }
+});
+
+// Sync options on demand - triggered by the options page and panel
+// to force sync options when opened
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.action === 'syncOptions') {
+    store.resolve(Options).then((options) => sync(options));
+  }
+});

--- a/src/pages/panel/index.js
+++ b/src/pages/panel/index.js
@@ -25,13 +25,14 @@ mount(document.body, {
   `,
 });
 
-/* Ping telemetry on panel open */
+// Ping telemetry on panel open
 chrome.runtime.sendMessage({ action: 'telemetry', event: 'engaged' });
 
-/*
-  Safari extension popup has a bug, which focuses visibly the first element on the page
-  when the popup is opened. This is a workaround to remove the focus.
-*/
+// Sync options with background
+chrome.runtime.sendMessage({ action: 'syncOptions' });
+
+// Safari extension popup has a bug, which focuses visibly the first element on the page
+// when the popup is opened. This is a workaround to remove the focus.
 if (__PLATFORM__ === 'safari') {
   window.addEventListener('load', () => {
     setTimeout(() => {

--- a/src/pages/settings/index.js
+++ b/src/pages/settings/index.js
@@ -36,6 +36,9 @@ store
       };
     }
 
+    // Sync options with background
+    chrome.runtime.sendMessage({ action: 'syncOptions' });
+
     mount(document.body, Settings);
   })
   .catch(() => {

--- a/src/store/options.js
+++ b/src/store/options.js
@@ -17,7 +17,7 @@ import * as OptionsObserver from '/utils/options-observer.js';
 
 import CustomFilters from './custom-filters.js';
 
-export const UPDATE_OPTIONS_ACTION_NAME = 'updateOptions';
+const UPDATE_OPTIONS_ACTION_NAME = 'updateOptions';
 export const GLOBAL_PAUSE_ID = '<all_urls>';
 
 export const SYNC_OPTIONS = [
@@ -116,7 +116,7 @@ const Options = {
 
       return options;
     },
-    async set(_, options, keys) {
+    async set(_, options) {
       options = options || {};
 
       await chrome.storage.local.set({
@@ -131,7 +131,6 @@ const Options = {
       chrome.runtime
         .sendMessage({
           action: UPDATE_OPTIONS_ACTION_NAME,
-          keys,
         })
         .catch(() => {
           // sendMessage may fail without potential target

--- a/src/store/options.js
+++ b/src/store/options.js
@@ -11,15 +11,13 @@
 
 import { store } from 'hybrids';
 
-import { getUserOptions, setUserOptions } from '/utils/api.js';
 import { DEFAULT_REGIONS } from '/utils/regions.js';
 import { isOpera } from '/utils/browser-info.js';
 import * as OptionsObserver from '/utils/options-observer.js';
 
 import CustomFilters from './custom-filters.js';
-import Session from './session.js';
 
-const UPDATE_OPTIONS_ACTION_NAME = 'updateOptions';
+export const UPDATE_OPTIONS_ACTION_NAME = 'updateOptions';
 export const GLOBAL_PAUSE_ID = '<all_urls>';
 
 export const SYNC_OPTIONS = [
@@ -133,20 +131,16 @@ const Options = {
       chrome.runtime
         .sendMessage({
           action: UPDATE_OPTIONS_ACTION_NAME,
+          keys,
         })
         .catch(() => {
           // sendMessage may fail without potential target
         });
 
-      sync(options, keys);
-
       return options;
     },
     observe: (_, options, prevOptions) => {
       OptionsObserver.execute(options, prevOptions);
-
-      // Sync if the current memory context get options for the first time
-      if (!prevOptions) sync(options);
     },
   },
 };
@@ -161,8 +155,7 @@ chrome.runtime.onMessage.addListener((msg) => {
 });
 
 async function migrate(options, optionsVersion) {
-  const keys = [];
-
+  // Pushed in v10.3.14
   if (optionsVersion < 2) {
     // Migrate 'paused' array to record
     if (options.paused) {
@@ -171,8 +164,11 @@ async function migrate(options, optionsVersion) {
         return acc;
       }, {});
     }
+
+    console.debug('[options] Migrated to version 2:', options);
   }
 
+  // Pushed in v10.4.3
   if (optionsVersion < 3) {
     // Check if the user has custom filters, so we need to
     // reflect the enabled state in the options
@@ -182,8 +178,9 @@ async function migrate(options, optionsVersion) {
         ...options.customFilters,
         enabled: true,
       };
-      keys.push('customFilters');
     }
+
+    console.debug('[options] Migrated to version 3:', options);
   }
 
   // Flush updated options and version to the storage
@@ -191,9 +188,6 @@ async function migrate(options, optionsVersion) {
     options,
     optionsVersion: OPTIONS_VERSION,
   });
-
-  // Send updated options to the server
-  Promise.resolve().then(() => sync(options, keys));
 }
 
 let managed = __PLATFORM__ === 'chromium' && isOpera() ? false : null;
@@ -243,69 +237,4 @@ export function isPaused(options, domain = '') {
     !!options.paused[GLOBAL_PAUSE_ID] ||
     (domain && !!options.paused[domain.replace(/^www\./, '')])
   );
-}
-
-export async function sync(options, keys) {
-  try {
-    // Do not sync if revision is set or terms and sync options are false
-    if (keys?.includes('revision') || !options.terms || !options.sync) {
-      return;
-    }
-
-    const { user } = await store.resolve(Session);
-
-    // If user is not logged in, clean up options revision and return
-    if (!user) {
-      if (options.revision !== 0) {
-        store.set(Options, { revision: 0 });
-      }
-      return;
-    }
-
-    // If options update, set revision to "dirty" state
-    if (keys && options.revision > 0) {
-      options = await store.set(Options, { revision: options.revision * -1 });
-    }
-
-    const serverOptions = await getUserOptions();
-
-    // Server has newer options - merge with local options
-    if (serverOptions.revision > Math.abs(options.revision)) {
-      const values = SYNC_OPTIONS.reduce(
-        (acc, key) => {
-          if (!keys?.includes(key) && hasOwnProperty.call(serverOptions, key)) {
-            acc[key] = serverOptions[key];
-          }
-
-          return acc;
-        },
-        { revision: serverOptions.revision },
-      );
-
-      options = await store.set(Options, values);
-    }
-
-    // Set options or update:
-    // * No revision on server - initial sync
-    // * Keys are passed - options update
-    // * Revision is negative - local options are dirty (not synced)
-    if (!serverOptions.revision || keys || options.revision < 0) {
-      const { revision } = await setUserOptions(
-        SYNC_OPTIONS.reduce(
-          (acc, key) => {
-            if (hasOwnProperty.call(options, key)) {
-              acc[key] = options[key];
-            }
-            return acc;
-          },
-          { revision: serverOptions.revision + 1 },
-        ),
-      );
-
-      // Update local revision
-      await store.set(Options, { revision });
-    }
-  } catch (e) {
-    console.error(`[options] Error while syncing options: `, e);
-  }
 }

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -1,0 +1,40 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+export default function debounce(fn, { waitFor, maxWait }) {
+  let delayedTimer;
+  let maxWaitTimer;
+
+  const clear = () => {
+    clearTimeout(delayedTimer);
+    clearTimeout(maxWaitTimer);
+    delayedTimer = undefined;
+    maxWaitTimer = undefined;
+  };
+
+  let args = [];
+  const run = () => {
+    clear();
+    fn(...args);
+
+    args = [];
+  };
+
+  return (...latestArgs) => {
+    args = latestArgs;
+
+    if (maxWait > 0 && maxWaitTimer === undefined) {
+      maxWaitTimer = setTimeout(run, maxWait);
+    }
+    clearTimeout(delayedTimer);
+    delayedTimer = setTimeout(run, waitFor);
+  };
+}

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -23,9 +23,12 @@ export default function debounce(fn, { waitFor, maxWait }) {
   let args = [];
   const run = () => {
     clear();
-    fn(...args);
 
-    args = [];
+    try {
+      fn(...args);
+    } finally {
+      args = [];
+    }
   };
 
   return (...latestArgs) => {

--- a/src/utils/options-observer.js
+++ b/src/utils/options-observer.js
@@ -11,7 +11,7 @@
 import { store } from 'hybrids';
 import Options from '/store/options.js';
 
-function isOptionEqual(a, b) {
+export function isOptionEqual(a, b) {
   if (typeof b !== 'object' || b === null) return a === b;
 
   const aKeys = Object.keys(a);


### PR DESCRIPTION
This PR moves out the sync of options into the background process.

The trigger of the sync process programmatically stays as it was - every time the background starts up the sync is triggered. However, if any other context wants to force the sync, the message `syncOptions` must be sent (added to the settings page and panel).

The `background/session.js` can be cleaned up from alarms. As the sync is triggered with every background process start-up, the alarms don't give much, as any request made by the browser brings the BG back to life. For the same reason, it is safe to trigger sync then, as from my testing, BG is not killed that often (many sites make some background calls, or the user moves the mouse over the page or something similar).

Also, the sync option in the Account section is unlocked. I found a use case, where you can log in, switch sync to false, and then log out, keeping the sync set to `false`. On the other hand, currently, it is impossible to log in without sync turned off. It is pointless to block this setting before the user is logged in, as it might be "hacked" anyway.

After code review, the PR requires manual testing.