### PR TITLE
fix(safari): use declarative content script for request stats

### DIFF
--- a/src/content_scripts/whotracksme/index.js
+++ b/src/content_scripts/whotracksme/index.js
@@ -99,14 +99,19 @@ function postMessage({ urls }) {
 
   // fetch, XMLHTTPRequest and others must be injected in main world
   function injectMonkeyPatches() {
-    const script = document.createElement('script');
-    script.src = chrome.runtime.getURL(
-      'content_scripts/whotracksme/ghostery-whotracksme.js',
-    );
-    script.onload = function () {
-      this.remove();
-    };
-    (document.head || document.documentElement).appendChild(script);
+    // Safari 17.x does not support "main" world in content scripts
+    // so we need to inject the script in the main world
+    // TODO: Remove script injection when we drop support for Safari 17.x
+    if (navigator.userAgent.includes('17_')) {
+      const script = document.createElement('script');
+      script.src = chrome.runtime.getURL(
+        'content_scripts/whotracksme/ghostery-whotracksme.js',
+      );
+      script.onload = function () {
+        this.remove();
+      };
+      (document.head || document.documentElement).appendChild(script);
+    }
 
     window.addEventListener('message', (message) => {
       if (

--- a/src/manifest.chromium.json
+++ b/src/manifest.chromium.json
@@ -18,12 +18,7 @@
     "webRequest",
     "offscreen"
   ],
-  "host_permissions": [
-    "http://*/*",
-    "https://*/*",
-    "ws://*/*",
-    "wss://*/*"
-  ],
+  "host_permissions": ["http://*/*", "https://*/*", "ws://*/*", "wss://*/*"],
   "icons": {
     "64": "/icons/icon-64.png",
     "128": "/icons/icon-128.png"
@@ -95,10 +90,10 @@
       "run_at": "document_start"
     },
     {
-			"js": ["content_scripts/youtube.js"],
+      "js": ["content_scripts/youtube.js"],
       "matches": ["*://www.youtube.com/*"],
       "run_at": "document_start"
-		},
+    },
     {
       "js": ["content_scripts/trackers-preview.js"],
       "run_at": "background_execute_script"
@@ -121,9 +116,7 @@
       "use_dynamic_url": true
     },
     {
-      "resources": [
-        "pages/notifications/youtube.html"
-      ],
+      "resources": ["pages/notifications/youtube.html"],
       "matches": ["*://www.youtube.com/*"],
       "use_dynamic_url": true
     }

--- a/src/manifest.safari.json
+++ b/src/manifest.safari.json
@@ -16,12 +16,7 @@
     "tabs",
     "activeTab"
   ],
-  "host_permissions": [
-    "http://*/*",
-    "https://*/*",
-    "ws://*/*",
-    "wss://*/*"
-  ],
+  "host_permissions": ["http://*/*", "https://*/*", "ws://*/*", "wss://*/*"],
   "icons": {
     "32": "/icons/icon.svg",
     "64": "/icons/icon.svg",
@@ -44,8 +39,8 @@
     "page": "background/index.html",
     "persistent": false
   },
-  "declarative_net_request" : {
-    "rule_resources" : [
+  "declarative_net_request": {
+    "rule_resources": [
       {
         "id": "ads",
         "enabled": false,
@@ -70,6 +65,12 @@
       "run_at": "document_start"
     },
     {
+      "js": ["content_scripts/whotracksme/ghostery-whotracksme.js"],
+      "matches": ["http://*/*", "https://*/*"],
+      "run_at": "document_start",
+      "world": "MAIN"
+    },
+    {
       "js": ["content_scripts/adblocker.js"],
       "matches": ["http://*/*", "https://*/*"],
       "run_at": "document_start",
@@ -92,10 +93,10 @@
       "run_at": "document_start"
     },
     {
-			"js": ["content_scripts/youtube.js"],
+      "js": ["content_scripts/youtube.js"],
       "matches": ["*://www.youtube.com/*"],
       "run_at": "document_start"
-		},
+    },
     {
       "js": ["content_scripts/trackers-preview.js"],
       "run_at": "background_execute_script"
@@ -111,8 +112,7 @@
         "pages/trackers-preview/index.html",
         "pages/notifications/pause-assistant.html",
         "pages/notifications/pause-resume.html",
-        "pages/notifications/pause-feedback.html",
-        "content_scripts/whotracksme/ghostery-whotracksme.js"
+        "pages/notifications/pause-feedback.html"
       ],
       "matches": ["<all_urls>"],
       "all_frames": true,


### PR DESCRIPTION
Fixes #2311.

We have to keep the current solution beside the declarative content script, as the "main" world is supported from 18.x version of Safari. 

From my testing it's fine to run the declarative content script in 17.x, it just tries to monkey patch isolated environment, so there is no effect, but also no errors etc.

FYI: my editor have started linting manifests, that's why I clean up all of them (there are styling changes for Chromium and Safari).