### PR TITLE
fix(trackers-preview): update image layout with fixed size

### DIFF
--- a/src/pages/trackers-preview/index.js
+++ b/src/pages/trackers-preview/index.js
@@ -47,7 +47,7 @@ define({
                 <img
                   src="${DisablePreviewImg}"
                   alt="Disable Preview Trackers"
-                  layout="self:center"
+                  layout="self:center size:161px:160px"
                 />
                 <div layout="block:center column gap">
                   <ui-text type="label-l">


### PR DESCRIPTION
Fixes #2144. It looks like on Firefox the initial load of the svg images is too slow, and the result height is smaller, but only once the image is cached.