### PR TITLE
chore(deps): Move reviewers to CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+package.json @smalluban @chrmod

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,6 @@ updates:
     schedule:
       interval: 'daily'
       time: '07:00'
-    reviewers:
-      - 'smalluban'
-      - 'chrmod'
     open-pull-requests-limit: 99
     groups:
       adblocker:
@@ -29,8 +26,6 @@ updates:
     schedule:
       interval: 'weekly'
       time: '07:00'
-    reviewers:
-      - 'smalluban'
     groups:
       eslint:
         patterns:


### PR DESCRIPTION
The `reviewer` option is deprecated, and we need to move to `CODEOWNERS` files.

More info here: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

For now, I added specific config for `package.json` file. We can add more if we like.