### PR TITLE
fix: retrieve DOM features before mutation observation

### DIFF
--- a/src/content_scripts/adblocker.js
+++ b/src/content_scripts/adblocker.js
@@ -135,11 +135,7 @@ document.addEventListener('DOMContentLoaded', () => {
     subtree: true,
   });
 
-  for (const el of new Set([
-    ...document.querySelectorAll('[id]'),
-    ...document.querySelectorAll('[class]'),
-    ...document.querySelectorAll('[href]'),
-  ])) {
+  for (const el of document.querySelectorAll('[id],[class],[href]')) {
     addFeatures(el);
   }
   injectCosmetics();

--- a/src/content_scripts/adblocker.js
+++ b/src/content_scripts/adblocker.js
@@ -57,6 +57,15 @@ function addSelector(type, selector) {
   }
 }
 
+function addFeatures(el) {
+  if (el.className) {
+    el.classList.forEach((c) => addSelector('classes', c));
+  }
+
+  addSelector('ids', el.getAttribute('id'));
+  addSelector('hrefs', el.getAttribute('href'));
+}
+
 const injectCosmetics = debounce(
   () => {
     if (selectors.classes.size || selectors.ids.size || selectors.hrefs.size) {
@@ -104,13 +113,7 @@ const observer = new MutationObserver((mutations) => {
           while (el) {
             if (!visited.has(el)) {
               visited.add(el);
-
-              if (el.className) {
-                el.classList.forEach((c) => addSelector('classes', c));
-              }
-
-              addSelector('ids', el.getAttribute('id'));
-              addSelector('hrefs', el.getAttribute('href'));
+              addFeatures(el);
             }
 
             el = treeWalker.nextNode();
@@ -131,4 +134,13 @@ document.addEventListener('DOMContentLoaded', () => {
     childList: true,
     subtree: true,
   });
+
+  for (const el of new Set([
+    ...document.querySelectorAll('[id]'),
+    ...document.querySelectorAll('[class]'),
+    ...document.querySelectorAll('[href]'),
+  ])) {
+    addFeatures(el);
+  }
+  injectCosmetics();
 });

--- a/src/content_scripts/adblocker.js
+++ b/src/content_scripts/adblocker.js
@@ -57,7 +57,7 @@ function addSelector(type, selector) {
   }
 }
 
-function addFeatures(el) {
+function addSelectors(el) {
   if (el.className) {
     el.classList.forEach((c) => addSelector('classes', c));
   }

--- a/src/content_scripts/adblocker.js
+++ b/src/content_scripts/adblocker.js
@@ -113,7 +113,7 @@ const observer = new MutationObserver((mutations) => {
           while (el) {
             if (!visited.has(el)) {
               visited.add(el);
-              addFeatures(el);
+              addSelectors(el);
             }
 
             el = treeWalker.nextNode();
@@ -136,7 +136,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   for (const el of document.querySelectorAll('[id],[class],[href]')) {
-    addFeatures(el);
+    addSelectors(el);
   }
   injectCosmetics();
 });


### PR DESCRIPTION
fixes #2344 

Generic cosmetic filtering was not properly done because we didn't retrieve existing DOM features before the mutation observation.

-- Added functions
* `function addFeatures(el)`: Retrieve features from an element and add pass them to `addSelector`