### PR TITLE
fix(build): remove stub resources from non-firefox builds

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -279,7 +279,7 @@ mkdirSync(resolve(options.outDir, 'rule_resources/redirects'), {
 for (const file of readdirSync(
   resolve(options.srcDir, 'rule_resources', 'redirects'),
 )) {
-  if (__PLATFORM__ !== 'firefox' && file.includes('MIME_TYPE_STUB')) {
+  if (argv.target !== 'firefox' && file.includes('MIME_TYPE_STUB')) {
     continue;
   }
   cpSync(


### PR DESCRIPTION
This responds to Opera's automatic rejection on `.flv`.

refs https://github.com/ghostery/ghostery-extension/pull/2399