### PR TITLE
fix(notifications): close other notifications when `use_dynamic_url` is used

### DIFF
--- a/src/content_scripts/notifications.js
+++ b/src/content_scripts/notifications.js
@@ -119,7 +119,10 @@ function mount(url, position = 'right') {
     if (type === notifications.CLOSE_WINDOW_EVENT) {
       if (e.data.clear) {
         // Send clearIframe message to other pages
-        chrome.runtime.sendMessage({ action: notifications.CLEAR_ACTION, url });
+        chrome.runtime.sendMessage({
+          action: notifications.CLEAR_ACTION,
+          id: new URL(url).pathname.split('/').pop(),
+        });
       }
 
       wrapper.addEventListener('transitionend', () => {

--- a/src/utils/notifications.js
+++ b/src/utils/notifications.js
@@ -43,7 +43,10 @@ export function setupNotificationPage(width = 440) {
   document.body.style.overflow = 'hidden';
 
   chrome.runtime.onMessage.addListener((msg) => {
-    if (msg.action === CLEAR_ACTION && location.href === msg.url) {
+    if (
+      msg.action === CLEAR_ACTION &&
+      location.pathname.split('/').pop() === msg.id
+    ) {
       window.parent.postMessage({ type: CLOSE_WINDOW_EVENT }, '*');
     }
   });


### PR DESCRIPTION
Using `use_dynamic_url` option for content scripts introduced a bug for closing notifications on other tabs. The condition checks the URL, but it is dynamic in the context of the content script.

<img width="646" height="85" alt="Zrzut ekranu 2025-07-21 o 11 37 18" src="https://github.com/user-attachments/assets/768b448d-9b47-4bed-ab7b-b6a0ee7ed749" />