### PR TITLE
fix(custom-filters): chrome textarea focus bug

### DIFF
--- a/src/pages/settings/views/custom-filters.js
+++ b/src/pages/settings/views/custom-filters.js
@@ -93,6 +93,7 @@ export default {
               </ui-toggle>
             </settings-card>
             ${options.customFilters.enabled &&
+            store.ready(input) &&
             html`
               <div layout="column gap:2">
                 <label layout="row gap items:center ::user-select:none">
@@ -117,8 +118,7 @@ export default {
                     autocapitalize="off"
                     spellcheck="false"
                     oninput="${html.set(input, 'text')}"
-                    disabled="${!store.ready(input)}"
-                    defaultValue="${store.ready(input) ? input.text : ''}"
+                    defaultValue="${input.text}"
                     data-qa="input:custom-filters"
                   ></textarea>
                 </ui-input>


### PR DESCRIPTION
Fixes the Chrome bug, which makes the textarea readonly (no carret and unable to write). 

When `<textarea>` element is `disabled` by default and then dynamically enabled (by `el.disabled = false` action) the textrea behaves as it would be in readonly state.

Currently, the affected versions are everything up from Beta channel (v138+).