### PR TITLE
fix(panel): pause action & minor report fixes

### DIFF
--- a/src/pages/panel/components/alert.js
+++ b/src/pages/panel/components/alert.js
@@ -9,10 +9,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import { html } from 'hybrids';
+import { dispatch, html } from 'hybrids';
 
 function close(host) {
-  host.parentNode.removeChild(host);
+  dispatch(host, 'close');
 }
 
 const slide = {
@@ -68,7 +68,7 @@ export default {
   },
   render: ({ icon, autoclose }) => html`
     <template
-      layout="grid:max|1|max items:center gap:0.5 height:4 padding:0:1.5"
+      layout="grid:max|1|max items:center gap:0.5 height:5 padding:0:1.5"
       layout[slide]="absolute inset bottom:auto"
     >
       <ui-icon name="${icon}"></ui-icon>

--- a/src/pages/panel/components/menu-item.js
+++ b/src/pages/panel/components/menu-item.js
@@ -17,13 +17,14 @@ export default {
   href: '',
   icon: '',
   suffixIcon: 'arrow-right',
-  render: ({ href, icon, suffixIcon }) => html`
-    <template layout>
+  internal: ({ href }) => href.startsWith(location.origin + location.pathname),
+  render: ({ href, icon, suffixIcon, internal }) => html`
+    <template layout="block">
       <ui-action>
         <a
           href="${href}"
           layout="grid:max|1|max items:center:start gap:1.5 padding margin:0:1"
-          onclick="${openTabWithUrl}"
+          onclick="${internal ? undefined : openTabWithUrl}"
         >
           <ui-icon name="${icon}" color="gray-600" layout="size:2.5"></ui-icon>
           <ui-text

--- a/src/pages/panel/index.js
+++ b/src/pages/panel/index.js
@@ -53,12 +53,14 @@ if (__PLATFORM__ === 'safari') {
 // Close window when anchor is clicked
 document.addEventListener('click', (event) => {
   let el = event.target;
-  while (el && !el.href) el = el.parentElement;
 
+  while (el && !el.href) el = el.parentElement;
   if (!el) return;
 
+  const { hostname, pathname } = new URL(el.href);
+
   // Timeout is required to prevent from closing the window before the anchor is opened
-  if (el.origin !== location.origin || el.pathname !== location.pathname) {
+  if (hostname !== location.hostname || pathname !== location.pathname) {
     setTimeout(window.close, 50);
   }
 });

--- a/src/pages/panel/views/main.js
+++ b/src/pages/panel/views/main.js
@@ -169,7 +169,7 @@ export default {
             <panel-alert
               type="info"
               slide
-              autoclose="10"
+              autoclose="6"
               onclose="${html.set('alert', '')}"
             >
               ${alert}

--- a/src/pages/panel/views/menu.js
+++ b/src/pages/panel/views/menu.js
@@ -15,6 +15,8 @@ import Options from '/store/options.js';
 import Session from '/store/session.js';
 import { openTabWithUrl } from '/utils/tabs.js';
 
+import ReportForm from './report-form.js';
+
 export default {
   options: store(Options),
   session: store(Session),
@@ -124,11 +126,7 @@ export default {
               Support
             </ui-text>
 
-            <panel-menu-item
-              href="https://www.ghostery.com/support?utm_source=gbe"
-              icon="report"
-              suffix-icon="link-external-m"
-            >
+            <panel-menu-item href="${router.url(ReportForm)}" icon="report">
               Report a broken page
             </panel-menu-item>
 

--- a/src/pages/panel/views/report-form.js
+++ b/src/pages/panel/views/report-form.js
@@ -113,7 +113,7 @@ export default {
             </ui-text>
             <ui-input>
               <textarea
-                placeholder="Please describe the issue"
+                placeholder="${msg`Please describe the issue`}"
                 rows="4"
                 autocomplete="off"
                 style="resize: vertical"
@@ -127,7 +127,7 @@ export default {
               <input
                 type="email"
                 name="email"
-                placeholder="Enter email address"
+                placeholder="${msg`Enter email address`}"
                 layout="::ui:font:body-s"
                 value="${form.email}"
                 oninput="${html.set(form, 'email')}"

--- a/src/pages/settings/views/tracker-details.js
+++ b/src/pages/settings/views/tracker-details.js
@@ -189,7 +189,7 @@ export default {
               <div layout="margin:3:0">
                 <ui-action>
                   <a
-                    href="${`${WTM_PAGE_URL}trackers/${tracker.id}`}"
+                    href="${`${WTM_PAGE_URL}/trackers/${tracker.id}`}"
                     target="_blank"
                   >
                     <settings-wtm-link>

--- a/src/pages/settings/views/website-details.js
+++ b/src/pages/settings/views/website-details.js
@@ -201,7 +201,7 @@ export default {
         html`
           <div layout="margin:3:0">
             <ui-action>
-              <a href="${`${WTM_PAGE_URL}websites/${domain}`}" target="_blank">
+              <a href="${`${WTM_PAGE_URL}/websites/${domain}`}" target="_blank">
                 <settings-wtm-link>
                   WhoTracks.Me Statistical Report
                 </settings-wtm-link>

--- a/src/pages/trackers-preview/index.js
+++ b/src/pages/trackers-preview/index.js
@@ -13,6 +13,8 @@ import { define, html, store } from 'hybrids';
 
 import { sortCategories } from '/ui/categories.js';
 import { getWTMStats } from '/utils/wtm-stats.js';
+import { WTM_PAGE_URL } from '/utils/urls.js';
+
 import Options from '/store/options.js';
 
 import DisablePreviewImg from './assets/disable-preview.svg';
@@ -90,7 +92,7 @@ define({
                   domain="${domain}"
                   categories="${stats}"
                   layout="relative layer:101"
-                  wtm-link
+                  wtmLink="${`${WTM_PAGE_URL}/websites/${domain}`}"
                   data-qa="component:stats"
                 >
                 </ui-stats>

--- a/src/ui/components/stats.js
+++ b/src/ui/components/stats.js
@@ -11,10 +11,7 @@
 
 import { html, store, router, dispatch } from 'hybrids';
 
-import { GHOSTERY_DOMAIN } from '/utils/urls.js';
 import { openTabWithUrl } from '/utils/tabs.js';
-
-const WTM_URL = `https://www.${GHOSTERY_DOMAIN}/whotracksme/`;
 
 export default {
   categories: undefined,
@@ -44,7 +41,7 @@ export default {
     ),
   readonly: false,
   domain: '',
-  wtmLink: false,
+  wtmLink: '',
   type: {
     value: 'graph',
     observe(host, value, lastValue) {
@@ -77,11 +74,7 @@ export default {
           <ui-tooltip position="bottom">
             <span slot="content">WhoTracks.Me Statistical Report</span>
             <ui-action-button layout="size:4.5">
-              <a
-                href="${WTM_URL}websites/${domain}"
-                onclick="${openTabWithUrl}"
-                target="_blank"
-              >
+              <a href="${wtmLink}" onclick="${openTabWithUrl}" target="_blank">
                 <ui-icon name="whotracksme" color="gray-800"></ui-icon>
               </a>
             </ui-action-button>

--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -14,9 +14,10 @@ import { debugMode } from './debug.js';
 export const GHOSTERY_DOMAIN = debugMode ? 'ghosterystage.com' : 'ghostery.com';
 
 export const HOME_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/`;
+
 export const SIGNON_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/signin`;
 export const CREATE_ACCOUNT_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/register`;
 export const ACCOUNT_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/account`;
-export const SUPPORT_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/support`;
 
-export const WTM_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/whotracksme/`;
+export const WTM_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/whotracksme`;
+export const SUPPORT_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/support`;


### PR DESCRIPTION
* Removes autorefresh of the paused page - instead, we display "Reload to see changes" CTA in the top alert after pausing
* "Report a broken page" link in the menu leads to the panel's form 
* Minor fixes in the panel (WTM  link, missing translations in the report form)

Testing should also focus on checking links/actions in the panel menu on different platforms.

<img width="348" alt="Zrzut ekranu 2025-01-23 o 14 07 05" src="https://github.com/user-attachments/assets/25f1c93c-96b3-4dd8-9431-59291731e48f" />

<img width="348" alt="Zrzut ekranu 2025-01-23 o 14 07 05" src="https://github.com/user-attachments/assets/098a2d14-77d1-4f0d-a072-36599f5562fc" />

