### PR TITLE
fix(store): tab stats directly call for current tab info

### DIFF
--- a/src/background/helpers.js
+++ b/src/background/helpers.js
@@ -13,20 +13,6 @@ import * as OptionsObserver from '/utils/options-observer.js';
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   switch (msg.action) {
-    case 'getCurrentTab':
-      chrome.tabs.query({ active: true, currentWindow: true }).then(([tab]) => {
-        if (tab.url !== sender.url) {
-          sendResponse(tab);
-        } else {
-          chrome.tabs
-            .query({ active: true, currentWindow: false })
-            .then(([otherTab]) => {
-              sendResponse(otherTab || tab);
-            });
-        }
-      });
-
-      return true;
     case 'openTabWithUrl':
       chrome.tabs.create({ url: msg.url });
       break;

--- a/src/pages/panel/views/main.js
+++ b/src/pages/panel/views/main.js
@@ -11,7 +11,7 @@
 
 import { html, store, router, msg } from 'hybrids';
 
-import { openTabWithUrl } from '/utils/tabs.js';
+import { getCurrentTab, openTabWithUrl } from '/utils/tabs.js';
 import { hasWTMStats } from '/utils/wtm-stats.js';
 
 import Options, { GLOBAL_PAUSE_ID } from '/store/options.js';
@@ -51,8 +51,9 @@ function reloadTab() {
   clearTimeout(reloadTimeout);
 
   reloadTimeout = setTimeout(async () => {
-    const tab = await chrome.runtime.sendMessage({ action: 'getCurrentTab' });
-    chrome.tabs.reload(tab.id);
+    const tab = await getCurrentTab();
+    if (tab) chrome.tabs.reload(tab.id);
+
     reloadTimeout = null;
   }, 1000);
 }

--- a/src/store/tab-stats.js
+++ b/src/store/tab-stats.js
@@ -16,6 +16,7 @@ import AutoSyncingMap from '/utils/map.js';
 
 import Tracker from './tracker.js';
 import TrackerException from './tracker-exception.js';
+import { getCurrentTab } from '/utils/tabs.js';
 
 const StatsTracker = {
   ...Tracker,
@@ -64,15 +65,9 @@ const Stats = {
 
   [store.connect]: {
     async get() {
-      if (!tab) {
-        tab = await chrome.runtime.sendMessage({
-          action: 'getCurrentTab',
-        });
-      }
-
-      if (!tab.url.startsWith('http')) {
-        return {};
-      }
+      // Resolve tab info
+      tab ||= await getCurrentTab();
+      if (!tab || !tab.url.startsWith('http')) return {};
 
       const tabStats = await AutoSyncingMap.get('tabStats:v1', tab.id);
 

--- a/src/utils/tabs.js
+++ b/src/utils/tabs.js
@@ -34,3 +34,19 @@ export async function openTabWithUrl(host, event) {
 
   chrome.tabs.create({ url: href });
 }
+
+export async function getCurrentTab() {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab) return null;
+
+  if (tab.url !== window.location.href) {
+    return tab;
+  }
+
+  const [otherTab] = await chrome.tabs.query({
+    active: true,
+    currentWindow: false,
+  });
+
+  return otherTab || null;
+}


### PR DESCRIPTION
In the past, the `TabStats` model was used by the never-consent popup notification displayed in the iframe. As Firefox does not support Tabs API in iframes, we were calling BG for the current tab. This approach has a few drawbacks:
1. It is much slower (message passing), and can be affected by busy BG process - we have to wait until BG can resolve the message
2. If the BG somehow is dead - we have a blank popup panel

We can simplify the logic, as `getCurrentTab` message is currently used only by the panel.

Tested in all platforms - works as expected.