### PR TITLE
fix(engines): handle no engines case for merge

### DIFF
--- a/src/background/custom-filters.js
+++ b/src/background/custom-filters.js
@@ -139,14 +139,14 @@ async function updateDNRRules(dnrRules) {
   return dnrRules;
 }
 
-function updateEngine(text) {
+async function updateEngine(text) {
   const { networkFilters, cosmeticFilters, preprocessors } = parseFilters(text);
 
   engines.create(engines.CUSTOM_ENGINE, {
     cosmeticFilters,
     networkFilters,
     preprocessors,
-    config: engines.get(engines.MAIN_ENGINE).config,
+    config: (await engines.init(engines.FIXES_ENGINE)).config,
   });
 
   console.info(
@@ -167,7 +167,7 @@ async function update(text, { trustedScriptlets }) {
     trustedScriptlets,
   });
 
-  const result = updateEngine(
+  const result = await updateEngine(
     [
       ...(__PLATFORM__ === 'firefox' ? networkFilters : []),
       ...cosmeticFilters,

--- a/src/utils/engines.js
+++ b/src/utils/engines.js
@@ -428,18 +428,19 @@ export function create(name, options = null) {
 
 export function replace(name, engineOrEngines) {
   const engines = [].concat(engineOrEngines);
-  const engine =
-    engines.length > 1
-      ? FiltersEngine.merge(engines, {
-          skipResources: true,
-          overrideConfig: {
-            enableCompression: false,
-          },
-        })
-      : engines[0];
+  let engine;
+
+  if (engines.length > 1) {
+    engine = FiltersEngine.merge(engines, {
+      skipResources: true,
+      overrideConfig: { enableCompression: false },
+    });
+    engine.resources = Resources.copy(engines[0].resources);
+  } else {
+    engine = engines[0];
+  }
 
   engine.updateEnv(ENV);
-  engine.resources = Resources.copy(engines[0].resources);
 
   saveToMemory(name, engine);
   saveToStorage(name).catch(() => {


### PR DESCRIPTION
After all, there is a case where custom filters might need a `FIXES_ENGINE` configuration - if you disable all of the features before you enable custom filters for the first time - otherwise, the config will be default, and then when turning on engines, the error of merging is thrown.

Also, I realized that it might be a rare case, that for some reason all of engines won't initialize correctly, so the `engines.merge()` function should cover that case.