### PR TITLE
fix(setup): remove hard threshold in async setup

### DIFF
--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -124,7 +124,7 @@ async function updateEngines() {
 }
 
 const HOUR_IN_MS = 60 * 60 * 1000;
-export const setup = asyncSetup([
+export const setup = asyncSetup('adblocker', [
   OptionsObserver.addListener(
     async function adblockerEngines(value, lastValue) {
       options = value;

--- a/src/background/reporting/index.js
+++ b/src/background/reporting/index.js
@@ -36,7 +36,7 @@ import webRequestReporter from './webrequest-reporter.js';
   }
 })();
 
-const setup = asyncSetup([
+const setup = asyncSetup('reporting', [
   OptionsObserver.addListener('terms', async function reporting(terms) {
     if (terms) {
       if (webRequestReporter) {

--- a/src/background/telemetry/index.js
+++ b/src/background/telemetry/index.js
@@ -66,7 +66,7 @@ async function getConf(storage) {
 }
 
 let metrics;
-const setup = asyncSetup([
+const setup = asyncSetup('telemetry', [
   (async () => {
     const storage = await loadStorage();
     const { version } = chrome.runtime.getManifest();

--- a/src/utils/trackerdb.js
+++ b/src/utils/trackerdb.js
@@ -13,7 +13,9 @@ import { sortCategories } from '/ui/categories.js';
 import * as engines from './engines.js';
 import asyncSetup from './setup.js';
 
-export const setup = asyncSetup([engines.init(engines.TRACKERDB_ENGINE)]);
+export const setup = asyncSetup('trackerdb', [
+  engines.init(engines.TRACKERDB_ENGINE),
+]);
 
 export function getUnidentifiedTracker(hostname) {
   return {


### PR DESCRIPTION
We received several user feedback logs, where the threshold of 10 seconds was exceeded. As there is no way to prove how it should be set, we should allow waiting for promises to be resolved.

This PR keeps the threshold, but only for warning in the console, that some of the promises did not resolve. I added the `id` argument to make the log more helpful.

I tested a synthetic case with a delaying setup, as well as, throwing an error. The errors are logged in the console correctly, as they are caught in different contexts. It is sufficient to re-throw errors.