### PR TITLE
fix(settings): clear action on trackers view & clean up `blockByDefault` field

### DIFF
--- a/src/pages/settings/components/trackers-list.js
+++ b/src/pages/settings/components/trackers-list.js
@@ -9,7 +9,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import { html, dispatch, msg } from 'hybrids';
+import { html, dispatch } from 'hybrids';
 import * as labels from '/ui/labels.js';
 
 export default {
@@ -19,9 +19,8 @@ export default {
   adjusted: 0,
   blocked: 0,
   trusted: 0,
-  blockedByDefault: false,
   open: { value: false, reflect: true },
-  render: ({ name, size, adjusted, open, blockedByDefault }) => html`
+  render: ({ name, size, adjusted, open }) => html`
     <template layout="column gap:2 padding:1.5">
       <header layout="row items:center gap:1.5" layout@768px="gap:2">
         <ui-action>
@@ -58,11 +57,7 @@ export default {
         </ui-action>
 
         <ui-tooltip>
-          <span slot="content">
-            ${blockedByDefault
-              ? msg`Block all (recommended)`
-              : msg`Trust all (recommended)`}
-          </span>
+          <span slot="content">Block all</span>
           <ui-action-button layout="width:4.5">
             <button onclick="${(host) => dispatch(host, 'clear')}">
               <ui-icon name="refresh"></ui-icon>

--- a/src/pages/settings/views/trackers.js
+++ b/src/pages/settings/views/trackers.js
@@ -63,7 +63,7 @@ function clearCategory(id) {
     const category = store.get(TrackerCategory, id);
 
     const exceptions = category.trackers
-      .filter((t) => options.exceptions[t.id]?.global)
+      .filter((t) => options.exceptions[t.id])
       .reduce((acc, t) => {
         acc[t.id] = null;
         return acc;
@@ -161,89 +161,81 @@ export default {
             </div>
             <div layout="column gap:0.5">
               ${store.ready(categories) &&
-              categories.map(
-                ({
-                  id,
-                  key,
-                  description,
-                  trackers,
-                  adjusted,
-                  blockedByDefault,
-                }) =>
-                  html`
-                    <settings-trackers-list
-                      name="${key}"
-                      description="${description}"
-                      open="${isActive(category, key)}"
-                      size="${trackers.length}"
-                      adjusted="${adjusted}"
-                      blockedByDefault="${blockedByDefault}"
-                      ontoggle="${html.set(
-                        'category',
-                        isActive(category, key) ? '' : key,
-                      )}"
-                      onclear="${clearCategory(id)}"
-                    >
-                      ${isActive(category, key) &&
-                      html`
-                        <ui-line></ui-line>
-                        <div
-                          layout="column gap"
-                          layout@768px="padding:left:102px"
-                        >
-                          ${trackers.map(
-                            (tracker, index) =>
-                              index <= (limits[key] || PATTERNS_LIMIT) &&
-                              html`
-                                <div layout="row items:center gap">
-                                  <ui-action>
-                                    <a
-                                      href="${router.url(TrackerDetails, {
-                                        tracker: tracker.id,
-                                      })}"
-                                      layout="column grow basis:0"
-                                      layout@768px="row gap:2"
-                                    >
-                                      <ui-text type="label-m">
-                                        ${tracker.name}
-                                      </ui-text>
-                                      ${tracker.organization &&
-                                      html`
-                                        <ui-text color="secondary">
-                                          ${tracker.organization.name}
-                                        </ui-text>
-                                      `}
-                                    </a>
-                                  </ui-action>
-                                  <div layout="row items:center gap">
-                                    ${options.exceptions[tracker.id] &&
+              categories.map(({ id, key, description, trackers }) =>
+                html`
+                  <settings-trackers-list
+                    name="${key}"
+                    description="${description}"
+                    open="${isActive(category, key)}"
+                    size="${trackers.length}"
+                    adjusted="${trackers.filter((t) => options.exceptions[t.id])
+                      .length}"
+                    ontoggle="${html.set(
+                      'category',
+                      isActive(category, key) ? '' : key,
+                    )}"
+                    onclear="${clearCategory(id)}"
+                  >
+                    ${isActive(category, key) &&
+                    html`
+                      <ui-line></ui-line>
+                      <div
+                        layout="column gap"
+                        layout@768px="padding:left:102px"
+                      >
+                        ${trackers.map(
+                          (tracker, index) =>
+                            index <= (limits[key] || PATTERNS_LIMIT) &&
+                            html`
+                              <div layout="row items:center gap">
+                                <ui-action>
+                                  <a
+                                    href="${router.url(TrackerDetails, {
+                                      tracker: tracker.id,
+                                    })}"
+                                    layout="column grow basis:0"
+                                    layout@768px="row gap:2"
+                                  >
+                                    <ui-text type="label-m">
+                                      ${tracker.name}
+                                    </ui-text>
+                                    ${tracker.organization &&
                                     html`
-                                      <ui-text type="label-s" color="secondary">
-                                        <!-- Singular form - tracker has been adjusted | tracker -->adjusted
+                                      <ui-text color="secondary">
+                                        ${tracker.organization.name}
                                       </ui-text>
                                     `}
-                                    <settings-exception-toggle
-                                      value="${isTrusted(options, tracker)}"
-                                      responsive
-                                      onchange="${toggleException(tracker)}"
-                                      layout="shrink:0"
-                                    ></settings-exception-toggle>
-                                  </div>
+                                  </a>
+                                </ui-action>
+                                <div layout="row items:center gap">
+                                  ${options.exceptions[tracker.id] &&
+                                  html`
+                                    <ui-text type="label-s" color="secondary">
+                                      <!-- Singular form - tracker has been adjusted | tracker -->adjusted
+                                    </ui-text>
+                                  `}
+                                  <settings-exception-toggle
+                                    value="${isTrusted(options, tracker)}"
+                                    responsive
+                                    onchange="${toggleException(tracker)}"
+                                    layout="shrink:0"
+                                  ></settings-exception-toggle>
                                 </div>
-                              `.key(tracker.id),
-                          )}
+                              </div>
+                            `.key(tracker.id),
+                        )}
+                      </div>
+                      ${(limits[key] || PATTERNS_LIMIT) < trackers.length &&
+                      html`
+                        <div layout="row center margin:bottom:2">
+                          <ui-button onclick="${loadMore(key)}">
+                            <button>Load more</button>
+                          </ui-button>
                         </div>
-                        ${(limits[key] || PATTERNS_LIMIT) < trackers.length &&
-                        html`
-                          <div layout="row center margin:bottom:2">
-                            <ui-button onclick="${loadMore(key)}">
-                              <button>Load more</button>
-                            </ui-button>
-                          </div>
-                        `}
                       `}
-                    </settings-trackers-list>
-                  `.key(key),
+                    `}
+                  </settings-trackers-list>
+                `.key(key),
               )}
             </div>
           </section>

--- a/src/store/tracker-category.js
+++ b/src/store/tracker-category.js
@@ -24,9 +24,6 @@ export default {
   name: '',
   description: '',
   trackers: [Tracker],
-  blockedByDefault: false,
-  adjusted: ({ trackers }) =>
-    trackers.reduce((count, tracker) => count + Number(tracker.adjusted), 0),
   [store.connect]: {
     async list({ query, filter }) {
       const result = (await categories).map((category) => ({
@@ -34,39 +31,35 @@ export default {
         ...category,
       }));
 
-      if (query || filter) {
-        const options = await store.resolve(Options);
-        query = query.trim().toLowerCase();
+      const options = await store.resolve(Options);
+      query = query.trim().toLowerCase();
 
-        return result
-          .map((category) => ({
-            ...category,
-            trackers: category.trackers.filter((t) => {
-              const match =
-                !query ||
-                t.name.toLowerCase().includes(query) ||
-                t.organization?.name.toLowerCase().includes(query);
+      return result
+        .map((category) => ({
+          ...category,
+          trackers: category.trackers.filter((t) => {
+            const match =
+              !query ||
+              t.name.toLowerCase().includes(query) ||
+              t.organization?.name.toLowerCase().includes(query);
 
-              if (!match) return false;
+            if (!match) return false;
 
-              const exception = options.exceptions[t.id];
+            const exception = options.exceptions[t.id];
 
-              switch (filter) {
-                case 'blocked':
-                  return !exception?.global;
-                case 'trusted':
-                  return exception?.global;
-                case 'adjusted':
-                  return exception;
-                default:
-                  return true;
-              }
-            }),
-          }))
-          .filter((category) => category.trackers.length);
-      }
-
-      return result;
+            switch (filter) {
+              case 'blocked':
+                return !exception?.global;
+              case 'trusted':
+                return exception?.global;
+              case 'adjusted':
+                return exception;
+              default:
+                return true;
+            }
+          }),
+        }))
+        .filter((category) => category.trackers.length);
     },
   },
 };

--- a/src/utils/trackerdb.js
+++ b/src/utils/trackerdb.js
@@ -23,7 +23,6 @@ export function getUnidentifiedTracker(hostname) {
     name: hostname.length > 24 ? '...' + hostname.slice(-24) : hostname,
     category: 'unidentified',
     exception: hostname,
-    blockedByDefault: true,
   };
 }
 
@@ -86,7 +85,6 @@ function getTrackers() {
               privacyPolicyUrl: organization.privacy_policy_url,
             }
           : undefined,
-        blockedByDefault: true,
       });
     }
   }
@@ -128,7 +126,6 @@ export async function getCategories() {
       {
         key,
         description,
-        blockedByDefault: true,
         trackers: [],
       },
     ]),


### PR DESCRIPTION
Fixes minor leftovers of the #2343

* Trackers view `adjusted` value was missed
* Clear action did not removed domain exceptions
* Unused `blockByDefault` was here and there