### PR TITLE
fix(broken-page-report): update fields & set screenshot opt-out

### DIFF
--- a/src/pages/panel/views/report-form.js
+++ b/src/pages/panel/views/report-form.js
@@ -21,7 +21,7 @@ const Form = {
   url: '',
   email: '',
   description: '',
-  screenshot: false,
+  screenshot: true,
   [store.connect]: {
     async get() {
       const [currentTab, session] = await Promise.all([
@@ -137,6 +137,7 @@ export default {
               <ui-input>
                 <input
                   type="checkbox"
+                  checked="${form.screenshot}"
                   onchange="${html.set(form, 'screenshot')}"
                 />
               </ui-input>


### PR DESCRIPTION
* Uses `domain` and `version` fields
* Sets `screenshot` enabled by default
* Updates subject of the report