### PR TITLE
fix(engines): remove capturing errors for failing indexeddb

### DIFF
--- a/src/utils/engines.js
+++ b/src/utils/engines.js
@@ -20,7 +20,6 @@ import {
 
 import { registerDatabase } from './indexeddb.js';
 import debug from './debug.js';
-import { captureException } from './errors.js';
 import { CDN_URL } from './api.js';
 
 export const MAIN_ENGINE = 'main';
@@ -103,11 +102,6 @@ async function loadFromStorage(name) {
         });
       })
       .catch((e) => {
-        // Suppress the private browsing mode in Firefox
-        if (!e.message?.includes('database that did not allow mutations')) {
-          captureException(e);
-        }
-
         if (__PLATFORM__ === 'firefox') {
           const key = `engines:${name}`;
           return chrome.storage.local.get([key]).then((data) => data[key]);


### PR DESCRIPTION
The reason behind capturing was to discover other issues in Firefox related to saving engines to IndexedDB. After a while, we did not find anything useful in the error messages coming from that place. 

We can keep the `/utils/errors.js` for future use, as it won't be included (and sentry library as well) in distribution if it is not being used.