### PR TITLE
fix(e2e): use Chrome Canary Testing channel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: macos-15-large
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -17,13 +17,20 @@ jobs:
           cache: 'npm'
           cache-dependency-path: ./package-lock.json
 
+      - name: test tree
+        run: |
+          echo "Current directory:"
+          pwd
+          echo "Directory contents:"
+          ls -la
+
       - name: Install dependencies
         run: npm ci
 
-      - name: Lint
-        run: npm run lint
+      # - name: Lint
+      #   run: npm run lint
 
-      - name: Test - installated extension
+      - name: Test - installed extension
         run: npm run wdio
 
       - name: Test - updated extension

--- a/tests/e2e/wdio.conf.js
+++ b/tests/e2e/wdio.conf.js
@@ -85,6 +85,7 @@ export function buildForChrome() {
     cpSync(path.join(process.cwd(), 'dist'), CHROME_PATH, {
       recursive: true,
     });
+    execSync('ls -la ' + CHROME_PATH, { stdio: 'inherit' });
   }
 }
 
@@ -105,19 +106,6 @@ export const config = {
   maxInstances: process.env.GITHUB_ACTIONS ? 1 : 2,
   capabilities: [
     {
-      browserName: 'firefox',
-      'moz:firefoxOptions': {
-        args: argv.debug ? [] : ['-headless'],
-        prefs: {
-          'browser.cache.disk.enable': false,
-          'browser.cache.memory.enable': false,
-          'browser.cache.offline.enable': false,
-          'network.http.use-cache': false,
-          'intl.accept_languages': 'en-GB',
-        },
-      },
-    },
-    {
       browserName: 'chrome',
       browserVersion: 'stable',
       'goog:chromeOptions': {
@@ -128,6 +116,19 @@ export const config = {
         ]),
       },
     },
+    // {
+    //   browserName: 'firefox',
+    //   'moz:firefoxOptions': {
+    //     args: argv.debug ? [] : ['-headless'],
+    //     prefs: {
+    //       'browser.cache.disk.enable': false,
+    //       'browser.cache.memory.enable': false,
+    //       'browser.cache.offline.enable': false,
+    //       'network.http.use-cache': false,
+    //       'intl.accept_languages': 'en-GB',
+    //     },
+    //   },
+    // },
   ].filter((capability) => argv.target.includes(capability.browserName)),
   onPrepare: async (config, capabilities) => {
     if (argv.clean) {


### PR DESCRIPTION
Github Actions setup uses local version of Chrome if the main version matches, but we need to force to use Testing version of Chrome.

The way is to use Canary channel, as is always has newer major version.