### PR TITLE
fix(safari): clean up fixed bugs

### DIFF
--- a/src/background/session.js
+++ b/src/background/session.js
@@ -20,7 +20,7 @@ function refreshSession() {
 }
 
 // Observe cookie changes (login/logout actions)
-chrome.cookies.onChanged.addListener(async ({ cookie }) => {
+chrome.cookies.onChanged.addListener(({ cookie }) => {
   if (cookie.domain === COOKIE_DOMAIN && cookie.name === 'access_token') {
     refreshSession();
   }

--- a/src/background/stats.js
+++ b/src/background/stats.js
@@ -349,22 +349,15 @@ if (__PLATFORM__ === 'safari') {
     if (sender.url && sender.frameId !== undefined && sender.tab?.id > -1) {
       switch (msg.action) {
         case 'updateTabStats':
-          // On Safari `onBeforeNavigate` event is not trigger correctly
-          // if a user navigates to the page by setting URL in the address bar.
-          // This condition ensures that we setup tabStats for the tab
-          // when `updateTabStats` message is received.
-          if (tabStats.get(sender.tab.id)?.url !== sender.url) {
-            setupTabStats({
-              tabId: sender.tab.id,
-              url: sender.url,
-              timeStamp: Date.now(),
-            });
-          }
-
           updateTabStats(
             sender.tab.id,
             msg.urls.map((url) =>
-              Request.fromRequestDetails({ url, originUrl: sender.url }),
+              Request.fromRequestDetails({
+                url,
+                originUrl: sender.url,
+                tabId: sender.tab.id,
+                requestId: `${Math.random().toString(36).substring(2, 9)}-${Math.random().toString(36).substring(2, 9)}`,
+              }),
             ),
           );
           break;

--- a/src/background/stats.js
+++ b/src/background/stats.js
@@ -356,7 +356,7 @@ if (__PLATFORM__ === 'safari') {
                 url,
                 originUrl: sender.url,
                 tabId: sender.tab.id,
-                requestId: `${Math.random().toString(36).substring(2, 9)}-${Math.random().toString(36).substring(2, 9)}`,
+                requestId: Math.random().toString(36).substring(2, 20),
               }),
             ),
           );

--- a/src/content_scripts/youtube.js
+++ b/src/content_scripts/youtube.js
@@ -79,7 +79,6 @@ async function isFeatureDisabled() {
   return false;
 }
 
-// INFO: Safari always returns false for `inIncognitoContext`
 if (!chrome.extension.inIncognitoContext) {
   (async () => {
     if (await isFeatureDisabled()) return;

--- a/src/pages/logger/index.js
+++ b/src/pages/logger/index.js
@@ -19,13 +19,17 @@ import Main from './views/main.js';
 const port = chrome.runtime.connect({ name: 'logger' });
 
 // Listen for requests from the background script
-port.onMessage.addListener((message) => {
+port.onMessage.addListener(async (message) => {
   if (message.action === 'logger:requests') {
-    for (const data of message.logs) {
-      const log = store.get(Log, data.id);
-      delete data.id;
+    try {
+      for (const data of message.logs) {
+        const log = store.get(Log, data.id);
+        delete data.id;
 
-      store.set(log, data);
+        await store.set(log, data);
+      }
+    } catch (error) {
+      console.error('Error processing logs:', error);
     }
   }
 });

--- a/src/pages/panel/index.js
+++ b/src/pages/panel/index.js
@@ -31,23 +31,6 @@ chrome.runtime.sendMessage({ action: 'telemetry', event: 'engaged' });
 // Sync options with background
 chrome.runtime.sendMessage({ action: 'syncOptions' });
 
-// Safari extension popup has a bug, which focuses visibly the first element on the page
-// when the popup is opened. This is a workaround to remove the focus.
-if (__PLATFORM__ === 'safari') {
-  window.addEventListener('load', () => {
-    setTimeout(() => {
-      document.body.focus();
-      document.body.addEventListener(
-        'focus',
-        () => {
-          document.body.removeAttribute('tabIndex');
-        },
-        { once: true },
-      );
-    }, 100);
-  });
-}
-
 // Close window when anchor is clicked
 document.addEventListener('click', (event) => {
   let el = event.target;

--- a/src/store/tab-stats.js
+++ b/src/store/tab-stats.js
@@ -84,20 +84,13 @@ const Stats = {
 
       return { hostname: parse(tab.url).hostname };
     },
-    observe:
-      __PLATFORM__ === 'safari' &&
-      (() => {
-        setTimeout(() => store.clear(Stats, false), 1000);
-      }),
   },
 };
 
 export default Stats;
 
-if (__PLATFORM__ !== 'safari') {
-  chrome.storage.onChanged.addListener((changes) => {
-    if (changes['tabStats:v1']) {
-      store.clear(Stats, false);
-    }
-  });
-}
+chrome.storage.onChanged.addListener((changes) => {
+  if (changes['tabStats:v1']) {
+    store.clear(Stats, false);
+  }
+});

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -34,6 +34,9 @@ if (__PLATFORM__ === 'safari') {
   //
   // Below code tries to detect the offset between the two
   // and use it to convert the expirationDate to seconds
+
+  // TODO: Tested on Safari 18.3.1 - both issue are fixed.
+  // Remove this code when we drop support for older versions
   (async () => {
     try {
       const cookie = await chrome.cookies.set({
@@ -100,6 +103,10 @@ async function getCookie(name) {
 
     // By the specs, the `expirationDate` should be in seconds since the epoch
     // and we need to convert it to milliseconds, but Safari returns it in milliseconds
+
+    // TODO: Tested on Safari 18.3.1 - issue fixed
+    // Multiple date for all platforms when we drop support
+    // for older versions of Safari
     if (
       __PLATFORM__ !== 'safari' ||
       new Date(expirationDate).getFullYear() === 1970

--- a/xcode/Ghostery.xcodeproj/project.pbxproj
+++ b/xcode/Ghostery.xcodeproj/project.pbxproj
@@ -234,7 +234,6 @@
 		B4EBAD7E2A1DFA6C006A7D73 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		B4FFD50127F73B820041049C /* rule_resources */ = {isa = PBXFileReference; lastKnownFileType = folder; name = rule_resources; path = ../../dist/rule_resources; sourceTree = "<group>"; };
 		CEC6DBC9292BE699001E9642 /* virtual */ = {isa = PBXFileReference; lastKnownFileType = folder; name = virtual; path = ../../dist/virtual; sourceTree = "<group>"; };
-    B475613F2CF47A6500807030 /* static_pages */ = {isa = PBXFileReference; lastKnownFileType = folder; name = static_pages; path = ../../dist/static_pages; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -576,7 +575,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1300;
-				LastUpgradeCheck = 1540;
+				LastUpgradeCheck = 1620;
 				TargetAttributes = {
 					468E428A2701F84A008B5792 = {
 						CreatedOnToolsVersion = 13.0;
@@ -681,7 +680,7 @@
 				B4D49C7028045EFC00277CCA /* store in Resources */,
 				B469CA9227BE924D00408C43 /* content_scripts in Resources */,
 				B463BF722ADE91F00088B0F0 /* icons in Resources */,
-        CEC6DBCC292BE699001E9642 /* static_pages in Resources */,
+				CEC6DBCC292BE699001E9642 /* static_pages in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -702,7 +701,7 @@
 				B4D49C7128045EFC00277CCA /* store in Resources */,
 				B469CA9327BE924D00408C43 /* content_scripts in Resources */,
 				B463BF732ADE91F00088B0F0 /* icons in Resources */,
-        CEC6DBCD292BE699001E9642 /* static_pages in Resources */,
+				CEC6DBCD292BE699001E9642 /* static_pages in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1044,7 +1043,6 @@
 		468E42D02701F84A008B5792 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
@@ -1059,7 +1057,7 @@
 				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleLightContent;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1083,7 +1081,6 @@
 		468E42D12701F84A008B5792 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
@@ -1098,7 +1095,7 @@
 				INFOPLIST_KEY_UIStatusBarStyle = UIStatusBarStyleLightContent;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1193,7 +1190,6 @@
 		468E42D72701F84A008B5792 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "macOS (App)/Ghostery – Privacy Ad Blocker.entitlements";
@@ -1214,7 +1210,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
 				OTHER_LDFLAGS = (
 					"-framework",
@@ -1233,7 +1229,6 @@
 		468E42D82701F84A008B5792 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "macOS (App)/Ghostery – Privacy Ad Blocker.entitlements";
@@ -1253,7 +1248,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
 				OTHER_LDFLAGS = (
 					"-framework",

--- a/xcode/Ghostery.xcodeproj/xcshareddata/xcschemes/Ghostery – Privacy Ad Blocker (iOS).xcscheme
+++ b/xcode/Ghostery.xcodeproj/xcshareddata/xcschemes/Ghostery – Privacy Ad Blocker (iOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1540"
+   LastUpgradeVersion = "1620"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/xcode/Ghostery.xcodeproj/xcshareddata/xcschemes/Ghostery – Privacy Ad Blocker (macOS).xcscheme
+++ b/xcode/Ghostery.xcodeproj/xcshareddata/xcschemes/Ghostery – Privacy Ad Blocker (macOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1540"
+   LastUpgradeVersion = "1620"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Fxies #2339 Fixes https://github.com/ghostery/journal/issues/496
* Bumps platform targets to iOS 18 and macOS 13
* `cookies.get()` and `cookies.set()` correctly sets/gets `expirationDate`, but we still support the older version of the platform, so we have to keep bugfixes - `TODO` added
* `chrome.extension.inIncognitoContext` correctly returns `true` in private window
* Opening panel (extension's popup window) does not trigger focus on first element
* `chrome.storage.onChanged` triggers correctly in the context of the extension's popup window
* Fixes missing fields of requests sent to Logger