### PR TITLE
fix(element-picker): separate engine for element picker selectors

### DIFF
--- a/src/background/element-picker.js
+++ b/src/background/element-picker.js
@@ -1,0 +1,78 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { store } from 'hybrids';
+import { parseFilters } from '@ghostery/adblocker';
+
+import * as engines from '/utils/engines.js';
+import ElementPickerSelectors from '/store/element-picker-selectors.js';
+import Options from '/store/options.js';
+import CustomFilters from '/store/custom-filters.js';
+
+import { setup, reloadMainEngine } from './adblocker.js';
+import { updateCustomFilters } from './custom-filters.js';
+
+// Initialize element picker selectors
+// to ensure that store.observe() is called
+store.resolve(ElementPickerSelectors).then(async ({ hostnames }) => {
+  // Migrate element picker selector from custom filters engine
+  // TODO: Remove this migration after a few releases
+  if (
+    Object.keys(hostnames).length &&
+    !(await engines.init(engines.ELEMENT_PICKER_ENGINE))
+  ) {
+    console.log(
+      '[element-picker] Migrating selectors from custom filters engine...',
+    );
+
+    // Force refresh the element picker engine
+    store.clear(ElementPickerSelectors, false);
+    store.get(ElementPickerSelectors);
+
+    // Refresh custom filters without element picker selectors
+    const [options, customFilters] = await Promise.all([
+      store.resolve(Options),
+      store.resolve(CustomFilters),
+    ]);
+
+    updateCustomFilters(customFilters.text, options.customFilters);
+  }
+});
+
+store.observe(ElementPickerSelectors, async (_, model, lastModel) => {
+  if (!lastModel) return;
+
+  let entries = Object.entries(model.hostnames);
+
+  if (entries.length) {
+    const elementPickerFilters = entries.reduce(
+      (acc, [hostname, selectors]) => {
+        for (const selector of selectors) {
+          acc.push(`${hostname}##${selector}`);
+        }
+        return acc;
+      },
+      [],
+    );
+
+    const { cosmeticFilters } = parseFilters(elementPickerFilters.join('\n'));
+
+    engines.create(engines.ELEMENT_PICKER_ENGINE, {
+      cosmeticFilters,
+      config: (await engines.init(engines.FIXES_ENGINE)).config,
+    });
+  } else {
+    engines.remove(engines.ELEMENT_PICKER_ENGINE);
+  }
+
+  setup.pending && (await setup.pending);
+  await reloadMainEngine();
+});

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -15,6 +15,7 @@ import './config.js';
 import './autoconsent.js';
 import './adblocker.js';
 import './custom-filters.js';
+import './element-picker.js';
 import './dnr.js';
 import './exceptions.js';
 import './paused.js';

--- a/src/background/paused.js
+++ b/src/background/paused.js
@@ -36,7 +36,7 @@ const ALL_RESOURCE_TYPES = [
   'other',
 ];
 
