### PR TITLE
fix(background): revert to background page for Safari 17.x

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,15 @@ export default [
       ecmaVersion: 'latest',
       sourceType: 'module',
     },
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'Program > ExpressionStatement > AwaitExpression',
+          message: 'Global await in module body is not allowed.',
+        },
+      ],
+    },
   },
   {
     files: ['scripts/**/*.js', 'tests/**/*.js'],

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -383,6 +383,31 @@ const buildPromise = build({
       },
     },
   },
+  plugins: [
+    // This custom plugin cleans ups chunks imports of the `.html` inputs
+    //  to only include CSS files. This is necessary because Vite generates
+    // every imported JS file as script tag in the resulting HTML file.
+    // It is related to our custom usage, where we don't bundle JS into single files.
+    {
+      name: 'clean-up-html-imports',
+      enforce: 'pre',
+      generateBundle(options, bundle) {
+        for (const chunk of Object.values(bundle)) {
+          if (chunk.fileName.endsWith('.html.js')) {
+            for (const name of chunk.imports) {
+              const importChunk = bundle[name];
+              if (importChunk.type === 'chunk') {
+                // Imports of the single chunk generated from HTML should only include CSS files
+                importChunk.imports = importChunk.imports.filter((name) =>
+                  name.endsWith('.css.js'),
+                );
+              }
+            }
+          }
+        }
+      },
+    },
+  ],
 });
 
 // --- Build content scripts ---

--- a/src/background/index.html
+++ b/src/background/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <script type="module" src="./index.js" async></script>
+  </head>
+  <body></body>
+</html>

--- a/src/manifest.safari.json
+++ b/src/manifest.safari.json
@@ -38,8 +38,7 @@
     "open_in_tab": true
   },
   "background": {
-    "scripts": ["background/index.js"],
-    "type": "module",
+    "page": "background/index.html",
     "persistent": false
   },
   "declarative_net_request" : {


### PR DESCRIPTION
As the Safari 18.x works "just fine", we missed that using `scripts` option in manifest is broken in 17.x. 

In the result, the background process sometimes is not saved correctly to be bring back to life with upcoming events.

From my testing only iOS 17.x and  is affected (I tried hard to reproduce on iOS 18, but I couldn't).

This PR brings back the custom background page, which runs script in `<head>` and only `async` attribute (the autogenerated page has `defer` in body).

The change in `build.js` is required, as I discovered a rare case, where including all of the imports in generated html file affected timing of attaching options listener in Safari. I wanted fix this from some time, so this was the best moment to do that.

The additional eslint rule will prevent potential `async` call in the main module body. This is not an issue now, but I think we should prevent that as well, as we can't do that. Otherwise, Safari won't register the background correctly (we had that issue in the past).