### PR TITLE
fix(element-picker): website settings textarea wrapping in Safari

### DIFF
--- a/src/pages/settings/views/website-details.js
+++ b/src/pages/settings/views/website-details.js
@@ -235,7 +235,7 @@ export default {
               spellcheck="false"
               autocorrect="off"
               oninput="${enableElementPickerSelectors}"
-              style="white-space:nowrap"
+              style="white-space:pre"
             ></textarea>
           </ui-input>
           <div layout="row gap:2">


### PR DESCRIPTION
Safari omitts new lines when `white-space` is set to `nowrap`. The same effect (one block per line) has value `pre`.