### PR TITLE
fix(build): add versioning for data dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
     "plotly.js-basic-dist": "^3.0.1",
     "tldts-experimental": "^7.0.7"
   },
+  "dataDependencies": {
+    "wtm-stats": "ded8cb4a9bad0fa1fb0b60996382ba6527127c33"
+  },
   "engineStrict": true,
   "engines": {
     "npm": ">=9.6.7"

--- a/scripts/data-dependencies.js
+++ b/scripts/data-dependencies.js
@@ -1,0 +1,31 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+
+const packageJson = JSON.parse(readFileSync('package.json', 'utf-8'));
+
+console.log('Updating data dependencies...');
+
+// wtm-stats
+packageJson.dataDependencies['wtm-stats'] = await fetch(
+  'https://api.github.com/repos/whotracksme/whotracks.me/commits?per_page=1',
+  { headers: { 'Accept': 'application/vnd.github.v3+json' } },
+)
+  .then((res) => res.json())
+  .then((data) => data[0].sha);
+
+// Save the updated package.json
+writeFileSync(
+  'package.json',
+  JSON.stringify(packageJson, null, 2) + '\n',
+  'utf-8',
+);

--- a/scripts/download-wtm-stats.js
+++ b/scripts/download-wtm-stats.js
@@ -9,16 +9,21 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import { writeFileSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { resolve } from 'node:path';
 
-const TARGET_PATH = resolve('src', 'rule_resources', 'wtm-stats.js');
-const DATA_URL =
-  'https://raw.githubusercontent.com/whotracksme/whotracks.me/ded8cb4a9bad0fa1fb0b60996382ba6527127c33/whotracksme/data/assets/trackers-preview.json';
+const { dataDependencies } = JSON.parse(
+  readFileSync(resolve('package.json'), 'utf-8'),
+);
 
+const TARGET_PATH = resolve('src', 'rule_resources', 'wtm-stats.js');
 if (existsSync(TARGET_PATH)) process.exit(0);
 
-const data = await fetch(DATA_URL).then((res) => {
+console.log(`Downloading wtm-stats (${dataDependencies['wtm-stats']})...`);
+
+const data = await fetch(
+  `https://raw.githubusercontent.com/whotracksme/whotracks.me/${dataDependencies['wtm-stats']}/whotracksme/data/assets/trackers-preview.json`,
+).then((res) => {
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   return res.text();
 });
@@ -26,7 +31,7 @@ const data = await fetch(DATA_URL).then((res) => {
 writeFileSync(
   TARGET_PATH,
   `/**
- * This file is an automatic conversion of a JSON to JavaScipt.
+ * This file is an automatic conversion of a JSON to JavaScript.
  * Source: https://github.com/whotracksme/whotracks.me/blob/master/whotracksme/data/assets/trackers-preview.json
  * Conversion script: scripts/download-wtm-stats.js
  *
@@ -44,5 +49,3 @@ writeFileSync(
 export default ${data};
 `,
 );
-
-console.log('Trackers preview data downloaded');

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,6 +16,9 @@ if [ "$1" != "build" ]; then
   npm version "${1:-patch}" --no-commit-hooks --no-git-tag-version
 fi
 
+# Update data dependencies
+node ./scripts/data-dependencies.js
+
 # Update xcode version
 node ./scripts/xcode-version.js
 


### PR DESCRIPTION
Fixes #2364.

* Adds `dataDependencies` custom field to `package.json` (it is a safe and recommended way) to keep versions of the data assets
* Updates the `release.sh` script to update data dependencies on each release 
* The anti-tracking whitelist has the potential to be added as well, but currently it is not being used at all (it is not a part of the build), so I skipped it
* The adblocker engines use a unified URL to the CDN, which does not provide versioning, so currently, there is no way to fix the version of the downloaded engines. However, from the perspective of the issue's goal, the AMO reviews did not complain about `.dat` files, only `.js` files that are imported and part of the executed code.
