### PR TITLE
fix(backup): open exported config in the new tab on iOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@whotracksme/reporting": "^7.4.0",
         "apexsankey": "github:ghostery/apexsankey",
         "bowser": "^2.11.0",
+        "file-saver": "^2.0.5",
         "hybrids": "^9.1.18",
         "idb": "^8.0.2",
         "jwt-decode": "^4.0.0",
@@ -7446,6 +7447,12 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==",
+      "license": "MIT"
     },
     "node_modules/filelist": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@whotracksme/reporting": "^7.4.0",
     "apexsankey": "github:ghostery/apexsankey",
     "bowser": "^2.11.0",
+    "file-saver": "^2.0.5",
     "hybrids": "^9.1.18",
     "idb": "^8.0.2",
     "jwt-decode": "^4.0.0",


### PR DESCRIPTION
Fixes #2537
Relates to #2532

Safari on iOS has a bug that prevents downloading the generated `Blob` object. To mitigate the issue, the only way is to open a new tab and display the content. Then, the user might copy the text and save it (however, this is not trivial). Unfortunately, there is no better way.

When doing the research, I have found a helpful library `file-saver`, which does not fix the iOS issue, but it is valuable to avoid other edge cases. I replaced our custom code with a call to the `saveAs` function from the library.

Additionally, the PR adds support for element picker selectors in the backup file.