### PR TITLE
fix(whats-new): Set current version after installation

### DIFF
--- a/src/background/whats-new.js
+++ b/src/background/whats-new.js
@@ -34,6 +34,13 @@ chrome.runtime.onStartup.addListener(async () => {
     return;
   }
 
+  // After installing the extension version is 0,
+  // so we need to set it to the current version and return early
+  if (options.whatsNewVersion === 0) {
+    store.set(options, { whatsNewVersion });
+    return;
+  }
+
   const tabs = await chrome.tabs.query({ currentWindow: true });
   const activeTab = tabs.find((tab) => tab.active);
 

--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -22,7 +22,7 @@ export const ACCOUNT_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/account`;
 
 export const WTM_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/whotracksme`;
 export const SUPPORT_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/support`;
-export const WHATS_NEW_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/blog/ghostery-extension-v10-5?embed=1`;
+export const WHATS_NEW_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/blog/ghostery-extension-v10-5?embed=1&utm_campaign=whatsnew`;
 
 export const REVIEW_PAGE_URL = (() => {
   if (__PLATFORM__ === 'safari') return 'https://mygho.st/ReviewSafariPanel';


### PR DESCRIPTION
To prevent displaying "What's new" to users who clear storage at the end of the session, we need to set the current version if it's not already set. 

IMPORTANT TESTING NOTICE: With this change, it won't be possible to test What's new notification/page by restarting the browser after installation.  To trigger it, the extension must change its minor version, eg, from 10.5.x to 10.6.x. It must be changed manually in the `manifest.json` file in the file system where the unpacked extension is loaded in the browser.

@AdamGhst, please update the test case for What's new with the above instruction. 