### PR TITLE
fix(panel): pause state for global domain

### DIFF
--- a/src/pages/panel/views/main.js
+++ b/src/pages/panel/views/main.js
@@ -60,8 +60,7 @@ async function togglePause(host, event) {
 
   if (paused) {
     const pausedHostname = Object.keys(options.paused)
-      .sort()
-      .reverse()
+      .sort((a, b) => b.localeCompare(a))
       .find((domain) => stats.hostname.endsWith(domain));
 
     store.set(options, {

--- a/src/pages/panel/views/main.js
+++ b/src/pages/panel/views/main.js
@@ -13,7 +13,7 @@ import { html, store, router, msg } from 'hybrids';
 
 import { getCurrentTab, openTabWithUrl } from '/utils/tabs.js';
 
-import Options, { GLOBAL_PAUSE_ID } from '/store/options.js';
+import Options, { getPausedDetails, GLOBAL_PAUSE_ID } from '/store/options.js';
 import TabStats from '/store/tab-stats.js';
 import * as exceptions from '/utils/exceptions.js';
 
@@ -53,17 +53,29 @@ function reloadTab(host, event) {
 }
 
 async function togglePause(host, event) {
-  const { paused, pauseType } = event.target;
-
   host.alert = '';
 
-  await store.set(host.options, {
-    paused: {
-      [host.stats.hostname]: !paused
-        ? { revokeAt: pauseType && Date.now() + 60 * 60 * 1000 * pauseType }
-        : null,
-    },
-  });
+  const { paused, pauseType } = event.target;
+  const { options, stats } = host;
+
+  if (paused) {
+    const pausedHostname = Object.keys(options.paused)
+      .sort()
+      .reverse()
+      .find((domain) => stats.hostname.endsWith(domain));
+
+    store.set(options, {
+      paused: { [pausedHostname]: null },
+    });
+  } else {
+    await store.set(options, {
+      paused: {
+        [stats.hostname]: {
+          revokeAt: pauseType && Date.now() + 60 * 60 * 1000 * pauseType,
+        },
+      },
+    });
+  }
 
   host.alert = paused
     ? msg`Ghostery has been resumed on this site.`
@@ -110,7 +122,7 @@ export default {
   notification: store(Notification),
   alert: '',
   paused: ({ options, stats }) =>
-    store.ready(options, stats) && options.paused[stats.hostname],
+    store.ready(options, stats) && !!getPausedDetails(options, stats.hostname),
   globalPause: ({ options }) =>
     store.ready(options) && options.paused[GLOBAL_PAUSE_ID],
   render: ({


### PR DESCRIPTION
Fixes the panel pause state for the case, when a user adds global domain by hand. The expected behavior is to show paused state for all subdomains.

## Testing

* Ensure that pausing by clicking on pause button works as before - adds proper full domain with subdomain and shows correct state
* Add global domain in settings by hand and check how the pause state is displayed in panel and "redo" action works (for example `onet.pl`, and go to `www.onet.pl`, or some subdomain like `kobieta.onet.pl`)