### PR TITLE
feat(logger): POC Adblocker request logger

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -307,7 +307,7 @@ if (manifest.declarative_net_request?.rule_resources) {
 
 // --- Generate entry points ---
 
-const source = ['pages/onboarding/index.html'];
+const source = ['pages/onboarding/index.html', 'pages/logger/index.html'];
 const content_scripts = [];
 
 if (manifest.action?.default_popup) {

--- a/src/background/logger.js
+++ b/src/background/logger.js
@@ -1,0 +1,31 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+const ports = new Set();
+
+chrome.runtime.onConnect.addListener((port) => {
+  if (port.name === 'logger') {
+    ports.add(port);
+
+    const id = port.sender.tab.id;
+    console.log('[logger] Connected logger with id', id);
+
+    port.onDisconnect.addListener(() => {
+      ports.delete(port);
+      console.log('[logger] Disconnected logger with id', id);
+    });
+  }
+});
+
+export function send(requests) {
+  for (const port of ports) {
+    port.postMessage({ action: 'logger:requests', requests });
+  }
+}

--- a/src/background/logger.js
+++ b/src/background/logger.js
@@ -8,6 +8,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
+import { setup } from './adblocker.js';
+import * as engines from '/utils/engines.js';
+
 const ports = new Set();
 
 chrome.runtime.onConnect.addListener((port) => {
@@ -24,8 +27,18 @@ chrome.runtime.onConnect.addListener((port) => {
   }
 });
 
-export function send(requests) {
+export async function sendRequests(requests) {
+  if (ports.size === 0) return;
+
+  setup.pending && (await setup.pending);
+
+  const engine = engines.get(engines.MAIN_ENGINE);
+  const logs = requests.map((request) => {
+    const { filter } = engine.match(request);
+    return { ...request, filter: filter ? String(filter) : '' };
+  });
+
   for (const port of ports) {
-    port.postMessage({ action: 'logger:requests', requests });
+    port.postMessage({ action: 'logger:requests', logs });
   }
 }

--- a/src/background/stats.js
+++ b/src/background/stats.js
@@ -144,7 +144,7 @@ const OBSERVED_REQUESTS_LIMIT = 25;
 function pushTabStats(stats, requests) {
   let trackersUpdated = false;
 
-  logger.send(requests);
+  logger.sendRequests(requests);
 
   for (const request of requests) {
     const metadata =

--- a/src/background/stats.js
+++ b/src/background/stats.js
@@ -26,6 +26,7 @@ import Request from '/utils/request.js';
 import { isOpera } from '/utils/browser-info.js';
 
 import { getException } from './exceptions.js';
+import * as logger from './logger.js';
 
 export const tabStats = new AutoSyncingMap({ storageKey: 'tabStats:v1' });
 
@@ -142,6 +143,8 @@ const OBSERVED_REQUESTS_LIMIT = 25;
 
 function pushTabStats(stats, requests) {
   let trackersUpdated = false;
+
+  logger.send(requests);
 
   for (const request of requests) {
     const metadata =
@@ -403,8 +406,6 @@ if (__PLATFORM__ === 'chromium') {
             if (request.id === details.requestId) {
               request.blocked = true;
               tracker.blocked = true;
-
-              return;
             }
           }
         }

--- a/src/pages/logger/index.html
+++ b/src/pages/logger/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Ghostery Logger</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="icon" type="image/png" href="/ui/assets/favicon.png" />
+    <link rel="icon" type="image/svg+xml" href="/ui/assets/favicon.svg" />
+    <script type="module" src="./index.js"></script>
+  </head>
+  <body></body>
+</html>

--- a/src/pages/logger/index.js
+++ b/src/pages/logger/index.js
@@ -1,0 +1,44 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { mount, store } from 'hybrids';
+import { Request } from '@ghostery/adblocker';
+
+import * as engines from '/utils/engines.js';
+
+import '/ui/index.js';
+import Log from './store/log.js';
+import Main from './views/main.js';
+
+// This is a top level await, but it's fine as this is a page script
+const engine = await engines.init(engines.MAIN_ENGINE);
+
+// Register the logger tab
+const port = chrome.runtime.connect({ name: 'logger' });
+
+// Listen for requests from the background script
+port.onMessage.addListener((message) => {
+  if (message.action === 'logger:requests') {
+    for (const data of message.requests) {
+      const log = store.get(Log, data.id);
+      delete data.id;
+
+      const { filter } = engine.match(
+        Request.fromRawDetails(data._originalRequestDetails),
+      );
+
+      data.filter = filter;
+      store.set(log, data);
+    }
+  }
+});
+
+mount(document.body, Main);

--- a/src/pages/logger/index.js
+++ b/src/pages/logger/index.js
@@ -10,16 +10,10 @@
  */
 
 import { mount, store } from 'hybrids';
-import { Request } from '@ghostery/adblocker';
-
-import * as engines from '/utils/engines.js';
 
 import '/ui/index.js';
 import Log from './store/log.js';
 import Main from './views/main.js';
-
-// This is a top level await, but it's fine as this is a page script
-const engine = await engines.init(engines.MAIN_ENGINE);
 
 // Register the logger tab
 const port = chrome.runtime.connect({ name: 'logger' });
@@ -27,15 +21,10 @@ const port = chrome.runtime.connect({ name: 'logger' });
 // Listen for requests from the background script
 port.onMessage.addListener((message) => {
   if (message.action === 'logger:requests') {
-    for (const data of message.requests) {
+    for (const data of message.logs) {
       const log = store.get(Log, data.id);
       delete data.id;
 
-      const { filter } = engine.match(
-        Request.fromRawDetails(data._originalRequestDetails),
-      );
-
-      data.filter = filter;
       store.set(log, data);
     }
   }

--- a/src/pages/logger/store/log.js
+++ b/src/pages/logger/store/log.js
@@ -39,11 +39,19 @@ export default {
       storage.set(id, request);
       return request;
     },
-    list: ({ tabId, status }) =>
+    list: ({ tabId, query, status }) =>
       Array.from(storage.values()).filter((request) => {
         let match = true;
 
         if (tabId && request.tabId !== tabId) {
+          match = false;
+        }
+
+        if (
+          query &&
+          !request.url.includes(query) &&
+          !request.filter.includes(query)
+        ) {
           match = false;
         }
 

--- a/src/pages/logger/store/log.js
+++ b/src/pages/logger/store/log.js
@@ -1,0 +1,67 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+import { store } from 'hybrids';
+
+const storage = new Map();
+
+export default {
+  id: true,
+  tabId: '',
+
+  // From request
+  url: '',
+  timestamp: 0,
+  blocked: false,
+  modified: false,
+  type: '',
+
+  // From matched filter
+  filter: '',
+
+  time: ({ timestamp }) => new Date(timestamp).toLocaleTimeString(),
+
+  [store.connect]: {
+    get: (id) => storage.get(id),
+    set: (id, values) => {
+      const request = {
+        ...values,
+        type: values.type === 'xmlhttprequest' ? 'xhr' : values.type,
+      };
+
+      storage.set(id, request);
+      return request;
+    },
+    list: ({ tabId, status }) =>
+      Array.from(storage.values()).filter((request) => {
+        let match = true;
+
+        if (tabId && request.tabId !== tabId) {
+          match = false;
+        }
+
+        switch (status) {
+          case 'touched':
+            if (!request.blocked && !request.modified) match = false;
+            break;
+
+          case 'warning':
+            if (request.filter && (request.blocked || request.modified))
+              match = false;
+            if (!request.filter && !request.blocked && !request.modified)
+              match = false;
+            break;
+        }
+
+        return match;
+      }),
+    loose: true,
+  },
+};

--- a/src/pages/logger/store/log.js
+++ b/src/pages/logger/store/log.js
@@ -10,7 +10,7 @@
  */
 import { store } from 'hybrids';
 
-const storage = new Map();
+const storage = [];
 
 export default {
   id: true,
@@ -36,11 +36,17 @@ export default {
         type: values.type === 'xmlhttprequest' ? 'xhr' : values.type,
       };
 
-      storage.set(id, request);
+      const log = storage.find((item) => item.id === id);
+      if (log) {
+        Object.assign(log, request);
+      } else {
+        storage.push(request);
+      }
+
       return request;
     },
     list: ({ tabId, query, status }) =>
-      Array.from(storage.values()).filter((request) => {
+      storage.filter((request) => {
         let match = true;
 
         if (tabId && request.tabId !== tabId) {

--- a/src/pages/logger/store/tab.js
+++ b/src/pages/logger/store/tab.js
@@ -1,0 +1,21 @@
+import { store } from 'hybrids';
+
+export default {
+  id: true,
+  title: '',
+  hostname: '',
+  active: false,
+  [store.connect]: {
+    async list() {
+      const tabs = await chrome.tabs.query({});
+      return tabs
+        .filter(({ url }) => url !== location.href)
+        .map((tab) => ({
+          id: tab.id,
+          title: tab.title,
+          hostname: new URL(tab.url).hostname,
+          active: tab.active,
+        }));
+    },
+  },
+};

--- a/src/pages/logger/views/main.js
+++ b/src/pages/logger/views/main.js
@@ -1,0 +1,115 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { html, store } from 'hybrids';
+
+import Log from '../store/log.js';
+import Tab from '../store/tab.js';
+
+function refreshSelectedTab(host) {
+  chrome.tabs.reload(Number(host.tabId));
+}
+
+export default {
+  logs: store([Log], {
+    id: ({ tabId, status }) => ({ tabId, status }),
+  }),
+  tabs: store([Tab]),
+  tabId: ({ tabs }, value) => {
+    if (value !== undefined) return value;
+    return store.ready(tabs) ? tabs.find((tab) => tab.active).id : '';
+  },
+  status: '',
+  render: ({ logs, tabs, tabId, status }) => html`
+    <template layout="height:full">
+      <main layout="column gap height:full" translate="no">
+        <div layout="row items:center gap padding:2:2:0">
+          <ui-text type="label-l">Logger</ui-text>
+          <ui-input layout="width:30">
+            <select onchange="${html.set('tabId')}" value="${tabId}">
+              <option value="">All tabs</option>
+              ${store.ready(tabs) &&
+              tabs.map(
+                (tab) => html`
+                  <option value="${tab.id}" selected=${tab.id === tabId}>
+                    ${tab.title} ${tab.hostname}
+                  </option>
+                `,
+              )}
+            </select>
+          </ui-input>
+          <ui-input>
+            <select onchange="${html.set('status')}" value="${status}">
+              <option value="">All requests</option>
+              <option value="touched">Blocked / Modified</option>
+              <option value="warning">With warning</option>
+            </select>
+          </ui-input>
+          <ui-button
+            onclick="${refreshSelectedTab}"
+            layout="width:5"
+            disabled="${!tabId}"
+          >
+            <button><ui-icon name="refresh"></ui-icon></button>
+          </ui-button>
+        </div>
+        <ui-line></ui-line>
+        <div layout="overflow:scroll">
+          <div layout="column-reverse gap padding:0:2:2">
+            ${store.error(logs)}
+            ${store.ready(logs) &&
+            logs.map((log) =>
+              html`
+                <div layout="grid:60px|60px|240px|60px|1 gap">
+                  <ui-text type="body-s" color="gray-400">
+                    ${log.time}
+                  </ui-text>
+                  <ui-text type="body-s" layout="self:center">
+                    ${log.type}
+                  </ui-text>
+                  <ui-text type="body-s" color="gray-400" ellipsis>
+                    ${log.filter}
+                  </ui-text>
+                  <div layout="row gap:0.5 center">
+                    ${log.blocked &&
+                    html`<ui-icon
+                      name="block-s"
+                      color="danger-700"
+                      layout="size:2"
+                    ></ui-icon>`}
+                    ${log.modified &&
+                    html`<ui-icon
+                      name="eye"
+                      color="primary-700"
+                      layout="size:2"
+                    ></ui-icon>`}
+                    ${((log.filter && !log.blocked && !log.modified) ||
+                      (!log.filter && (log.blocked || log.modified))) &&
+                    html`<ui-icon
+                      name="warning"
+                      color="warning-500"
+                      layout="size:2"
+                    ></ui-icon>`}
+                  </div>
+                  <ui-text ellipsis>${log.url}</ui-text>
+                </div>
+              `.key(log.id),
+            )}
+          </div>
+        </div>
+      </main>
+    </template>
+  `.css`
+    .blocked {
+      color: var(--ui-color-danger-400);
+    }
+  `,
+};

--- a/src/pages/logger/views/main.js
+++ b/src/pages/logger/views/main.js
@@ -20,13 +20,14 @@ function refreshSelectedTab(host) {
 
 export default {
   logs: store([Log], {
-    id: ({ tabId, status }) => ({ tabId, status }),
+    id: ({ tabId, query, status }) => ({ tabId, query, status }),
   }),
   tabs: store([Tab]),
   tabId: ({ tabs }, value) => {
     if (value !== undefined) return value;
     return store.ready(tabs) ? tabs.find((tab) => tab.active).id : '';
   },
+  query: '',
   status: '',
   render: ({ logs, tabs, tabId, status }) => html`
     <template layout="height:full">
@@ -46,6 +47,13 @@ export default {
               )}
             </select>
           </ui-input>
+          <ui-input layout="grow">
+            <input
+              type="search"
+              placeholder="Search..."
+              oninput="${html.set('query')}"
+            />
+          </ui-input>
           <ui-input>
             <select onchange="${html.set('status')}" value="${status}">
               <option value="">All requests</option>
@@ -58,7 +66,15 @@ export default {
             layout="width:5"
             disabled="${!tabId}"
           >
-            <button><ui-icon name="refresh"></ui-icon></button>
+            <button title="Refresh current tab">
+              <ui-icon name="refresh" layout="size:2"></ui-icon>
+            </button>
+          </ui-button>
+
+          <ui-button onclick="${() => location.reload()}" layout="width:5">
+            <button title="Clear logs and reload">
+              <ui-icon name="trash" layout="size:2"></ui-icon>
+            </button>
           </ui-button>
         </div>
         <ui-line></ui-line>

--- a/src/pages/settings/components/devtools.js
+++ b/src/pages/settings/components/devtools.js
@@ -104,6 +104,13 @@ function formatDate(date) {
   });
 }
 
+function openLogger() {
+  const url = chrome.runtime.getURL('/pages/logger/index.html');
+
+  window.open(url, 'Ghostery Logger', 'toolbar=no');
+  window.close();
+}
+
 export default {
   counter: 0,
   options: store(Options),
@@ -214,13 +221,16 @@ export default {
             `}
 
             <div layout="column gap">
-              <ui-text type="headline-s">Local Storage</ui-text>
+              <ui-text type="headline-s">Actions</ui-text>
               <div layout="row gap items:start">
                 <ui-button onclick="${clearStorage}" layout="shrink:0">
                   <button>
                     <ui-icon name="trash" layout="size:2"></ui-icon>
                     Clear storage
                   </button>
+                </ui-button>
+                <ui-button>
+                  <button onclick="${openLogger}">Open logger</button>
                 </ui-button>
               </div>
             </div>

--- a/src/pages/settings/components/devtools.js
+++ b/src/pages/settings/components/devtools.js
@@ -106,9 +106,9 @@ function formatDate(date) {
 
 function openLogger() {
   const url = chrome.runtime.getURL('/pages/logger/index.html');
+  const features = 'toolbar=no,width=1000,height=500';
 
-  window.open(url, 'Ghostery Logger', 'toolbar=no');
-  window.close();
+  window.open(url, 'Ghostery Logger', features);
 }
 
 export default {
@@ -230,7 +230,10 @@ export default {
                   </button>
                 </ui-button>
                 <ui-button>
-                  <button onclick="${openLogger}">Open logger</button>
+                  <button onclick="${openLogger}">
+                    <ui-icon name="play" layout="size:2"></ui-icon>
+                    Logger
+                  </button>
                 </ui-button>
               </div>
             </div>

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -69,6 +69,8 @@ export default class ExtendedRequest extends Request {
       sourceDomain: parsedSourceUrl.domain || parsedSourceUrl.hostname || '',
       sourceHostname: parsedSourceUrl.hostname || '',
 
+      timestamp: details.timeStamp,
+
       type: details.type,
 
       _originalRequestDetails: details,
@@ -86,5 +88,7 @@ export default class ExtendedRequest extends Request {
     this.sourceUrl = data.sourceUrl;
     this.sourceDomain = data.sourceDomain;
     this.sourceHostname = data.sourceHostname;
+
+    this.timestamp = data.timestamp;
   }
 }


### PR DESCRIPTION
Adds Logger feature to developer tools. For now, it provides:
* Log of network requests with connected filter from adblocker engine and status (blocked/modified)
* Filter by tab, filter by status
* Refresh the tab to get a new stream of requests 
* Search by URL/filter
* Reload Logger to clear logs

<img width="862" alt="Zrzut ekranu 2025-01-14 o 10 45 15" src="https://github.com/user-attachments/assets/2a64fad3-8d1d-44cb-a5d5-6b0d5561fea4" />

<img width="1109" alt="Zrzut ekranu 2025-01-14 o 10 46 50" src="https://github.com/user-attachments/assets/b9bc0f83-9e57-489c-b7c7-9c1e2dcbe6b8" />
