### PR TITLE
fix(wdio): update browser to 'chromium'

### DIFF
--- a/tests/e2e/wdio.conf.js
+++ b/tests/e2e/wdio.conf.js
@@ -11,10 +11,10 @@
 
 /*
  * Usage:
- *   wdio tests/wdio.conf.js [--target=firefox,chrome] [--debug] [--clean]
+ *   wdio tests/wdio.conf.js [--target=firefox,chromium] [--debug] [--clean]
  *
  * Options:
- *   --target: comma separated list of browsers to run the tests on (default: firefox,chrome)
+ *   --target: comma separated list of browsers to run the tests on (default: firefox,chromium)
  *   --debug: run the tests in debug mode (default: false)
  *   --clean: clean the build artifacts before running the tests (default: false)
  */
@@ -50,7 +50,7 @@ export const argv = process.argv.slice(2).reduce(
     }
     return acc;
   },
-  { target: ['firefox', 'chrome'], debug: false, clean: false },
+  { target: ['firefox', 'chromium'], debug: false, clean: false },
 );
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
@@ -118,7 +118,7 @@ export const config = {
       },
     },
     {
-      browserName: 'chrome',
+      browserName: 'chromium',
       'goog:chromeOptions': {
         args: (argv.debug ? [] : ['headless', 'disable-gpu']).concat([
           `--load-extension=${CHROME_PATH}`,
@@ -139,7 +139,7 @@ export const config = {
             buildForFirefox();
             break;
           }
-          case 'chrome': {
+          case 'chromium': {
             buildForChrome();
             break;
           }
@@ -169,7 +169,7 @@ export const config = {
       }
 
       // Disable cache for Chrome to avoid caching issues
-      if (capabilities.browserName === 'chrome') {
+      if (capabilities.browserName === 'chromium') {
         await browser.sendCommand('Network.setCacheDisabled', {
           cacheDisabled: true,
         });

--- a/tests/e2e/wdio.update.conf.js
+++ b/tests/e2e/wdio.update.conf.js
@@ -60,7 +60,7 @@ export const config = {
 
       for (const capability of capabilities) {
         const target =
-          capability.browserName === 'chrome' ? 'chromium' : 'firefox';
+          capability.browserName === 'chromium' ? 'chromium' : 'firefox';
 
         const fileName = `ghostery-${target}-${version}.zip`;
         const url = `https://github.com/ghostery/ghostery-extension/releases/download/v${version}/`;
@@ -124,7 +124,7 @@ export const config = {
 
       // Reload extension with the source
       switch (capabilities.browserName) {
-        case 'chrome': {
+        case 'chromium': {
           await browser.url('chrome://extensions');
           await $('>>>#devMode').click();
 


### PR DESCRIPTION
Starting from v137, the offical Chrome builds deprecated `--load-extension` flag (https://support.google.com/chrome/a/answer/7679408?sjid=9819695566660205428-EU#chromeBrsrE137)

There is a new way to load extension by `Extensions.loadUnpacked` CDP protocol, but it requires some flags, which currently don't work with WDIO.

> Developers can still use the --load-extension switch in non-branded builds such as Chromium and Chrome For Testing.

The workaround is to move to Chromium builds.