### PR TITLE
Adblocker: disable engine compression

### DIFF
--- a/src/utils/engines.js
+++ b/src/utils/engines.js
@@ -459,7 +459,12 @@ export function replace(name, engineOrEngines) {
   const engines = [].concat(engineOrEngines);
   const engine =
     engines.length > 1
-      ? FiltersEngine.merge(engines, { skipResources: true })
+      ? FiltersEngine.merge(engines, {
+          skipResources: true,
+          overrideConfig: {
+            enableCompression: false,
+          },
+        })
       : engines[0];
 
   engine.updateEnv(ENV);


### PR DESCRIPTION
With @ghostery/adblocker 2.3.0 it is now possible to disable engine compression on merge. This helps to reduce the overall merge time (including storage) from ~670ms to ~370ms. Additionally, uncompressed engine should perform better on matching. The cost is increased engine size with when compressed was an UintArray with size of 72055507, and when uncompressed it size is 8942525.