### PR TITLE
feat: scripting on response started

### DIFF
--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -112,6 +112,17 @@ if (__PLATFORM__ === 'chromium') {
 // on the fly.
 const executedDocumentIds = new Set();
 
+/**
+ * Computes a unique id corresponding to specific tab and frame.
+ * `documentId` may not available from `webRequest` event callbacks as the
+ * document may not present at the time of event occurrence.
+ * @param {number} tabId
+ * @param {number} frameId
+ */
+function computeDocumentId(tabId, frameId) {
+  return (tabId * 38) ^ (frameId * 483);
+}
+
 function getEnabledEngines(config) {
   if (config.terms) {
     const list = ENGINES.filter(({ key }) => config[key]).map(
@@ -356,15 +367,13 @@ async function injectCosmetics(details, config) {
     return;
   }
 
-  const { frameId, url, tabId, documentId } = details;
-
-  console.log(debugMarker, documentId, executedDocumentIds.has(documentId));
+  const { frameId, url, tabId } = details;
 
   if (
     __PLATFORM__ === 'chromium' &&
-    ENABLE_CHROMIUM_SCRIPTING_ONRESPONSESTARTED &&
-    documentId !== undefined
+    ENABLE_CHROMIUM_SCRIPTING_ONRESPONSESTARTED
   ) {
+    const documentId = computeDocumentId(tabId, frameId);
     if (executedDocumentIds.has(documentId)) {
       executedDocumentIds.delete(documentId);
       return;

--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -112,6 +112,10 @@ if (__PLATFORM__ === 'chromium') {
 // on the fly.
 const executedDocumentIds = new Set();
 
+// http://isthe.com/chongo/tech/comp/fnv/
+const FNV_1A_PRIME = 16777619;
+const FNV_1A_OFFSET_BASIS = 2166136261;
+
 /**
  * Computes a unique id corresponding to specific tab and frame.
  * `documentId` may not available from `webRequest` event callbacks as the
@@ -120,7 +124,26 @@ const executedDocumentIds = new Set();
  * @param {number} frameId
  */
 function computeDocumentId(tabId, frameId) {
-  return (tabId * 38) ^ (frameId * 483);
+  let hash = FNV_1A_OFFSET_BASIS;
+  let iter = 0;
+  while (tabId > 0) {
+    hash = hash ^ tabId % 10;
+    hash = hash * FNV_1A_PRIME;
+    tabId = (tabId / 10) >>> 0;
+    iter++;
+  }
+  hash = hash ^ iter;
+  hash = hash * FNV_1A_PRIME;
+  iter = 0;
+  while (frameId > 0) {
+    hash = hash ^ frameId % 10;
+    hash = hash * FNV_1A_PRIME;
+    frameId = (frameId / 10) >>> 0;
+    iter++;
+  }
+  hash = hash ^ iter;
+  hash = hash * FNV_1A_PRIME;
+  return hash;
 }
 
 function getEnabledEngines(config) {

--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -110,11 +110,10 @@ if (__PLATFORM__ === 'chromium') {
 // not available on Firefox yet. If we need to listen from multiple events on
 // Firefox, we need to calculate a hash of tab and frame to generate `documentId`
 // on the fly.
+/**
+ * @type {Set<string>}
+ */
 const executedDocumentIds = new Set();
-
-// http://isthe.com/chongo/tech/comp/fnv/
-const FNV_1A_PRIME = 16777619;
-const FNV_1A_OFFSET_BASIS = 2166136261;
 
 /**
  * Computes a unique id corresponding to specific tab and frame.
@@ -124,30 +123,7 @@ const FNV_1A_OFFSET_BASIS = 2166136261;
  * @param {number} frameId
  */
 function computeDocumentId(tabId, frameId) {
-  let hash = FNV_1A_OFFSET_BASIS;
-  let iter = 0;
-  while (tabId > 0) {
-    hash = hash ^ tabId % 10;
-    hash = hash * FNV_1A_PRIME;
-    tabId = (tabId / 10) >>> 0;
-    iter++;
-  }
-  hash = hash ^ iter;
-  hash = hash * FNV_1A_PRIME;
-  // The iteration is responsible for numeric sequence recognition.
-  // Setting any integer value higher than 16 is enough to distinguish,
-  // `tabId` and `frameId` in hash. Because the decimal representation of
-  // `Number.MAX_SAFE_INTEGER` is the length of 16.
-  iter = 128;
-  while (frameId > 0) {
-    hash = hash ^ frameId % 10;
-    hash = hash * FNV_1A_PRIME;
-    frameId = (frameId / 10) >>> 0;
-    iter++;
-  }
-  hash = hash ^ iter;
-  hash = hash * FNV_1A_PRIME;
-  return hash;
+  return `${tabId},${frameId}`;
 }
 
 function getEnabledEngines(config) {

--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -134,7 +134,11 @@ function computeDocumentId(tabId, frameId) {
   }
   hash = hash ^ iter;
   hash = hash * FNV_1A_PRIME;
-  iter = 0;
+  // The iteration is responsible for numeric sequence recognition.
+  // Setting any integer value higher than 16 is enough to distinguish,
+  // `tabId` and `frameId` in hash. Because the decimal representation of
+  // `Number.MAX_SAFE_INTEGER` is the length of 16.
+  iter = 128;
   while (frameId > 0) {
     hash = hash ^ frameId % 10;
     hash = hash * FNV_1A_PRIME;

--- a/src/pages/settings/components/devtools.js
+++ b/src/pages/settings/components/devtools.js
@@ -18,6 +18,7 @@ import Config, {
   ACTION_PAUSE_ASSISTANT,
   FLAG_PAUSE_ASSISTANT,
   FLAG_FIREFOX_CONTENT_SCRIPT_SCRIPTLETS,
+  FLAG_CHROMIUM_SCRIPTING_ONRESPONSESTARTED,
 } from '/store/config.js';
 
 const VERSION = chrome.runtime.getManifest().version;
@@ -78,7 +79,11 @@ async function testConfigDomain(host) {
 async function testConfigFlag(host) {
   const flags = window.prompt(
     'Enter flags to test:',
-    [FLAG_PAUSE_ASSISTANT, FLAG_FIREFOX_CONTENT_SCRIPT_SCRIPTLETS].join(', '),
+    [
+      FLAG_PAUSE_ASSISTANT,
+      FLAG_FIREFOX_CONTENT_SCRIPT_SCRIPTLETS,
+      FLAG_CHROMIUM_SCRIPTING_ONRESPONSESTARTED,
+    ].join(', '),
   );
   if (!flags) return;
 

--- a/src/store/config.js
+++ b/src/store/config.js
@@ -19,6 +19,8 @@ export const ACTION_PAUSE_ASSISTANT = 'pause-assistant';
 export const FLAG_PAUSE_ASSISTANT = 'pause-assistant';
 export const FLAG_FIREFOX_CONTENT_SCRIPT_SCRIPTLETS =
   'firefox-content-script-scriptlets';
+export const FLAG_CHROMIUM_SCRIPTING_ONRESPONSESTARTED =
+  'chromium-scripting-onresponsestarted';
 
 const Config = {
   enabled: true,


### PR DESCRIPTION
This improves scripting on Chromium platforms by listening from both `webNavigation.onCommitted` and `webRequest.onResponseStarted`. In many times, especially, when the page is loaded from cache, `webRequest.onResponseStarted` fired in prior to `webNavigation.onCommitted`.

To be sure this doesn't perfectly solve late injection issue when you navigate from URL. When pasting URL to Omnibox, none of Tabs, Web Navigation, Web Request API properly fired right after the document creation.

With this change, users are expected problems to be solved after a few times of refresh if the cause was late injection. From testing myself, even one time of refresh was enough in most cases.

Besides the injection timing adjustment, we need to take care of hashing function. It's defined as `computeDocumentId` function. The hash IDs are expected to live extremely short as it's removed once both events are fired. However, to ensure less collinsion better, use of commonly known hash functions like crc32 is better. Since we're mixing two integers, none of 4 basic operations help. Alternatively, the below function can help us to transform number into the array of flatten decimal digits with appendix of the length of its string representation.

```
export function createHashableStream(a: number, b: number) {
  const arr: number[] = [];
  let c: number = 0;
  while (a > 0) {
    a = (a / 10) >>> 0;
    arr.push(a % 10);
  }
  arr.push(c);
  c = 0;
  while (b > 0) {
    b = (b / 10) >>> 0;
    arr.push(b % 10);
  }
  arr.push(c);
  return arr;
}
```