### PR TITLE
fix(pin-it): trigger notification only once

### DIFF
--- a/src/background/pin-it.js
+++ b/src/background/pin-it.js
@@ -19,9 +19,6 @@ import { getBrowser } from '/utils/browser-info.js';
 import { openNotification } from './notifications.js';
 
 if (__PLATFORM__ === 'chromium' && getBrowser() !== 'oculus') {
-  const NOTIFICATION_DELAY = 7 * 24 * 60 * 60 * 1000; // 7 days in milliseconds
-  const NOTIFICATION_SHOW_LIMIT = 4;
-
   chrome.webNavigation.onCompleted.addListener(async (details) => {
     if (
       details.frameId !== 0 ||
@@ -38,10 +35,7 @@ if (__PLATFORM__ === 'chromium' && getBrowser() !== 'oculus') {
       !terms ||
       managedConfig.disableUserControl ||
       // The notification was already shown maximum times
-      onboarding.pinIt >= NOTIFICATION_SHOW_LIMIT ||
-      // The notification was already shown recently
-      (onboarding.pinItAt &&
-        Date.now() - onboarding.pinItAt < NOTIFICATION_DELAY)
+      onboarding.pinIt
     ) {
       return false;
     }

--- a/src/pages/notifications/pin-it.js
+++ b/src/pages/notifications/pin-it.js
@@ -39,20 +39,8 @@ switch (getBrowser().name) {
     pathname = `/ghostery-ad-blocker-chrome#how-do-i-pin-the-ghostery-extension-to-the-chrome-toolbar`;
 }
 
-const closeDialog = notifications.setupNotificationPage(390);
-
-async function close() {
-  const options = await store.resolve(Options);
-
-  await store.set(options, {
-    onboarding: {
-      pinIt: options.onboarding.pinIt + 1,
-      pinItAt: Date.now(),
-    },
-  });
-
-  closeDialog();
-}
+const close = notifications.setupNotificationPage(390);
+store.set(Options, { onboarding: { pinIt: true } });
 
 mount(document.body, {
   render: () => html`

--- a/src/store/options.js
+++ b/src/store/options.js
@@ -86,7 +86,7 @@ const Options = {
     ...(__PLATFORM__ === 'chromium' && isOpera()
       ? { serpShownAt: 0, serpShown: 0 }
       : {}),
-    ...(__PLATFORM__ === 'chromium' ? { pinIt: 0, pinItAt: 0 } : {}),
+    ...(__PLATFORM__ === 'chromium' ? { pinIt: false } : {}),
   },
   installDate: '',
 


### PR DESCRIPTION
Changes trigger logic of the "Pin it" notification to show it only once, and set the "shown" flag automatically after displaying the notification (no user action required).