### PR TITLE
Temporarily disable anti-tracking fingerprinting removal in URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@ghostery/adblocker-webextension": "^2.1.1",
         "@github/relative-time-element": "^4.3.0",
         "@sentry/browser": "^8.41.0",
-        "@whotracksme/reporting": "^5.1.38",
+        "@whotracksme/reporting": "^5.2.0",
         "bowser": "^2.11.0",
         "hybrids": "^9.1.8",
         "idb": "^8.0.0",
@@ -3328,9 +3328,9 @@
       }
     },
     "node_modules/@whotracksme/reporting": {
-      "version": "5.1.38",
-      "resolved": "https://registry.npmjs.org/@whotracksme/reporting/-/reporting-5.1.38.tgz",
-      "integrity": "sha512-2XKSyDp7dbHn083vuEtbMxMTW2zn+nFfWKL1+DDkqzNhg389qCdd5+GBznLXYdWl/gyUNpdsw+0oeraFK1hXZQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@whotracksme/reporting/-/reporting-5.2.0.tgz",
+      "integrity": "sha512-EnKbcDMH30Vd74+836xkh098V12dOA5cfaxscjMg+lAxok1ZPM6JEu32crHr9l9fDxWA5x/ITic1Vqqm/2EEeg==",
       "license": "MPL-2.0",
       "workspaces": [
         "reporting",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@ghostery/adblocker-webextension": "^2.1.1",
     "@github/relative-time-element": "^4.3.0",
     "@sentry/browser": "^8.41.0",
-    "@whotracksme/reporting": "^5.1.38",
+    "@whotracksme/reporting": "^5.2.0",
     "bowser": "^2.11.0",
     "hybrids": "^9.1.8",
     "idb": "^8.0.0",

--- a/src/background/reporting/webrequest-reporter.js
+++ b/src/background/reporting/webrequest-reporter.js
@@ -37,6 +37,7 @@ if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'firefox') {
     getBrowserInfo,
     isRequestAllowed: (state) =>
       !options.blockTrackers || isPaused(options, state.tabUrlParts.hostname),
+    dryRunMode: true,
     onTrackerInteraction: (event, state) => {
       if (event === 'observed') {
         return;


### PR DESCRIPTION
Rationale: there are currently open issues like https://github.com/ghostery/broken-page-reports/issues/873; we need to find solutions before we can safely enable it again.

Note "dry-run" mode applies to Firefox only. Chromium-based browsers are on Manifest V3 (where blocking webRequestAPI is not available). And on Safari, urlReporting (including the anti-tracking subsystem) is disabled completely (mostly because of quirks in the APIs).

refs https://github.com/whotracksme/webextension-packages/pull/142