### PR TITLE
fix: Use full hostname & unify pause logic

### DIFF
--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -357,15 +357,17 @@ function isTrusted(request, type) {
   const exception = getException(metadata?.id || request.hostname);
 
   if (exception) {
-    const tabHostname = request.sourceHostname.replace(/^www\./, '');
-
     // The request is trusted if:
     // - tracker is blocked, but tab hostname is added to trusted domains
     // - tracker is not blocked and tab hostname is not found in the blocked domains
     if (
       exception.blocked
-        ? exception.trustedDomains.includes(tabHostname)
-        : !exception.blockedDomains.includes(tabHostname)
+        ? exception.trustedDomains.some((id) =>
+            request.sourceHostname.endsWith(id),
+          )
+        : !exception.blockedDomains.some((id) =>
+            request.sourceHostname.endsWith(id.sourceHostname),
+          )
     ) {
       return true;
     }

--- a/src/background/stats.js
+++ b/src/background/stats.js
@@ -314,7 +314,7 @@ function setupTabStats(details) {
 
   if (request.isHttp || request.isHttps) {
     tabStats.set(details.tabId, {
-      hostname: request.hostname.replace('www.', ''),
+      hostname: request.hostname,
       url: request.url,
       trackers: [],
       timestamp: details.timeStamp,
@@ -327,7 +327,7 @@ function setupTabStats(details) {
 }
 
 // Setup stats for the tab when a user navigates to a new page
-chrome.webNavigation.onBeforeNavigate.addListener((details) => {
+chrome.webNavigation.onCommitted.addListener((details) => {
   if (details.tabId > -1 && details.parentFrameId === -1) {
     setupTabStats(details);
   }

--- a/src/pages/panel/views/main.js
+++ b/src/pages/panel/views/main.js
@@ -96,10 +96,6 @@ function setStatsType(host, event) {
   store.set(host.options, { panel: { statsType: type } });
 }
 
-function tail(hostname) {
-  return hostname.length > 24 ? '...' + hostname.slice(-24) : hostname;
-}
-
 export default {
   [router.connect]: { stack: [Menu, TrackerDetails, ProtectionStatus] },
   options: store(Options),
@@ -130,7 +126,7 @@ export default {
                         layout="row gap:2px items:center"
                       >
                         <ui-text type="label-m"
-                          >${tail(stats.hostname)}</ui-text
+                          >${stats.displayHostname}</ui-text
                         >
                         ${!options.managed &&
                         html`<ui-icon
@@ -142,7 +138,7 @@ export default {
                     </ui-action>
                   </panel-managed>
                 `
-              : tail(stats.hostname))}
+              : stats.displayHostname)}
             <ui-action slot="icon">
               <a href="https://www.ghostery.com" onclick="${openTabWithUrl}">
                 <ui-icon name="logo"></ui-icon>

--- a/src/pages/settings/store/hostname.js
+++ b/src/pages/settings/store/hostname.js
@@ -23,7 +23,7 @@ export default {
       }
       return {
         ...model,
-        value: parsed.hostname.replace(/^www\./, ''),
+        value: parsed.hostname,
       };
     },
   },

--- a/src/store/options.js
+++ b/src/store/options.js
@@ -231,9 +231,11 @@ async function manage(options) {
   return options;
 }
 
-export function isPaused(options, domain = '') {
+export function isPaused(options, hostname = '') {
+  if (options.paused[GLOBAL_PAUSE_ID]) return true;
+
   return (
-    !!options.paused[GLOBAL_PAUSE_ID] ||
-    (domain && !!options.paused[domain.replace(/^www\./, '')])
+    !!hostname &&
+    Object.keys(options.paused).some((id) => hostname.endsWith(id))
   );
 }

--- a/src/store/tab-stats.js
+++ b/src/store/tab-stats.js
@@ -35,13 +35,16 @@ let tab = undefined;
 const Stats = {
   hostname: '',
   trackers: [StatsTracker],
+
+  displayHostname: ({ hostname }) => {
+    hostname = hostname.replace(/^www\./, '');
+    return hostname.length > 24 ? '...' + hostname.slice(-24) : hostname;
+  },
   trackersBlocked: ({ trackers }) =>
     trackers.reduce((acc, { blocked }) => acc + Number(blocked), 0),
   trackersModified: ({ trackers }) =>
     trackers.reduce((acc, { modified }) => acc + Number(modified), 0),
-
   categories: ({ trackers }) => trackers.map((t) => t.category),
-
   topCategories: ({ categories }) => {
     const counts = Object.entries(
       categories.reduce((acc, category) => {
@@ -79,8 +82,7 @@ const Stats = {
         return tabStats;
       }
 
-      const hostname = parse(tab.url).hostname?.replace(/^www\./, '');
-      return { hostname };
+      return { hostname: parse(tab.url).hostname };
     },
     observe:
       __PLATFORM__ === 'safari' &&


### PR DESCRIPTION
Fixes #2168 and unifies pause behavior on subdomains if the top domain is paused.

* The tab stats setup should be done in `onCommited` instead of `onBeforeNavigate` to properly trigger setup after initial 30X redirects - the `cnn.com` or `onet.pl` sites are good examples - the `onCommited` is triggered once, but after redirects, with the final URL
* The removal of the `www.` subdomain was mainly caused by the above bug to avoid situations where not the latest (and correct) hostname was added to paused websites
* Instead of removing the `www` subdomain, we can only hide it in the panel header, as the browsers hide it in the URL address bar
* The DNR allow rule for `exmaple.com` works also for `abc.exmaple.com` - because of that this PR also unifies the behavior of the `isPaused()` function and `isTrusted()` for exceptions in Firefox - for the consistent logic through all the platforms. Unification helps with no-stress migration from the current production logic - if a user added `onet.pl`, it will work with unified logic as well, as the `www.onet.pl` contains the `onet.pl` (for isPaused and exceptions).