### PR TITLE
fix(paused): update rules in managed mode even if paused state hasn't changed

### DIFF
--- a/src/background/paused.js
+++ b/src/background/paused.js
@@ -68,7 +68,10 @@ OptionsObserver.addListener('paused', async (paused, prevPaused) => {
   // in the panel or the settings page.
   if (
     (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') &&
-    prevPaused
+    (prevPaused ||
+      // Managed mode can update the rules at any time - so we need to update
+      // the rules even if the paused state hasn't changed
+      (__PLATFORM__ === 'chromium' && (await store.resolve(Options).managed)))
   ) {
     const removeRuleIds = (await chrome.declarativeNetRequest.getDynamicRules())
       .filter(({ id }) => id <= 3)


### PR DESCRIPTION
The best way to fix the problem seems to be checking the `managed` flag on deman and don't change oberver, as it checks deep changes of the `paused` option.