### PR TITLE
fix: update autoconsent library to 12.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "10.4.19",
       "license": "GPL-3.0",
       "dependencies": {
-        "@duckduckgo/autoconsent": "^10.17.0",
+        "@duckduckgo/autoconsent": "^12.4.0",
         "@ghostery/adblocker": "^2.3.1",
         "@ghostery/adblocker-webextension": "^2.3.1",
         "@ghostery/scriptlets": "github:ghostery/scriptlets#29c825e",
@@ -413,12 +413,14 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "10.17.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-10.17.0.tgz",
-      "integrity": "sha512-zMB4BE5fpiqvjXPA0k8bCorWgh6eFMlkedRfuRVQYhbWqwLgrnsA7lv4U0ORTIJkvbBjABuYaprwr1yd/15D/w==",
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-12.4.0.tgz",
+      "integrity": "sha512-k7pNvq9IdPURoAhboAWx+xDMnIHKJ9JY74eft/aOOv1Lj5P8Bjv63ERyvttK5ugzvJvVyUR9GNp3DcQF/izlmA==",
       "license": "MPL-2.0",
       "dependencies": {
-        "tldts-experimental": "^6.1.37"
+        "@ghostery/adblocker": "^2.0.4",
+        "@ghostery/adblocker-content": "^2.0.4",
+        "tldts-experimental": "^6.1.41"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "webextension-polyfill": "^0.12.0"
   },
   "dependencies": {
-    "@duckduckgo/autoconsent": "^10.17.0",
+    "@duckduckgo/autoconsent": "^12.4.0",
     "@ghostery/adblocker": "^2.3.1",
     "@ghostery/adblocker-webextension": "^2.3.1",
     "@ghostery/scriptlets": "github:ghostery/scriptlets#29c825e",

--- a/src/background/autoconsent.js
+++ b/src/background/autoconsent.js
@@ -9,8 +9,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
+import { evalSnippets } from '@duckduckgo/autoconsent';
 import rules from '@duckduckgo/autoconsent/rules/rules.json';
-import { snippets } from '@duckduckgo/autoconsent/lib/eval-snippets';
+
 import { parse } from 'tldts-experimental';
 import { store } from 'hybrids';
 
@@ -33,6 +34,7 @@ async function initialize(msg, tab, frameId) {
           rules,
           config: {
             enableCosmeticRules: false,
+            enableFilterList: false,
           },
         },
         {
@@ -55,7 +57,7 @@ async function evalCode(snippetId, id, tabId, frameId) {
     world:
       chrome.scripting.ExecutionWorld?.MAIN ??
       (__PLATFORM__ === 'firefox' ? undefined : 'MAIN'),
-    func: snippets[snippetId],
+    func: evalSnippets[snippetId],
   });
 
   await chrome.tabs.sendMessage(


### PR DESCRIPTION
* The `eval` message is no longer sent to the background - execution of the scriptlets is done by the Autoconsent class in the content script by the library
* The library includes a source of the adblocker engine, even though we are not using it. The final size of the content script increased from 89kb to 528kb. 
* From initial testing, the library went much slower in detecting and "clicking" on CMPs—it might be related to the fact that we disable cosmetics, and then those CMPs are not hidden (?).