-OptionsObserver.addListener('paused', async (paused, prevPaused) => {
+OptionsObserver.addListener('paused', async (paused, lastPaused) => {
   const alarms = (await chrome.alarms.getAll()).filter(({ name }) =>
     name.startsWith(PAUSED_ALARM_PREFIX),
   );
@@ -69,7 +69,7 @@ OptionsObserver.addListener('paused', async (paused, prevPaused) => {
   // in the panel or the settings page.
   if (
     (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') &&
-    (prevPaused ||
+    (lastPaused ||
       // Managed mode can update the rules at any time - so we need to update
       // the rules even if the paused state hasn't changed
       (__PLATFORM__ === 'chromium' &&

--- a/src/background/sync.js
+++ b/src/background/sync.js
@@ -19,10 +19,10 @@ import { HOME_PAGE_URL, ACCOUNT_PAGE_URL } from '/utils/urls.js';
 import debounce from '/utils/debounce.js';
 
 const syncOptions = debounce(
-  async function (options, prevOptions) {
+  async function (options, lastOptions) {
     try {
       // Skip if revision has changed
-      if (prevOptions && options.revision !== prevOptions.revision) return;
+      if (lastOptions && options.revision !== lastOptions.revision) return;
 
       // Clean up if sync should be disabled
       if (
@@ -37,10 +37,10 @@ const syncOptions = debounce(
       }
 
       const keys =
-        prevOptions &&
+        lastOptions &&
         SYNC_OPTIONS.filter(
           (key) =>
-            !OptionsObserver.isOptionEqual(options[key], prevOptions[key]),
+            !OptionsObserver.isOptionEqual(options[key], lastOptions[key]),
         );
 
       // If options update, set revision to "dirty" state
@@ -112,8 +112,8 @@ const syncOptions = debounce(
 );
 
 // Sync options on startup and when options change
-OptionsObserver.addListener(function sync(options, prevOptions) {
-  syncOptions(options, prevOptions);
+OptionsObserver.addListener(function sync(options, lastOptions) {
+  syncOptions(options, lastOptions);
 });
 
 // Sync options when a user logs in/out directly

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -57,8 +57,8 @@ reloadTheme();
 if (document.documentElement.dataset.theme) {
   mode = document.documentElement.dataset.theme;
 } else {
-  OptionsObserver.addListener('theme', (theme, prevTheme) => {
-    if (theme || prevTheme) {
+  OptionsObserver.addListener('theme', (theme, lastTheme) => {
+    if (theme || lastTheme) {
       localStorage.setItem('theme', theme);
       mode = theme;
 

--- a/src/utils/engines.js
+++ b/src/utils/engines.js
@@ -23,9 +23,11 @@ import debug from './debug.js';
 import { CDN_URL } from './api.js';
 
 export const MAIN_ENGINE = 'main';
-export const CUSTOM_ENGINE = 'custom-filters';
 
 export const FIXES_ENGINE = 'fixes';
+export const ELEMENT_PICKER_ENGINE = 'element-picker-selectors';
+export const CUSTOM_ENGINE = 'custom-filters';
+
 export const TRACKERDB_ENGINE = 'trackerdb';
 
 const engines = new Map();
@@ -41,6 +43,14 @@ const ENV = new Map([
   ['env_mobile', checkUserAgent('Mobile')],
   ['env_experimental', false],
 ]);
+
+export function isPersistentEngine(name) {
+  return (
+    name !== ELEMENT_PICKER_ENGINE &&
+    name !== CUSTOM_ENGINE &&
+    name !== MAIN_ENGINE
+  );
+}
 
 export function setEnv(key, value) {
   if (ENV.has(key)) {
@@ -397,9 +407,8 @@ export async function init(name) {
   return (
     get(name) ||
     (await loadFromStorage(name)) ||
-    (name !== MAIN_ENGINE &&
-      name !== CUSTOM_ENGINE &&
-      (await loadFromFile(name)))
+    (isPersistentEngine(name) && (await loadFromFile(name))) ||
+    null
   );
 }
 

--- a/src/utils/options-observer.js
+++ b/src/utils/options-observer.js
@@ -43,17 +43,17 @@ export function addListener(...args) {
     const property = args.length === 2 ? args[0] : null;
 
     const getValue = property ? (v) => v[property] : (v) => v;
-    const getPrevValue = property ? (v) => v?.[property] : (v) => v;
+    const getLastValue = property ? (v) => v?.[property] : (v) => v;
 
-    const wrapper = async (options, prevOptions) => {
+    const wrapper = async (options, lastOptions) => {
       const value = getValue(options);
-      const prevValue = getPrevValue(prevOptions);
+      const lastValue = getLastValue(lastOptions);
 
-      if (isOptionEqual(value, prevValue)) return;
+      if (isOptionEqual(value, lastValue)) return;
 
       try {
         console.debug(`[options] Executing "${fn.name || property}" observer`);
-        await fn(value, prevValue);
+        await fn(value, lastValue);
         resolve();
       } catch (e) {
         reject(e);
@@ -70,7 +70,7 @@ export async function waitForIdle() {
   for (const queue of queues) await queue;
 }
 
-store.observe(Options, (_, options, prevOptions) => {
+store.observe(Options, (_, options, lastOptions) => {
   if (observers.length === 0) return;
 
   const queue = Promise.allSettled([...queues]).then(async () => {
@@ -79,7 +79,7 @@ store.observe(Options, (_, options, prevOptions) => {
     await Promise.all(
       observers.map(async (fn) => {
         try {
-          await fn(options, prevOptions);
+          await fn(options, lastOptions);
         } catch (e) {
           console.error(`Error while executing observer: `, e);
         }


### PR DESCRIPTION
* Moves out element picker selectors from custom filters to a separate engine
* Unifies last value variable names for observing changes in various models

I discovered that if there are a lot of custom filters, adding a single blocked element may block the browser UI, or at least be very slow. Before the change, it required recompiling the entire set of custom filters, which included network filters that had to be converted.

PR tested in Chrome and Firefox, and the migration process too. I recommend testing the custom filters and element picker feature in the next release.