### PR TITLE
fix(telemetry): send events on trailing edge of the frequency

### DIFF
--- a/src/background/telemetry/metrics.js
+++ b/src/background/telemetry/metrics.js
@@ -353,16 +353,17 @@ export default class Metrics {
     if (frequency === 'all') return 0;
 
     const key = `${type}_${frequency}`;
+    const now = Date.now();
 
     // Protect against calling events immediately after install for all frequencies
     // They should trigger on the trailing edge of the frequency
     if (!this.storage[key]) {
-      this.storage[key] = Date.now();
+      this.storage[key] = now;
       this.saveStorage(this.storage);
     }
 
     const last = this.storage[key];
-    const frequency_ago = Date.now() - FREQUENCIES[frequency];
+    const frequency_ago = now - FREQUENCIES[frequency];
 
     return last ? last - frequency_ago : 0;
   }

--- a/src/background/telemetry/metrics.js
+++ b/src/background/telemetry/metrics.js
@@ -352,7 +352,16 @@ export default class Metrics {
   _timeToExpired(type, frequency) {
     if (frequency === 'all') return 0;
 
-    const last = this.storage[`${type}_${frequency}`] || 0;
+    const key = `${type}_${frequency}`;
+
+    // Protect against calling events immediately after install for all frequencies
+    // They should trigger on the trailing edge of the frequency
+    if (!this.storage[key]) {
+      this.storage[key] = Date.now();
+      this.saveStorage(this.storage);
+    }
+
+    const last = this.storage[key];
     const frequency_ago = Date.now() - FREQUENCIES[frequency];
 
     return last ? last - frequency_ago : 0;


### PR DESCRIPTION
This PR only applies to the very first ping of the events with frequency set to `daily`, `weekly` or `monthy`. 

Currently, every installation of the extension (local, CI, bots(?)) which sucessfully pass the onboarding sends `active` ping for every frequency. However, after sending this, the next one goes only after the frequency period expires. This should also apply to the first event.

This change only affects new installations, and does not change logic with `all` frequency.