### PR TITLE
fix(manifest): update icon paths to remove leading slashes

### DIFF
--- a/src/manifest.chromium.json
+++ b/src/manifest.chromium.json
@@ -20,13 +20,13 @@
   ],
   "host_permissions": ["http://*/*", "https://*/*", "ws://*/*", "wss://*/*"],
   "icons": {
-    "64": "/icons/icon-64.png",
-    "128": "/icons/icon-128.png"
+    "64": "icons/icon-64.png",
+    "128": "icons/icon-128.png"
   },
   "action": {
     "default_icon": {
-      "64": "/icons/icon-64.png",
-      "128": "/icons/icon-128.png"
+      "64": "icons/icon-64.png",
+      "128": "icons/icon-128.png"
     },
     "default_title": "Ghostery",
     "default_popup": "pages/panel/index.html"

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -22,15 +22,15 @@
     "wss://*/*"
   ],
   "icons": {
-    "32": "/icons/icon.svg",
-    "64": "/icons/icon.svg",
-    "128": "/icons/icon.svg"
+    "32": "icons/icon.svg",
+    "64": "icons/icon.svg",
+    "128": "icons/icon.svg"
   },
   "browser_action": {
     "default_icon": {
-      "32": "/icons/icon.svg",
-      "64": "/icons/icon.svg",
-      "128": "/icons/icon.svg"
+      "32": "icons/icon.svg",
+      "64": "icons/icon.svg",
+      "128": "icons/icon.svg"
     },
     "default_area": "navbar",
     "default_title": "Ghostery",

--- a/src/manifest.safari.json
+++ b/src/manifest.safari.json
@@ -18,15 +18,15 @@
   ],
   "host_permissions": ["http://*/*", "https://*/*", "ws://*/*", "wss://*/*"],
   "icons": {
-    "32": "/icons/icon.svg",
-    "64": "/icons/icon.svg",
-    "128": "/icons/icon.svg"
+    "32": "icons/icon.svg",
+    "64": "icons/icon.svg",
+    "128": "icons/icon.svg"
   },
   "action": {
     "default_icon": {
-      "32": "/icons/icon.svg",
-      "64": "/icons/icon.svg",
-      "128": "/icons/icon.svg"
+      "32": "icons/icon.svg",
+      "64": "icons/icon.svg",
+      "128": "icons/icon.svg"
     },
     "default_title": "Ghostery",
     "default_popup": "pages/panel/index.html"


### PR DESCRIPTION
The Chrome Web Store has a bug that rejects uploading an extension's package with icons set by absolute path. As everything else is set with a relative path, we should unify all the paths.

<img width="591" alt="Zrzut ekranu 2025-04-24 o 14 50 14" src="https://github.com/user-attachments/assets/7c1fa161-5860-42c5-9159-d99f78bb0b71" />
