### PR TITLE
fix(logger): clean up unused CSS

### DIFF
--- a/src/pages/logger/views/main.js
+++ b/src/pages/logger/views/main.js
@@ -141,9 +141,5 @@ export default {
         </div>
       </main>
     </template>
-  `.css`
-    .blocked {
-      color: var(--color-danger-secondary);
-    }
   `,
 };


### PR DESCRIPTION
Fixes https://github.com/ghostery/journal/issues/522

Cleans up unused CSS code, which caused the view to render in Shadow DOM. As a result, the fix for the `<option>` element background in dark mode wasn't applied.