### PR TITLE
chore: remove `getBaseRules` from `engine.matchCosmeticFilters`

### DIFF
--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -354,7 +354,6 @@ async function injectCosmetics(details, config) {
       hrefs: config.hrefs,
       ids: config.ids,
 
-      getBaseRules: false,
       // This needs to be done only once per frame
       getInjectionRules: isBootstrap,
       getExtendedRules: isBootstrap,


### PR DESCRIPTION
`getBaseRules` is no longer present in `engine.matchCosmeticFilters`.

https://github.com/ghostery/adblocker/blob/de7bfb534aaac233f6d479af361962619f98ed11/packages/adblocker/src/engine/engine.ts#L1156-L1190 (v2.3.1)