### PR TITLE
fix(adblocker): inject scriplets with `browser.contentScripts` on Firefox

### DIFF
--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -183,6 +183,7 @@ const contentScripts = (() => {
           matchAboutBlank: true,
           matchOriginAsFallback: true,
           runAt: 'document_start',
+          world: 'MAIN',
         });
         map.set(hostname, contentScript);
       } catch (e) {
@@ -232,7 +233,7 @@ function injectScriptlets(filters, tabId, frameId, hostname) {
     }
 
     if (__PLATFORM__ === 'firefox') {
-      contentScript += `(function () { ${func.toString()} })(...${JSON.stringify(args)})`
+      contentScript += `(${func.toString()})(...${JSON.stringify(args)});\n`
       continue;
     }
 

--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -174,6 +174,13 @@ if (__PLATFORM__ === 'firefox') {
       contentScripts.unregisterAll();
     }
   });
+
+  OptionsObserver.addListener('paused', async (paused) => {
+    if (!ENABLE_FIREFOX_CONTENT_SCRIPT_SCRIPLET_INJECTION) return;
+    for (const hostname of Object.keys(paused)) {
+      contentScripts.unregister(hostname);
+    }
+  });
 }
 
 const contentScripts = (() => {

--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -86,7 +86,10 @@ export async function reloadMainEngine() {
     await engines.create(engines.MAIN_ENGINE);
     console.info('[adblocker] Main engine reloaded with no filters');
   }
-  if (__PLATFORM__ === 'firefox') {
+  if (
+    __PLATFORM__ === 'firefox' &&
+    ENABLE_FIREFOX_CONTENT_SCRIPT_SCRIPLET_INJECTION
+  ) {
     contentScripts.unregisterAll();
   }
 }


### PR DESCRIPTION
**WARNING:** This has to be tested very carefully.

On Firefox, scriptlet injection run into timing issues which makes it impossible to inject certain scriptlets before page scripts.

Examples we try to fix are:
* https://gorhill.github.io/uBlock/tests/scriptlet-injection-filters-1.html
* https://picrew.me

The only way to ensure the scriptlet is always executed before the page script is to use `browser.contentScripts` API which available on Firefox only.

Open questions:
* is injecting to `allFrames` safe? for example, can scriptlets from different hostnames be injected due to `allFrames`?
* do we need more triggering methods like `webRequest.onResponseStarted`?
* when content scripts should be cleaned? 
* do we handle redirects correctly? for example redirect from http://example.com to https://www.example.com ?
* can we speed up by not matching cosmetic filters for scriptlet injection once content scripts are registered? 

TODO:
* [ ] support selective blocking
* [x] support pause