### PR TITLE
chore(e2e): fix wdio config for Chrome

### DIFF
--- a/src/background/onboarding.js
+++ b/src/background/onboarding.js
@@ -8,10 +8,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
+import { debugMode } from '/utils/debug';
 import * as OptionsObserver from '/utils/options-observer.js';
 
 OptionsObserver.addListener('onboarding', (onboarding) => {
   if (!onboarding.shown) {
+    // The onboarding page should not be shown in debug mode especially for the e2e tests
+    // which fails if after initializing the extension additional tabs are opened
+    if (debugMode) return;
+
     chrome.tabs.create({
       url: chrome.runtime.getURL('/pages/onboarding/index.html'),
     });

--- a/tests/e2e/spec/panel.spec.js
+++ b/tests/e2e/spec/panel.spec.js
@@ -8,12 +8,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
-import { expect, $ } from '@wdio/globals';
+import { browser, expect, $ } from '@wdio/globals';
 import {
   enableExtension,
   getExtensionElement,
   switchToPanel,
-  switchToNewTabContext,
 } from '../utils.js';
 
 describe('Panel', function () {
@@ -22,14 +21,16 @@ describe('Panel', function () {
   it('opens licenses page', async function () {
     await switchToPanel(async () => {
       await getExtensionElement('button:menu').click();
+      const url =
+        await getExtensionElement('button:licenses').getProperty('href');
 
-      await switchToNewTabContext(
-        await getExtensionElement('button:licenses'),
-        async function () {
-          const bodyText = await $('body').getText();
-          await expect(bodyText.includes('MIT')).toBe(true);
-        },
-      );
+      const currentUrl = await browser.getUrl();
+      await browser.url(url);
+
+      const bodyText = await $('body').getText();
+      await expect(bodyText.includes('MIT')).toBe(true);
+
+      await browser.url(currentUrl);
     });
   });
 });

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -118,33 +118,3 @@ export async function switchToPanel(fn) {
   if (error) throw error;
   return result;
 }
-
-export async function switchToNewTabContext(anchor, fn) {
-  const url = await browser.getUrl();
-  let error = null;
-
-  try {
-    const href = await anchor.getProperty('href');
-    if (!href) throw new Error('Anchor does not have an href');
-
-    await anchor.click();
-
-    await browser.waitUntil(() =>
-      browser.switchWindow(href).then(
-        () => true,
-        () => false,
-      ),
-    );
-
-    await fn();
-  } catch (e) {
-    error = e;
-  }
-
-  if ((await browser.getUrl()) !== url) {
-    await browser.closeWindow();
-  }
-  await browser.switchWindow(url);
-
-  if (error) throw error;
-}


### PR DESCRIPTION
The recent update of Chrome introduced a problem with the `browser.switchWindow()` API, which closes the whole browser and makes tests fail immediately after. 

I tried many different approaches (from temporarily fixed Chrome version - v131 and older passes tests) to try to avoid the bug/feature of Chrome, but without success. However, the root problem is that the onboarding page automatically opens after an extension is installed. If we disable the automatic opening of that page, we can fix the issue using the latest Chrome.

I have used the `--debug` mode of the extension build to add conditions in the background to prevent onboarding from opening automatically. It is pointless to create a separate flag for it.

The good side-effect of using debug mode is sending telemetry signals to dev env, so for example `engaged` signals are not saved on prod (which can be many during a day, as every run of tests sends this signal).