### PR TITLE
fix(dnr): use direct import for DNR converter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@ghostery/adblocker-extended-selectors": "^2.11.1",
         "@ghostery/adblocker-webextension": "^2.11.3",
         "@ghostery/scriptlets": "github:ghostery/scriptlets",
-        "@ghostery/urlfilter2dnr": "^1.6.1",
+        "@ghostery/urlfilter2dnr": "^1.6.3",
         "@github/relative-time-element": "^4.4.8",
         "@sentry/browser": "^9.35.0",
         "@whotracksme/reporting": "^7.4.0",
@@ -1355,9 +1355,9 @@
       }
     },
     "node_modules/@ghostery/urlfilter2dnr": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@ghostery/urlfilter2dnr/-/urlfilter2dnr-1.6.1.tgz",
-      "integrity": "sha512-TZwOoKr0F3uVGayPFevnYhy6au0SzFASbANRlWKArROMXKypyv6Atzx18HvBtlv1mj8GaKY3hKFhRccjZnk3EQ==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@ghostery/urlfilter2dnr/-/urlfilter2dnr-1.6.3.tgz",
+      "integrity": "sha512-p5glTbTf++197Wc/1GVR/UDY5ruxcPdpXqdPZv7diL1OkfRd2S63xHfdGLz2q0B/ONQgjgt/YEbLK6zJeWYmPA==",
       "license": "GPL-3.0",
       "dependencies": {
         "@adguard/re2-wasm": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@ghostery/adblocker-extended-selectors": "^2.11.1",
     "@ghostery/adblocker-webextension": "^2.11.3",
     "@ghostery/scriptlets": "github:ghostery/scriptlets",
-    "@ghostery/urlfilter2dnr": "^1.6.1",
+    "@ghostery/urlfilter2dnr": "^1.6.3",
     "@github/relative-time-element": "^4.4.8",
     "@sentry/browser": "^9.35.0",
     "@whotracksme/reporting": "^7.4.0",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -397,6 +397,9 @@ const buildPromise = build({
     target: 'esnext',
     rollupOptions: {
       input: mapPaths(source),
+      // Prevent from loading re2-wasm dependency of the @ghostery/urlfilter2dnr package
+      // as it is used only in node environment
+      external: ['@adguard/re2-wasm'],
       preserveEntrySignatures: 'exports-only',
       output: {
         banner:

--- a/src/pages/dnr-converter/index.js
+++ b/src/pages/dnr-converter/index.js
@@ -13,7 +13,7 @@
 // The check is redone in the background script
 import './monkey-patch.js';
 
-import { convertWithAdguard } from '@ghostery/urlfilter2dnr';
+import convertWithAdguard from '@ghostery/urlfilter2dnr/adguard';
 
 export async function convert(filters) {
   try {

--- a/src/utils/dnr-converter.js
+++ b/src/utils/dnr-converter.js
@@ -25,7 +25,9 @@ export default async function convert(filters) {
         filters,
       });
     } else if (__PLATFORM__ === 'safari') {
-      const { convertWithAdguard } = await import('@ghostery/urlfilter2dnr');
+      const convertWithAdguard = await import(
+        '@ghostery/urlfilter2dnr/adguard'
+      );
       result = await convertWithAdguard(filters);
 
       result.rules = result.rules.reduce((acc, r) => {


### PR DESCRIPTION
Uses the latest version of the converter library, which add better three-shaking.