### PR TITLE
fix(wdio): move to Chrome for Testing

### DIFF
--- a/tests/e2e/wdio.conf.js
+++ b/tests/e2e/wdio.conf.js
@@ -119,10 +119,12 @@ export const config = {
     },
     {
       browserName: 'chrome',
+      browserVersion: 'stable',
       'goog:chromeOptions': {
         args: (argv.debug ? [] : ['headless', 'disable-gpu']).concat([
           `--load-extension=${CHROME_PATH}`,
           '--accept-lang=en-GB',
+          '--no-sandbox',
         ]),
       },
     },


### PR DESCRIPTION
Starting from v137, the offical Chrome builds deprecated `--load-extension` flag (https://support.google.com/chrome/a/answer/7679408?sjid=9819695566660205428-EU#chromeBrsrE137)

There is a new way to load extensions by `Extensions.loadUnpacked` CDP protocol, but it requires some flags, which currently don't work with WDIO (https://chromedevtools.github.io/devtools-protocol/tot/Extensions/#method-loadUnpacked)

> Developers can still use the --load-extension switch in non-branded builds such as Chromium and Chrome For Testing.

The workaround is to move to [Chrome for Testing](https://github.com/GoogleChromeLabs/chrome-for-testing). 