### PR TITLE
feat: add safe mode

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -18,6 +18,7 @@ import './custom-filters.js';
 import './dnr.js';
 import './exceptions.js';
 import './paused.js';
+import './safe-mode.js';
 import './session.js';
 import './stats.js';
 import './notifications.js';

--- a/src/background/paused.js
+++ b/src/background/paused.js
@@ -17,9 +17,9 @@ import ManagedConfig from '/store/managed-config';
 
 // Pause / unpause hostnames
 const PAUSED_ALARM_PREFIX = 'options:revoke';
-const PAUSED_RULE_PRIORITY = 10000000;
+export const PAUSED_RULE_PRIORITY = 10000000;
 
-const ALL_RESOURCE_TYPES = [
+export const ALL_RESOURCE_TYPES = [
   'main_frame',
   'sub_frame',
   'stylesheet',

--- a/src/background/safe-mode.js
+++ b/src/background/safe-mode.js
@@ -1,0 +1,76 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import * as OptionsObserver from '/utils/options-observer.js';
+import { SAFE_MODE_BLOCKED_DOMAINS } from '/utils/safe-mode.js';
+
+import { PAUSED_RULE_PRIORITY, ALL_RESOURCE_TYPES } from './paused.js';
+
+if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') {
+  OptionsObserver.addListener(async function safeMode(options) {
+    const removeRuleIds = (await chrome.declarativeNetRequest.getDynamicRules())
+      .filter(({ id }) => id >= 10 && id < 13)
+      .map(({ id }) => id);
+
+    if (options.safeMode.enabled) {
+      const excludedDomains = [
+        ...SAFE_MODE_BLOCKED_DOMAINS,
+        ...options.safeMode.domains,
+      ];
+
+      await chrome.declarativeNetRequest.updateDynamicRules({
+        addRules:
+          __PLATFORM__ === 'safari'
+            ? [
+                {
+                  id: 10,
+                  priority: PAUSED_RULE_PRIORITY,
+                  action: { type: 'allow' },
+                  condition: {
+                    excludedDomains: excludedDomains.map((d) => `*${d}`),
+                    excludedRequestDomains: excludedDomains.map((d) => `*${d}`),
+                    urlFilter: '*',
+                  },
+                },
+              ]
+            : [
+                {
+                  id: 10,
+                  priority: PAUSED_RULE_PRIORITY,
+                  action: { type: 'allow' },
+                  condition: {
+                    excludedInitiatorDomains: excludedDomains,
+                    excludedRequestDomains: excludedDomains,
+                    resourceTypes: ALL_RESOURCE_TYPES,
+                  },
+                },
+                {
+                  id: 11,
+                  priority: PAUSED_RULE_PRIORITY,
+                  action: { type: 'allowAllRequests' },
+                  condition: {
+                    excludedInitiatorDomains: excludedDomains,
+                    excludedRequestDomains: excludedDomains,
+                    resourceTypes: ['main_frame', 'sub_frame'],
+                  },
+                },
+              ],
+        removeRuleIds,
+      });
+      console.log('[safe-mode] Safe mode rules updated');
+    } else if (removeRuleIds.length) {
+      await chrome.declarativeNetRequest.updateDynamicRules({
+        removeRuleIds,
+      });
+      console.log('[safe-mode] Safe mode rules cleared');
+    }
+  });
+}

--- a/src/pages/panel/components/pause.js
+++ b/src/pages/panel/components/pause.js
@@ -67,9 +67,10 @@ export default {
   paused: { value: false, reflect: true },
   global: { value: false, reflect: true },
   revokeAt: 0,
+  safeMode: false,
   pauseType: 1,
   pauseList: { value: false, reflect: true },
-  render: ({ paused, pauseType, pauseList, revokeAt }) => html`
+  render: ({ paused, pauseType, pauseList, revokeAt, safeMode }) => html`
     <template layout="grid relative">
       <button
         id="main"
@@ -83,7 +84,9 @@ export default {
           <ui-icon name="pause"></ui-icon>
           <div layout="column">
             <ui-text type="label-m" color="inherit">
-              ${paused ? msg`Ghostery is paused` : msg`Pause on this site`}
+              ${paused && !safeMode && msg`Ghostery is paused`}
+              ${paused && safeMode && msg`Ghostery is inactive`}
+              ${!paused && msg`Pause on this site`}
             </ui-text>
             ${!!revokeAt &&
             html`<ui-text type="body-xs" color="inherit">

--- a/src/pages/panel/views/main.js
+++ b/src/pages/panel/views/main.js
@@ -65,9 +65,17 @@ async function togglePause(host, event) {
       .sort((a, b) => b.localeCompare(a))
       .find((domain) => stats.hostname.endsWith(domain));
 
-    store.set(options, {
-      paused: { [pausedHostname]: null },
-    });
+    if (host.paused.safeMode) {
+      store.set(options, {
+        safeMode: {
+          domains: [...options.safeMode.domains, stats.hostname],
+        },
+      });
+    } else {
+      store.set(options, {
+        paused: { [pausedHostname]: null },
+      });
+    }
   } else {
     await store.set(options, {
       paused: {
@@ -256,6 +264,7 @@ export default {
                 paused="${paused || globalPause}"
                 global="${globalPause}"
                 revokeAt="${globalPause?.revokeAt || paused?.revokeAt}"
+                safeMode="${paused?.safeMode}"
                 data-qa="component:pause"
               >
                 ${!!paused?.revokeAt &&
@@ -301,6 +310,23 @@ export default {
                             name="chevron-right"
                             layout="size:1.5"
                           ></ui-icon>
+                        </ui-text>
+                      </a>
+                    </ui-action>
+                  </div>
+                `}
+                ${!!paused?.safeMode &&
+                html`
+                  <div layout="row center">
+                    <ui-action>
+                      <a
+                        href="https://www.ghostery.com/blog/"
+                        onclick="${openTabWithUrl}"
+                        layout="row center gap padding:0.5:1:1 margin:top:-1"
+                      >
+                        <ui-text type="body-s">
+                          You're in safe mode - click resume to activate on this
+                          site
                         </ui-text>
                       </a>
                     </ui-action>

--- a/src/pages/settings/components/option.js
+++ b/src/pages/settings/components/option.js
@@ -19,7 +19,7 @@ export default {
       html`<ui-icon
         name="${icon}"
         color="quaternary"
-        layout="size:3"
+        layout="size:2.5"
       ></ui-icon>`}
 
       <div layout="column gap:0.5 grow">

--- a/src/pages/settings/views/privacy.js
+++ b/src/pages/settings/views/privacy.js
@@ -153,7 +153,7 @@ export default {
                   <ui-icon
                     name="pin"
                     color="quaternary"
-                    layout="size:3 margin:right"
+                    layout="size:2.5 margin:right"
                   ></ui-icon>
                   <ui-text type="headline-xs" layout="row gap:0.5 items:center">
                     Regional Filters
@@ -177,7 +177,7 @@ export default {
                   <ui-icon
                     name="search"
                     color="quaternary"
-                    layout="size:3 margin:right"
+                    layout="size:2.5 margin:right"
                   ></ui-icon>
                   <ui-text type="headline-xs" layout="row gap:0.5 items:center">
                     Search Engine Redirect Protection </ui-text
@@ -199,7 +199,7 @@ export default {
                   <ui-icon
                     name="flask"
                     color="quaternary"
-                    layout="size:3 margin:right"
+                    layout="size:2.5 margin:right"
                   ></ui-icon>
                   <ui-text type="headline-xs" layout="row gap:0.5 items:center">
                     Experimental Filters
@@ -225,7 +225,7 @@ export default {
                   <ui-icon
                     name="detailed-view"
                     color="quaternary"
-                    layout="size:3 margin:right"
+                    layout="size:2.5 margin:right"
                   ></ui-icon>
                   <ui-text type="headline-xs" layout="row gap:0.5 items:center">
                     Custom Filters

--- a/src/store/options.js
+++ b/src/store/options.js
@@ -13,6 +13,7 @@ import { store } from 'hybrids';
 
 import { DEFAULT_REGIONS } from '/utils/regions.js';
 import { isOpera } from '/utils/browser-info.js';
+import { SAFE_MODE_BLOCKED_DOMAINS } from '/utils/safe-mode.js';
 
 import Config, {
   ACTION_PAUSE_ASSISTANT,
@@ -98,6 +99,9 @@ const Options = {
 
   // Paused domains
   paused: store.record({ revokeAt: 0, assist: false }),
+
+  // Safe mode options
+  safeMode: { enabled: false, domains: [String] },
 
   // Sync
   sync: true,
@@ -234,6 +238,14 @@ export function getPausedDetails(options, hostname = '') {
   }
 
   if (!hostname) return null;
+
+  if (
+    options.safeMode.enabled &&
+    !SAFE_MODE_BLOCKED_DOMAINS.some((domain) => hostname.endsWith(domain)) &&
+    !options.safeMode.domains.some((domain) => hostname.endsWith(domain))
+  ) {
+    return { revokeAt: 0, assist: false, safeMode: true };
+  }
 
   const pausedHostname = Object.keys(options.paused).find((domain) =>
     hostname.endsWith(domain),

--- a/src/utils/safe-mode.js
+++ b/src/utils/safe-mode.js
@@ -1,0 +1,16 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+export const SAFE_MODE_BLOCKED_DOMAINS = [
+  'youtube.com',
+  'google.com',
+  'bing.com',
+];


### PR DESCRIPTION
* Enable in dev tools, by the "Safe mode" option
* Example list of enabled domains in `/utils/safe-mode.js`
* Not listed domains work similarly to extensions, which run on selected pages (when you click an extension icon) - the user must "redo" inactive extensions from the panel - then the hostname is added to enabled domains, and works as usual - the user can pause the page and unpause it