### PR TITLE
fix(autoconsent): use full hostname to check paused websites

### DIFF
--- a/src/background/autoconsent.js
+++ b/src/background/autoconsent.js
@@ -25,7 +25,7 @@ async function initialize(msg, tab, frameId) {
   ]);
 
   if (options.terms && options.blockAnnoyances) {
-    const domain = tab.url ? parse(tab.url).hostname.replace(/^www\./, '') : '';
+    const domain = tab.url ? parse(tab.url).hostname : '';
 
     if (
       isPaused(options, domain) ||


### PR DESCRIPTION
Leftover bug after #2171 - the removal of the `www` subdomain should be now only in the panel.

Without this PR after pausing page with `www` subdomain the autoconsent library is still activated.