### PR TITLE
feat(config): add remote configuration

### DIFF
--- a/src/background/config.js
+++ b/src/background/config.js
@@ -1,0 +1,114 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { store } from 'hybrids';
+
+import Config from '/store/config.js';
+
+function filter(item) {
+  if (item.filter) {
+    const { platform } = item.filter;
+    let check = true;
+
+    // Browser check
+    if (check && Array.isArray(platform)) {
+      check = platform.includes(__PLATFORM__);
+    }
+
+    return check;
+  }
+
+  return true;
+}
+
+// Fetch the remote config, update the local config
+// with current domains and add new flags (not initialized yet)
+(async function syncRemoteConfig() {
+  // TODO: implement fetching remote config from the server
+  // This is a mock of the fetched config
+  const fetchedConfig = {
+    'domains': {
+      'ghostery.com': {
+        'actions': ['assist'],
+        'filter': {
+          'platform': ['chromium'],
+        },
+      },
+      'consent.google.pl': {
+        'actions': ['disable-autoconsent'],
+      },
+    },
+    'flags': {
+      'assist': [
+        {
+          percentage: 100,
+        },
+      ],
+      'firefox-content-script-scriptlets': [
+        {
+          'percentage': 20,
+          'filter': {
+            'platform': ['firefox'],
+          },
+        },
+      ],
+    },
+  };
+
+  const config = await store.resolve(Config);
+
+  // -- domains --
+
+  const domains = { ...config.domains };
+
+  // Clear out domains removed from the config
+  for (const name of Object.keys(domains)) {
+    if (fetchedConfig.domains[name] === undefined) {
+      domains[name] = null;
+    }
+  }
+
+  // Update the config with new values
+  for (const [name, item] of Object.entries(fetchedConfig.domains)) {
+    domains[name] = filter(item) ? item : null;
+  }
+
+  // -- flags --
+
+  const flags = { ...config.flags };
+
+  // Clear out flags removed from the config
+  for (const name of Object.keys(flags)) {
+    if (fetchedConfig.flags[name] === undefined) {
+      flags[name] = null;
+    }
+  }
+
+  // Update the config with the new values
+  for (const [name, items] of Object.entries(fetchedConfig.flags)) {
+    const item = items.find((item) => filter(item));
+    if (!item) {
+      flags[name] = null;
+      continue;
+    }
+    // Generate local percentage only once for each flag
+    const percentage =
+      flags[name]?.percentage || Math.floor(Math.random() * 100) + 1;
+
+    flags[name] = {
+      percentage,
+      enabled: percentage <= item.percentage,
+    };
+  }
+
+  // Update the config
+  store.set(Config, { domains, flags });
+})();

--- a/src/background/config.js
+++ b/src/background/config.js
@@ -32,9 +32,15 @@ function filter(item) {
   return true;
 }
 
-// Fetch the remote config, update the local config
-// with current domains and add new flags (not initialized yet)
-(async function syncRemoteConfig() {
+const HALF_HOUR_IN_MS = 1000 * 60 * 30;
+
+export default async function syncConfig() {
+  const config = await store.resolve(Config);
+
+  if (config.updatedAt > Date.now() - HALF_HOUR_IN_MS) {
+    return;
+  }
+
   // TODO: implement fetching remote config from the server
   // This is a mock of the fetched config
   try {
@@ -42,8 +48,6 @@ function filter(item) {
       if (!res.ok) throw new Error('Failed to fetch the remote config');
       return res.json();
     });
-
-    const config = await store.resolve(Config);
 
     // -- domains --
 
@@ -90,8 +94,14 @@ function filter(item) {
     }
 
     // Update the config
-    store.set(Config, { domains, flags });
+    store.set(Config, {
+      updatedAt: Date.now(),
+      domains,
+      flags,
+    });
   } catch (e) {
     console.error('[config] Failed to sync remote config:', e);
   }
-})();
+}
+
+syncConfig();

--- a/src/background/devtools.js
+++ b/src/background/devtools.js
@@ -13,6 +13,7 @@ import { store } from 'hybrids';
 
 import DailyStats from '/store/daily-stats';
 import Options from '/store/options.js';
+import Config from '/store/config.js';
 
 import { deleteDatabases } from '/utils/indexeddb.js';
 
