### PR TITLE
fix(settings): backup buttons on desktop layout for longer translations

### DIFF
--- a/src/pages/settings/views/my-ghostery.js
+++ b/src/pages/settings/views/my-ghostery.js
@@ -198,7 +198,7 @@ export default {
                     </ui-text>
                   `}
                 </div>
-                <div layout="row:wrap gap">
+                <div layout="row:wrap gap" layout@768px="content:end">
                   <ui-button size="s" onclick="${backup.exportToFile}">
                     <button>
                       <ui-icon name="arrow-square-up"></ui-icon> Export to file


### PR DESCRIPTION
<img width="831" alt="Zrzut ekranu 2025-05-5 o 10 47 19" src="https://github.com/user-attachments/assets/53325665-f50e-4fc4-a88f-5486c74c2ec0" />
<img width="792" alt="Zrzut ekranu 2025-05-5 o 10 47 27" src="https://github.com/user-attachments/assets/41f7f4c7-bcb8-4c51-8693-f0309adbd3d7" />
