### PR TITLE
fix(safari): match min Safari version with target deployment

### DIFF
--- a/src/manifest.safari.json
+++ b/src/manifest.safari.json
@@ -131,7 +131,7 @@
   "content_security_policy": "script-src 'self'",
   "browser_specific_settings": {
     "safari": {
-      "strict_min_version": "17.0"
+      "strict_min_version": "18.0"
     }
   }
 }


### PR DESCRIPTION
Currently, we target ios 18+ and macos 13.5+ (as the oldest macOS version, which supports Safari 18). We should align the min Safari version in the manifest with the targets.