### PR TITLE
fix(options): clean deprecated `installDate` field

### DIFF
--- a/src/store/options.js
+++ b/src/store/options.js
@@ -88,7 +88,6 @@ const Options = {
       : {}),
     ...(__PLATFORM__ === 'chromium' ? { pinIt: false } : {}),
   },
-  installDate: '',
 
   // UI
   panel: { statsType: 'graph', notifications: true },


### PR DESCRIPTION
The `options.installDate` is no longer used. The migration code was also removed.

https://github.com/ghostery/ghostery-extension/pull/2123/files#diff-24fea820b5c870bbf4fd772569b99109a37ed01b9d48175139fc53d45194bd9cL52