### PR TITLE
fix: typo in `injectCosmetics` config

### DIFF
--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -421,7 +421,7 @@ async function injectCosmetics(details, config) {
 
 chrome.webNavigation.onCommitted.addListener(
   (details) => {
-    injectCosmetics(details, { bootstrap: true });
+    injectCosmetics(details, { isBootstrap: true });
   },
   { url: [{ urlPrefix: 'http://' }, { urlPrefix: 'https://' }] },
 );


### PR DESCRIPTION
It should be `isBootstrap` not `bootstrap`. Confirmed while debugging a website.

<img width="836" alt="image" src="https://github.com/user-attachments/assets/acc308eb-8a66-4450-8889-fcb6181df863" />