@@ -33,6 +34,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
           try {
             store.clear(Options);
             store.clear(DailyStats);
+            store.clear(Config);
           } catch (e) {
             console.error('[devtools] Error clearing store cache:', e);
           }

--- a/src/background/devtools.js
+++ b/src/background/devtools.js
@@ -17,6 +17,8 @@ import Config from '/store/config.js';
 
 import { deleteDatabases } from '/utils/indexeddb.js';
 
+import syncConfig from './config.js';
+
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   switch (msg.action) {
     case 'clearStorage':
@@ -44,6 +46,19 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
           sendResponse('Storage cleared');
         } catch (e) {
           sendResponse(`[devtools] Error clearing storage: ${e}`);
+        }
+      })();
+
+      return true;
+    case 'syncConfig':
+      (async () => {
+        try {
+          await store.set(Config, { updatedAt: 0 });
+          await syncConfig();
+
+          sendResponse('Config synced');
+        } catch (e) {
+          sendResponse(`[devtools] Error syncing config: ${e}`);
         }
       })();
 

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -10,6 +10,7 @@
  */
 
 import './onboarding.js';
+import './config.js';
 
 import './autoconsent.js';
 import './adblocker.js';

--- a/src/pages/settings/components/devtools.js
+++ b/src/pages/settings/components/devtools.js
@@ -12,6 +12,7 @@
 import { html, store, dispatch } from 'hybrids';
 
 import Options from '/store/options.js';
+import Config from '/store/config.js';
 
 const VERSION = chrome.runtime.getManifest().version;
 
