### PR TITLE
fix(managed): add `disableUserAccount` option to managed storage

### DIFF
--- a/src/managed_storage.json
+++ b/src/managed_storage.json
@@ -13,6 +13,12 @@
       "type": "boolean"
     },
 
+    "disableUserAccount": {
+      "title": "Disable user account",
+      "description": "Prevents the user from creating an account or logging in",
+      "type": "boolean"
+    },
+
     "trustedDomains": {
       "title": "Trusted domains",
       "description": "A list of domains that are trusted by default",

--- a/src/pages/panel/store/notification.js
+++ b/src/pages/panel/store/notification.js
@@ -77,12 +77,13 @@ export default {
       return NOTIFICATIONS.review;
     }
 
-    // Show contributor notification if user is not a contributor
-    if (
-      __PLATFORM__ !== 'safari' &&
-      !(await store.resolve(Session)).contributor
-    ) {
-      return CONTRIBUTOR_NOTIFICATION;
+    if (__PLATFORM__ !== 'safari') {
+      const session = await store.resolve(Session);
+
+      // Show contributor notification if user is not a contributor
+      if (session.enabled && !session.contributor) {
+        return CONTRIBUTOR_NOTIFICATION;
+      }
     }
 
     // By default, show review notification

--- a/src/pages/panel/views/menu.js
+++ b/src/pages/panel/views/menu.js
@@ -104,6 +104,7 @@ export default {
 
               ${__PLATFORM__ !== 'safari' &&
               store.ready(session) &&
+              session.enabled &&
               !session.contributor &&
               html`
                 <ui-button type="outline-primary" layout="margin:1:1.5">

--- a/src/pages/settings/settings.js
+++ b/src/pages/settings/settings.js
@@ -99,6 +99,7 @@ export default {
           </a>
           ${__PLATFORM__ !== 'safari' &&
           store.ready(session) &&
+          session.enabled &&
           html`
             <settings-card
               layout="hidden"

--- a/src/pages/settings/views/my-ghostery.js
+++ b/src/pages/settings/views/my-ghostery.js
@@ -62,83 +62,95 @@ export default {
           <div layout="column gap" layout@992px="margin:bottom">
             <ui-text type="headline-m">My Ghostery</ui-text>
           </div>
-          <settings-card>
-            <img
-              src="${assets[
-                store.ready(session) && session.user ? 'shield' : 'contribution'
-              ]}"
-              layout="size:20"
-              alt="Contribution"
-              slot="picture"
-            />
-            ${store.ready(session) &&
-            (session.user
-              ? html`
-                  <div layout="column gap:0.5 margin:bottom:2">
-                    <ui-text type="label-m" color="secondary">
-                      You are signed in as:
-                    </ui-text>
-                    <div layout="row items:center gap:2">
-                      <ui-text type="headline-m">${session.name}</ui-text>
-                      ${session.contributor &&
-                      html`<settings-badge type="brand" uppercase>
-                        Contributor
-                      </settings-badge>`}
+          ${store.ready(session) &&
+          session.enabled &&
+          html`
+            <settings-card>
+              <img
+                src="${assets[
+                  store.ready(session) && session.user
+                    ? 'shield'
+                    : 'contribution'
+                ]}"
+                layout="size:20"
+                alt="Contribution"
+                slot="picture"
+              />
+              ${session.user
+                ? html`
+                    <div layout="column gap:0.5 margin:bottom:2">
+                      <ui-text type="label-m" color="secondary">
+                        You are signed in as:
+                      </ui-text>
+                      <div layout="row items:center gap:2">
+                        <ui-text type="headline-m">${session.name}</ui-text>
+                        ${session.contributor &&
+                        html`<settings-badge type="brand" uppercase>
+                          Contributor
+                        </settings-badge>`}
+                      </div>
+                      <ui-text type="body-m" color="secondary">
+                        ${session.email}
+                      </ui-text>
                     </div>
-                    <ui-text type="body-m" color="secondary">
-                      ${session.email}
-                    </ui-text>
-                  </div>
-                  <div layout="row gap">
-                    <ui-button type="primary">
-                      <a href="${ACCOUNT_PAGE_URL}" onclick="${openTabWithUrl}">
-                        Account details
-                        <ui-icon name="arrow-right-s"></ui-icon>
-                      </a>
-                    </ui-button>
-                  </div>
-                `
-              : html`
-                  <div>
-                    <ui-text type="headline-s">Join Ghostery</ui-text>
-                    <ui-text
-                      color="secondary"
-                      type="body-m"
-                      mobile-type="body-s"
-                    >
-                      Sign in or create account on ghostery.com
-                    </ui-text>
-                  </div>
-                  <div layout="row gap">
-                    <ui-button type="success">
-                      <button onclick="${openGhosteryPage(SIGNON_PAGE_URL)}">
-                        Sign in <ui-icon name="arrow-right-s"></ui-icon>
-                      </button>
-                    </ui-button>
-                    <ui-button>
-                      <button
-                        onclick="${openGhosteryPage(CREATE_ACCOUNT_PAGE_URL)}"
+                    <div layout="row gap">
+                      <ui-button type="primary">
+                        <a
+                          href="${ACCOUNT_PAGE_URL}"
+                          onclick="${openTabWithUrl}"
+                        >
+                          Account details
+                          <ui-icon name="arrow-right-s"></ui-icon>
+                        </a>
+                      </ui-button>
+                    </div>
+                  `
+                : html`
+                    <div>
+                      <ui-text type="headline-s">Join Ghostery</ui-text>
+                      <ui-text
+                        color="secondary"
+                        type="body-m"
+                        mobile-type="body-s"
                       >
-                        Create Account
-                        <ui-icon name="arrow-right-s"></ui-icon>
-                      </button>
-                    </ui-button>
-                  </div>
-                `)}
-          </settings-card>
+                        Sign in or create account on ghostery.com
+                      </ui-text>
+                    </div>
+                    <div layout="row gap">
+                      <ui-button type="success">
+                        <button onclick="${openGhosteryPage(SIGNON_PAGE_URL)}">
+                          Sign in <ui-icon name="arrow-right-s"></ui-icon>
+                        </button>
+                      </ui-button>
+                      <ui-button>
+                        <button
+                          onclick="${openGhosteryPage(CREATE_ACCOUNT_PAGE_URL)}"
+                        >
+                          Create Account
+                          <ui-icon name="arrow-right-s"></ui-icon>
+                        </button>
+                      </ui-button>
+                    </div>
+                  `}
+            </settings-card>
+          `}
           <div layout="column gap:4">
-            <ui-toggle
-              value="${options.sync}"
-              onchange="${html.set(options, 'sync')}"
-            >
-              <settings-option>
-                Sync Settings
-                <span slot="description">
-                  Saves and synchronizes your custom settings between browsers
-                  and devices.
-                </span>
-              </settings-option>
-            </ui-toggle>
+            ${store.ready(session) &&
+            session.enabled &&
+            html`
+              <ui-toggle
+                value="${options.sync}"
+                onchange="${html.set(options, 'sync')}"
+              >
+                <settings-option>
+                  Sync Settings
+                  <span slot="description">
+                    Saves and synchronizes your custom settings between browsers
+                    and devices.
+                  </span>
+                </settings-option>
+              </ui-toggle>
+            `}
 
             <div layout="row gap:2">
               <div layout="column grow gap:0.5">

--- a/src/pages/settings/views/privacy.js
+++ b/src/pages/settings/views/privacy.js
@@ -254,6 +254,7 @@ export default {
         `}
         ${__PLATFORM__ !== 'safari' &&
         store.ready(session) &&
+        session.enabled &&
         html`
           <section
             layout="grid:1/1 grow items:end:stretch padding:0"

--- a/src/pages/whotracksme/whotracksme.js
+++ b/src/pages/whotracksme/whotracksme.js
@@ -424,6 +424,7 @@ export default {
             ></whotracksme-sankey-chart>
           </section>
           ${store.ready(session) &&
+          session.enabled &&
           !session.contributor &&
           html`
             <section

--- a/src/utils/managed.js
+++ b/src/utils/managed.js
@@ -1,0 +1,32 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+import { isOpera } from './browser-info.js';
+
+let managed = __PLATFORM__ !== 'safari' && !isOpera() ? undefined : null;
+export async function getManagedConfig() {
+  if (managed === undefined) {
+    try {
+      managed = await chrome.storage.managed.get(null);
+
+      // Some of the platforms returns an empty object if there are no managed options
+      // so we need to check property existence that the managed options are enabled
+      managed = Object.keys(managed).length > 0 ? managed : null;
+
+      if (managed) {
+        console.debug(`[options] Managed storage received:`, managed);
+      }
+    } catch {
+      managed = null;
+    }
+  }
+
+  return managed;
+}


### PR DESCRIPTION
Fixes #2310.

* Adds `disableUserAccount` option to managed storage
* Disables session and contribution prompts if the option is used
* The code ensures proper tree-shaking for unsupported platforms