### PR TITLE
fix(panel): paused property should return an object

### DIFF
--- a/src/pages/panel/views/main.js
+++ b/src/pages/panel/views/main.js
@@ -123,7 +123,7 @@ export default {
   managedConfig: store(ManagedConfig),
   alert: '',
   paused: ({ options, stats }) =>
-    store.ready(options, stats) && !!getPausedDetails(options, stats.hostname),
+    store.ready(options, stats) && getPausedDetails(options, stats.hostname),
   globalPause: ({ options }) =>
     store.ready(options) && options.paused[GLOBAL_PAUSE_ID],
   render: ({


### PR DESCRIPTION
Fixes a minor bug introduced with #2413. The template uses `paused?.revokeAt` condition to display a message for reporting a broken page.