@@ -60,6 +61,7 @@ function refresh(host) {
 export default {
   counter: 0,
   options: store(Options),
+  config: store(Config),
   updatedAt: ({ options }) =>
     store.ready(options) &&
     options.filtersUpdatedAt &&
@@ -74,15 +76,29 @@ export default {
       },
     ),
   visible: false,
-  render: ({ visible, counter, updatedAt }) => html`
+  render: ({ visible, counter, updatedAt, config }) => html`
     <template layout="column gap:3">
       ${
         (visible || counter > 5) &&
         html`
           <section layout="column gap:3" translate="no">
             <ui-text type="headline-m">Developer tools</ui-text>
+
             <div layout="column gap">
-              <ui-text type="headline-s">Storage actions</ui-text>
+              <ui-text type="headline-s">Storage</ui-text>
+              ${store.ready(config) &&
+              html`
+                <div layout="column gap items:start" translate="no">
+                  <ui-toggle
+                    value="${config.enabled}"
+                    onchange="${html.set(config, 'enabled')}"
+                  >
+                    <ui-text layout="row items:center">
+                      Remote configuration
+                    </ui-text>
+                  </ui-toggle>
+                </div>
+              `}
               <div layout="row gap items:start">
                 <ui-button onclick="${clearStorage}" layout="shrink:0">
                   <button>Clear local storage</button>

--- a/src/pages/settings/components/devtools.js
+++ b/src/pages/settings/components/devtools.js
@@ -12,7 +12,10 @@
 import { html, store, dispatch } from 'hybrids';
 
 import Options from '/store/options.js';
-import Config from '/store/config.js';
+import Config, {
+  ACTION_ASSIST,
+  ACTION_DISABLE_AUTOCONSENT,
+} from '/store/config.js';
 
 const VERSION = chrome.runtime.getManifest().version;
 
@@ -43,6 +46,39 @@ function clearStorage(host, event) {
   asyncAction(event, chrome.runtime.sendMessage({ action: 'clearStorage' }));
 }
 
+async function syncConfig(host, event) {
+  asyncAction(event, chrome.runtime.sendMessage({ action: 'syncConfig' }));
+}
+
+async function testConfigDomain(host) {
+  const domain = window.prompt('Enter domain to test:', 'example.com');
+  if (!domain) return;
+
+  const actions = window.prompt(
+    'Enter actions to test:',
+    `${ACTION_ASSIST}, ${ACTION_DISABLE_AUTOCONSENT}`,
+  );
+
+  if (!actions) return;
+
+  await store.set(host.config, {
+    domains: {
+      [domain]: { actions: actions.split(',').map((a) => a.trim()) },
+    },
+  });
+}
+
+async function testConfigFlag(host) {
+  const flag = window.prompt('Enter flag to test:');
+  if (!flag) return;
+
+  await store.set(host.config, {
+    flags: {
+      [flag]: { enabled: true },
+    },
+  });
+}
+
 function updateFilters(host) {
   if (host.updatedAt) {
     store.set(host.options, { filtersUpdatedAt: 0 });
@@ -58,6 +94,16 @@ function refresh(host) {
   }
 }
 
+function formatDate(date) {
+  return new Date(date).toLocaleDateString(chrome.i18n.getUILanguage(), {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
 export default {
   counter: 0,
   options: store(Options),
@@ -65,16 +111,7 @@ export default {
   updatedAt: ({ options }) =>
     store.ready(options) &&
     options.filtersUpdatedAt &&
-    new Date(options.filtersUpdatedAt).toLocaleDateString(
-      chrome.i18n.getUILanguage(),
-      {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-      },
-    ),
+    formatDate(options.filtersUpdatedAt),
   visible: false,
   render: ({ visible, counter, updatedAt, config }) => html`
     <template layout="column gap:3">
@@ -86,40 +123,70 @@ export default {
 
             ${store.ready(config) &&
             html`
-              <div layout="column gap items:start" translate="no">
-                <ui-text type="headline-xs">Remote Config</ui-text>
+              <div layout="column gap" translate="no">
                 <ui-toggle
                   value="${config.enabled}"
                   onchange="${html.set(config, 'enabled')}"
                 >
-                  <ui-text layout="row items:center">
-                    Remote configuration global switch
-                  </ui-text>
+                  <div layout="column">
+                    <ui-text type="headline-s">Remote Configuration</ui-text>
+                    <ui-text type="body-xs" color="gray-400">
+                      Updated at: ${formatDate(config.updatedAt)}
+                    </ui-text>
+                  </div>
                 </ui-toggle>
-
-                <ui-text>
-                  <details>
-                    <summary>Config</summary>
-                    <pre>${JSON.stringify(config, null, 2)}</pre>
-                  </details>
-                </ui-text>
+                <div>
+                  <ui-text type="label-m">Domains</ui-text>
+                  <div layout="row:wrap gap">
+                    ${Object.entries(config.domains)
+                      .filter(([, d]) => d.actions.length)
+                      .map(
+                        ([name, d]) =>
+                          html`<ui-text color="gray-600">
+                            ${name} (${d.actions.join(', ')})
+                          </ui-text>`,
+                      ) || 'none'}
+                  </div>
+                </div>
+                <div>
+                  <ui-text type="label-m">Flags</ui-text>
+                  <ui-text color="gray-600">
+                    ${Object.entries(config.flags)
+                      .filter(([, f]) => f.enabled)
+                      .map(([name]) => name)
+                      .join(' ') || 'none'}
+                  </ui-text>
+                </div>
+                <div layout="row gap">
+                  <ui-button
+                    layout="shrink:0 self:start"
+                    onclick="${testConfigDomain}"
+                  >
+                    <button>Test domain</button>
+                  </ui-button>
+                  <ui-button
+                    layout="shrink:0 self:start"
+                    onclick="${testConfigFlag}"
+                  >
+                    <button>Test flag</button>
+                  </ui-button>
+                  <ui-button
+                    onclick="${syncConfig}"
+                    layout="shrink:0 self:start"
+                  >
+                    <button>
+                      <ui-icon name="refresh" layout="size:2"></ui-icon>
+                      Force sync
+                    </button>
+                  </ui-button>
+                </div>
               </div>
               <ui-line></ui-line>
             `}
-
-            <div layout="column gap">
-              <ui-text type="headline-xs">Local Storage</ui-text>
-              <div layout="row gap items:start">
-                <ui-button onclick="${clearStorage}" layout="shrink:0">
-                  <button>Clear local storage</button>
-                </ui-button>
-              </div>
-            </div>
-            <ui-line></ui-line>
             ${(__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') &&
             html`
               <div layout="column gap items:start" translate="no">
-                <ui-text type="headline-xs">Enabled DNR rulesets</ui-text>
+                <ui-text type="headline-s">Enabled DNR rulesets</ui-text>
                 <ui-text type="body-xs" color="gray-400">
                   The below list is not reactive to changes made in the
                   extension - use refresh button
@@ -143,20 +210,35 @@ export default {
                   <button>Refresh</button>
                 </ui-button>
               </div>
+              <ui-line></ui-line>
             `}
+
+            <div layout="column gap">
+              <ui-text type="headline-s">Local Storage</ui-text>
+              <div layout="row gap items:start">
+                <ui-button onclick="${clearStorage}" layout="shrink:0">
+                  <button>
+                    <ui-icon name="trash" layout="size:2"></ui-icon>
+                    Clear storage
+                  </button>
+                </ui-button>
+              </div>
+            </div>
           </section>
         `
       }
       <div layout="column gap center">
         <div layout="row center gap:2">
-          <ui-text
-            type="label-s"
-            color="gray-300"
-            onclick="${refresh}"
-            translate="no"
-          >
-            v${VERSION}
-          </ui-text>
+          <div onclick="${refresh}">
+            <ui-text
+              type="label-s"
+              color="gray-300"
+              translate="no"
+              style="user-select: none;"
+            >
+              v${VERSION}
+            </ui-text>
+          </div>
         </div>
         <ui-action>
           <ui-text type="label-xs" color="gray-300" onclick="${updateFilters}">

--- a/src/pages/settings/components/devtools.js
+++ b/src/pages/settings/components/devtools.js
@@ -84,21 +84,31 @@ export default {
           <section layout="column gap:3" translate="no">
             <ui-text type="headline-m">Developer tools</ui-text>
 
+            ${store.ready(config) &&
+            html`
+              <div layout="column gap items:start" translate="no">
+                <ui-text type="headline-xs">Remote Config</ui-text>
+                <ui-toggle
+                  value="${config.enabled}"
+                  onchange="${html.set(config, 'enabled')}"
+                >
+                  <ui-text layout="row items:center">
+                    Remote configuration global switch
+                  </ui-text>
+                </ui-toggle>
+
+                <ui-text>
+                  <details>
+                    <summary>Config</summary>
+                    <pre>${JSON.stringify(config, null, 2)}</pre>
+                  </details>
+                </ui-text>
+              </div>
+              <ui-line></ui-line>
+            `}
+
             <div layout="column gap">
-              <ui-text type="headline-s">Storage</ui-text>
-              ${store.ready(config) &&
-              html`
-                <div layout="column gap items:start" translate="no">
-                  <ui-toggle
-                    value="${config.enabled}"
-                    onchange="${html.set(config, 'enabled')}"
-                  >
-                    <ui-text layout="row items:center">
-                      Remote configuration
-                    </ui-text>
-                  </ui-toggle>
-                </div>
-              `}
+              <ui-text type="headline-xs">Local Storage</ui-text>
               <div layout="row gap items:start">
                 <ui-button onclick="${clearStorage}" layout="shrink:0">
                   <button>Clear local storage</button>
@@ -109,7 +119,7 @@ export default {
             ${(__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') &&
             html`
               <div layout="column gap items:start" translate="no">
-                <ui-text type="headline-s">Enabled DNR rulesets</ui-text>
+                <ui-text type="headline-xs">Enabled DNR rulesets</ui-text>
                 <ui-text type="body-xs" color="gray-400">
                   The below list is not reactive to changes made in the
                   extension - use refresh button
@@ -133,7 +143,6 @@ export default {
                   <button>Refresh</button>
                 </ui-button>
               </div>
-              <ui-line></ui-line>
             `}
           </section>
         `

--- a/src/store/config.js
+++ b/src/store/config.js
@@ -18,7 +18,7 @@ export const FLAG_ASSIST = 'assist';
 export const FLAG_FIREFOX_CONTENT_SCRIPT_SCRIPTLETS =
   'firefox-content-script-scriptlets';
 
-export default {
+const Config = {
   enabled: true,
   domains: store.record({
     actions: [String],
@@ -30,13 +30,13 @@ export default {
 
   // Helper methods
 
-  hasAction({ domains }) {
+  hasAction({ domains, enabled }) {
     return (domain, action) =>
-      !!(domain && domains[domain]?.actions.includes(action));
+      enabled && !!(domain && domains[domain]?.actions.includes(action));
   },
 
-  hasFlag({ flags }) {
-    return (flag) => !!(flag && flags[flag]?.enabled);
+  hasFlag({ flags, enabled }) {
+    return (flag) => enabled && !!(flag && flags[flag]?.enabled);
   },
 
   [store.connect]: {
@@ -55,3 +55,8 @@ export default {
     },
   },
 };
+export default Config;
+
+chrome.storage.onChanged.addListener((changes) => {
+  if (changes['config']) store.clear(Config, false);
+});

--- a/src/store/config.js
+++ b/src/store/config.js
@@ -1,0 +1,57 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { store } from 'hybrids';
+
+export const ACTION_DISABLE_AUTOCONSENT = 'disable-autoconsent';
+export const ACTION_ASSIST = 'assist';
+
+export const FLAG_ASSIST = 'assist';
+export const FLAG_FIREFOX_CONTENT_SCRIPT_SCRIPTLETS =
+  'firefox-content-script-scriptlets';
+
+export default {
+  enabled: true,
+  domains: store.record({
+    actions: [String],
+  }),
+  flags: store.record({
+    percentage: 0,
+    enabled: false,
+  }),
+
+  // Helper methods
+
+  hasAction({ domains }) {
+    return (domain, action) =>
+      !!(domain && domains[domain]?.actions.includes(action));
+  },
+
+  hasFlag({ flags }) {
+    return (flag) => !!(flag && flags[flag]?.enabled);
+  },
+
+  [store.connect]: {
+    async get() {
+      const { config = {} } = await chrome.storage.local.get(['config']);
+      return config;
+    },
+    async set(_, values) {
+      await chrome.storage.local.set({
+        config:
+          __PLATFORM__ === 'firefox'
+            ? JSON.parse(JSON.stringify(values))
+            : values,
+      });
+      return values;
+    },
+  },
+};

--- a/src/store/config.js
+++ b/src/store/config.js
@@ -20,6 +20,7 @@ export const FLAG_FIREFOX_CONTENT_SCRIPT_SCRIPTLETS =
 
 const Config = {
   enabled: true,
+  updatedAt: 0,
   domains: store.record({
     actions: [String],
   }),
@@ -45,6 +46,8 @@ const Config = {
       return config;
     },
     async set(_, values) {
+      values ||= {};
+
       await chrome.storage.local.set({
         config:
           __PLATFORM__ === 'firefox'

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -12,9 +12,14 @@
 import { jwtDecode } from 'jwt-decode';
 
 import { GHOSTERY_DOMAIN } from '/utils/urls.js';
+import { stagingMode } from './debug.js';
 
 const AUTH_URL = `https://consumerapi.${GHOSTERY_DOMAIN}/api/v2`;
 const ACCOUNT_URL = `https://accountapi.${GHOSTERY_DOMAIN}/api/v2.1.0`;
+
+export const CDN_URL = stagingMode
+  ? 'https://staging-cdn.ghostery.com/'
+  : 'https://cdn.ghostery.com/';
 
 export const COOKIE_DOMAIN = `.${GHOSTERY_DOMAIN}`;
 const COOKIE_URL = `https://${GHOSTERY_DOMAIN}`;

--- a/src/utils/engines.js
+++ b/src/utils/engines.js
@@ -19,8 +19,9 @@ import {
 } from '@ghostery/adblocker';
 
 import { registerDatabase } from './indexeddb.js';
-import debug, { stagingMode } from './debug.js';
+import debug from './debug.js';
 import { captureException } from './errors.js';
+import { CDN_URL } from './api.js';
 
 export const MAIN_ENGINE = 'main';
 export const CUSTOM_ENGINE = 'custom-filters';
@@ -204,10 +205,6 @@ function check(response) {
   return response;
 }
 
-const CDN_HOSTNAME = stagingMode
-  ? 'staging-cdn.ghostery.com'
-  : 'cdn.ghostery.com';
-
 export async function update(name) {
   // If the IndexedDB is corrupted, and there is no way to load the engine
   // from the storage, we should skip the update.
@@ -222,8 +219,7 @@ export async function update(name) {
 
   try {
     const urlName = name === 'trackerdb' ? 'trackerdbMv3' : `dnr-${name}`;
-
-    const listURL = `https://${CDN_HOSTNAME}/adblocker/configs/${urlName}/allowed-lists.json`;
+    const listURL = CDN_URL + `adblocker/configs/${urlName}/allowed-lists.json`;
 
     console.info(`[engines] Updating engine "${name}"...`);
 


### PR DESCRIPTION
* Adds remote configuration by `Config` store model, which reflects the configuration for the current environment (it does not reflect one-to-one remote JSON structure)
* The model source is `storage.local` with async sync process with CDN end-point
* Adds devtools section for global switch and look over the config