### PR TITLE
fix(stats): add missing leading slash to icon paths

### DIFF
--- a/src/background/stats.js
+++ b/src/background/stats.js
@@ -32,6 +32,12 @@ export const tabStats = new AutoSyncingMap({ storageKey: 'tabStats:v1' });
 const chromeAction = chrome.action || chrome.browserAction;
 
 const { icons } = chrome.runtime.getManifest();
+
+// We need to add a leading slash to the icon paths§
+Object.keys(icons).forEach((key) => {
+  icons[key] = `/${icons[key]}`;
+});
+
 const inactiveIcons = Object.keys(icons).reduce((acc, key) => {
   acc[key] = icons[key].replace('.', '-inactive.');
   return acc;


### PR DESCRIPTION
The #2390 fixed issue in the manifest, but it also introduced a bug in dynamic update of the icons (now I know why we used the absolute path).