### PR TITLE
fix(engines): use options observer instead of internal listener

### DIFF
--- a/src/background/exceptions.js
+++ b/src/background/exceptions.js
@@ -137,12 +137,14 @@ async function updateFilters() {
     .filter(({ id }) => id >= 2000000)
     .map(({ id }) => id);
 
-  await chrome.declarativeNetRequest.updateDynamicRules({
-    addRules,
-    removeRuleIds,
-  });
+  if (addRules.length || removeRuleIds.length) {
+    await chrome.declarativeNetRequest.updateDynamicRules({
+      addRules,
+      removeRuleIds,
+    });
 
-  console.info('[exceptions] Updated DNR rules');
+    console.info('[exceptions] Updated DNR rules');
+  }
 }
 
 if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') {

--- a/src/background/exceptions.js
+++ b/src/background/exceptions.js
@@ -11,8 +11,8 @@
 
 import { parseFilter } from '@ghostery/adblocker';
 
+import * as OptionsObserver from '/utils/options-observer.js';
 import * as trackerdb from '/utils/trackerdb.js';
-import * as engines from '/utils/engines.js';
 
 import {
   createDocumentConverter,
@@ -142,10 +142,20 @@ async function updateFilters() {
     removeRuleIds,
   });
 
-  console.info('[exceptions] DNR rules for filters updated successfully');
+  console.info('[exceptions] Updated DNR rules');
 }
 
 if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') {
   // Update exceptions filters every time TrackerDB updates
-  engines.addChangeListener(engines.TRACKERDB_ENGINE, updateFilters);
+  // It happens when all engines are updated
+  OptionsObserver.addListener(
+    'filtersUpdatedAt',
+    async function updateExceptions(value, lastValue) {
+      // Only update exceptions filters if the value has changed and is set to timestamp.
+      // It will happen only after successful update of the engines.
+      if (lastValue !== undefined && value !== 0) {
+        await updateFilters();
+      }
+    },
+  );
 }

--- a/src/utils/engines.js
+++ b/src/utils/engines.js
@@ -204,30 +204,6 @@ function check(response) {
   return response;
 }
 
-const updateListeners = new Map();
-export function addChangeListener(name, fn) {
-  if (!updateListeners.has(name)) {
-    updateListeners.set(name, new Set());
-  }
-
-  updateListeners.get(name).add(fn);
-}
-
-function notifyListeners(name) {
-  const fns = updateListeners.get(name);
-
-  fns?.forEach((fn) => {
-    try {
-      fn();
-    } catch (e) {
-      console.error(
-        `[engines] Error while calling update listener for "${name}"`,
-        e,
-      );
-    }
-  });
-}
-
 const CDN_HOSTNAME = stagingMode
   ? 'staging-cdn.ghostery.com'
   : 'cdn.ghostery.com';
@@ -411,9 +387,6 @@ export async function update(name) {
     if (updated) {
       console.info(`[engines] Engine "${name}" updated`);
 
-      // Notify listeners
-      notifyListeners(name);
-
       // Save the new engine to storage
       saveToStorage(name);
 
@@ -450,8 +423,6 @@ export function create(name, options = null) {
     console.error(`[engines] Failed to save engine "${name}" to storage`);
   });
 
-  notifyListeners(name);
-
   return engine;
 }
 
@@ -469,8 +440,6 @@ export function replace(name, engineOrEngines) {
   saveToStorage(name).catch(() => {
     console.error(`[engines] Failed to save engine "${name}" to storage`);
   });
-
-  notifyListeners(name);
 
   return engine;
 }


### PR DESCRIPTION
The update listener of the engines utility was already decoupled from options here https://github.com/ghostery/ghostery-extension/blob/78533f01cc0bb179eef8b49f520ca4fbf2b5a42d/src/background/custom-filters.js

This PR removes the feature completely. The exception filters were listening to the change of the TrackerDB to update the DNR rules. It can be also done by observing the `filtersUpdatedAt` option. Then, the mechanism in engines can be removed.