### PR TITLE
Adblocker: fix $replace and service worker blocking

### DIFF
--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -44,9 +44,9 @@ function getEnabledEngines(config) {
       list.push(engines.FIXES_ENGINE);
     }
 
-    if (config.customFilters.enabled) {
-      list.push(engines.CUSTOM_ENGINE);
-    }
+    // Custom filters should be always added as
+    // they have own settings which defines if they are enabled
+    list.push(engines.CUSTOM_ENGINE);
 
     return list;
   }
@@ -58,7 +58,7 @@ function pause(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function reloadMainEngine() {
+export async function reloadMainEngine() {
   // Delay the reload to avoid UI freezes in Firefox and Safari
   if (__PLATFORM__ !== 'chromium') await pause(1000);
 
@@ -83,12 +83,10 @@ async function reloadMainEngine() {
       `[adblocker] Main engine reloaded with: ${enabledEngines.join(', ')}`,
     );
   } else {
-    engines.create(engines.MAIN_ENGINE);
+    await engines.create(engines.MAIN_ENGINE);
     console.info('[adblocker] Main engine reloaded with no filters');
   }
 }
-
-engines.addChangeListener(engines.CUSTOM_ENGINE, reloadMainEngine);
 
 let updating = false;
 async function updateEngines() {
@@ -370,7 +368,7 @@ if (__PLATFORM__ === 'firefox') {
   function isExtensionRequest(details) {
     return (
       (details.tabId === -1 && details.url.startsWith('moz-extension://')) ||
-      details.originUrl.startsWith('moz-extension://')
+      details.originUrl?.startsWith('moz-extension://')
     );
   }
 

--- a/tests/e2e/spec/advanced.spec.js
+++ b/tests/e2e/spec/advanced.spec.js
@@ -96,6 +96,18 @@ describe('Advanced Features', function () {
       });
     });
 
+    // Scope for Firefox webRequest API tests
+    if (browser.isFirefox) {
+      it('adds $replace network filter', async function () {
+        await setCustomFilters([
+          `||${PAGE_DOMAIN}^$replace=/<title>.*<\\/title>/<title>hello world<\\/title>/`,
+        ]);
+
+        await browser.url(PAGE_URL, { wait: 'networkIdle' });
+        await expect(await browser.getTitle()).toBe('hello world');
+      });
+    }
+
     it('removes custom filters in settings page', async function () {
       await setCustomFilters([]);
       await setPrivacyToggle('custom-filters', false);


### PR DESCRIPTION
Filtering for `tabId === -1` is not correct as all requests from service workers have tabId === -1.
