### PR TITLE
feat(dnr): use dynamic DNR for fixes filters

### DIFF
--- a/src/background/custom-filters.js
+++ b/src/background/custom-filters.js
@@ -25,6 +25,7 @@ import Options from '/store/options.js';
 import CustomFilters from '/store/custom-filters.js';
 
 import { setup, reloadMainEngine } from './adblocker.js';
+import { CUSTOM_FILTERS_ID_RANGE, getDynamicRulesIds } from '/utils/dnr.js';
 
 class TrustedScriptletError extends Error {}
 
@@ -104,15 +105,10 @@ function normalizeFilters(text = '', { trustedScriptlets }) {
 }
 
 async function updateDNRRules(dnrRules) {
-  const dynamicRules = (await chrome.declarativeNetRequest.getDynamicRules())
-    .filter(({ id }) => id >= 1000000 && id < 2000000)
-    .map(({ id }) => id);
+  const removeRuleIds = await getDynamicRulesIds(CUSTOM_FILTERS_ID_RANGE);
 
-  if (dynamicRules.length) {
-    await chrome.declarativeNetRequest.updateDynamicRules({
-      removeRuleIds: dynamicRules,
-      // ids between 1 and 2 million are reserved for dynamic rules
-    });
+  if (removeRuleIds.length) {
+    await chrome.declarativeNetRequest.updateDynamicRules({ removeRuleIds });
   }
 
   if (dnrRules.length) {

--- a/src/background/dnr.js
+++ b/src/background/dnr.js
@@ -43,7 +43,7 @@ if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') {
       );
     }
 
-    // Add fixes rules
+    // Add latest fixes rules
     if (ids.length) {
       const fixesRulesIds = await getDynamicRulesIds(FIXES_ID_RANGE);
 

--- a/src/background/dnr.js
+++ b/src/background/dnr.js
@@ -10,7 +10,10 @@
  */
 
 import { ENGINES, getPausedDetails } from '/store/options.js';
+import { convertToSafariFormat } from '/utils/dnr-converter-safari.js';
+import { FIXES_ID_RANGE, getDynamicRulesIds } from '/utils/dnr.js';
 import * as OptionsObserver from '/utils/options-observer.js';
+import { ENGINE_CONFIGS_ROOT_URL } from '/utils/urls.js';
 
 if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') {
   const DNR_RESOURCES = chrome.runtime
@@ -21,28 +24,86 @@ if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') {
   // Ensure that DNR rulesets are equal to those from options.
   // eg. when web extension updates, the rulesets are reset
   // to the value from the manifest.
-  OptionsObserver.addListener(async function dnr(options) {
+  OptionsObserver.addListener(async function dnr(options, lastOptions) {
     const globalPause = getPausedDetails(options);
 
     const ids = ENGINES.map(({ name, key }) => {
       return !globalPause && options.terms && options[key] ? name : '';
     }).filter((id) => id && DNR_RESOURCES.includes(id));
 
-    if (ids.length) {
-      ids.push('fixes');
-
-      // Add regional network filters
-      if (options.regionalFilters.enabled) {
-        ids.push(
-          ...options.regionalFilters.regions
-            .map((id) => `lang-${id}`)
-            .filter((id) => DNR_RESOURCES.includes(id)),
-        );
-      }
-    }
-
     const enabledRulesetIds =
       (await chrome.declarativeNetRequest.getEnabledRulesets()) || [];
+
+    // Add regional network filters
+    if (ids.length && options.regionalFilters.enabled) {
+      ids.push(
+        ...options.regionalFilters.regions
+          .map((id) => `lang-${id}`)
+          .filter((id) => DNR_RESOURCES.includes(id)),
+      );
+    }
+
+    // Add fixes rules
+    if (ids.length) {
+      const fixesRulesIds = await getDynamicRulesIds(FIXES_ID_RANGE);
+
+      // Fixes should be set when engines are re-enabled and after each update.
+      // We can detect re-enabling by checking if both `fixes` static rules
+      // and dynamic fixes rules are not present.
+      if (
+        (!enabledRulesetIds.includes('fixes') && fixesRulesIds.length === 0) ||
+        lastOptions?.filtersUpdatedAt < options.filtersUpdatedAt
+      ) {
+        try {
+          await chrome.declarativeNetRequest.updateDynamicRules({
+            removeRuleIds: fixesRulesIds,
+          });
+
+          let addRules = await fetch(
+            `${ENGINE_CONFIGS_ROOT_URL}/dnr-fixes-v2/allowed-lists.json`,
+          )
+            .then((res) => res.json())
+            .then((list) => fetch(list.dnr.url))
+            .then((res) => res.json());
+
+          if (__PLATFORM__ === 'safari') {
+            addRules = addRules.reduce((acc, rule) => {
+              try {
+                acc.push(convertToSafariFormat(rule));
+              } catch {
+                // Ignore rules that cannot be converted
+              }
+              return acc;
+            }, []);
+          }
+
+          await chrome.declarativeNetRequest.updateDynamicRules({
+            addRules: addRules.map((rule, index) => ({
+              ...rule,
+              id: FIXES_ID_RANGE.start + index,
+            })),
+          });
+
+          console.info('[dnr] Updated dynamic fixes rules');
+        } catch (e) {
+          console.error('[dnr] Error while updating dynamic fixes rules:', e);
+
+          // As a fallback, add the static fixes rules from the resources
+          ids.push('fixes');
+        }
+      }
+    } else {
+      if (!enabledRulesetIds.includes('fixes')) {
+        // Remove all dynamic fixes rules
+        const removeRuleIds = await getDynamicRulesIds(FIXES_ID_RANGE);
+        if (removeRuleIds.length) {
+          await chrome.declarativeNetRequest.updateDynamicRules({
+            removeRuleIds,
+          });
+          console.info('[dnr] Removed dynamic fixes rules');
+        }
+      }
+    }
 
     const enableRulesetIds = [];
     const disableRulesetIds = [];
@@ -65,9 +126,9 @@ if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') {
           enableRulesetIds,
           disableRulesetIds,
         });
-        console.info('[dnr] Updated with rulesets:', ids.join(', '));
+        console.info('[dnr] Updated static rulesets:', ids.join(', '));
       } catch (e) {
-        console.error(`[dnr] Error while updating rulesets:`, e);
+        console.error(`[dnr] Error while updating static rulesets:`, e);
       }
     }
   });

--- a/src/background/dnr.js
+++ b/src/background/dnr.js
@@ -9,7 +9,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
+import { store } from 'hybrids';
+
 import { ENGINES, getPausedDetails } from '/store/options.js';
+import Config, { FLAG_DYNAMIC_DNR_FIXES } from '/store/config.js';
+import Resources from '/store/resources.js';
+
 import { convertToSafariFormat } from '/utils/dnr-converter-safari.js';
 import { FIXES_ID_RANGE, getDynamicRulesIds } from '/utils/dnr.js';
 import * as OptionsObserver from '/utils/options-observer.js';
@@ -24,10 +29,20 @@ if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') {
   function getIds(options) {
     if (!options.terms || getPausedDetails(options)) return [];
 
-    return ENGINES.reduce((acc, { name, key }) => {
+    const ids = ENGINES.reduce((acc, { name, key }) => {
       if (options[key] && DNR_RESOURCES.includes(name)) acc.push(name);
       return acc;
     }, []);
+
+    if (ids.length && options.regionalFilters.enabled) {
+      ids.push(
+        ...options.regionalFilters.regions
+          .map((id) => `lang-${id}`)
+          .filter((id) => DNR_RESOURCES.includes(id)),
+      );
+    }
+
+    return ids;
   }
 
   // Ensure that DNR rulesets are equal to those from options.
@@ -41,42 +56,33 @@ if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') {
       lastOptions.filtersUpdatedAt === options.filtersUpdatedAt &&
       String(ids) === String(getIds(lastOptions))
     ) {
-      // No changes in options triggering an update , skip updating rules
+      // No changes in options triggering an update, skip updating rules
       return;
     }
 
     const enabledRulesetIds =
       (await chrome.declarativeNetRequest.getEnabledRulesets()) || [];
 
-    // Add regional network filters
-    if (ids.length && options.regionalFilters.enabled) {
-      ids.push(
-        ...options.regionalFilters.regions
-          .map((id) => `lang-${id}`)
-          .filter((id) => DNR_RESOURCES.includes(id)),
-      );
-    }
+    const config = await store.resolve(Config);
 
     // Add latest fixes rules
-    if (ids.length) {
-      const fixesRulesIds = await getDynamicRulesIds(FIXES_ID_RANGE);
+    if (config.hasFlag(FLAG_DYNAMIC_DNR_FIXES)) {
+      const DNR_FIXES_KEY = 'dnr-fixes';
+      const resources = await store.resolve(Resources);
 
-      // Fixes should be set when engines are re-enabled and after each update.
-      // We can detect re-enabling by checking if both `fixes` static rules
-      // and dynamic fixes rules are not present.
-      if (
-        (!enabledRulesetIds.includes('fixes') && fixesRulesIds.length === 0) ||
-        lastOptions?.filtersUpdatedAt < options.filtersUpdatedAt
-      ) {
-        try {
-          await chrome.declarativeNetRequest.updateDynamicRules({
-            removeRuleIds: fixesRulesIds,
-          });
+      if (ids.length) {
+        if (
+          !resources.checksums[DNR_FIXES_KEY] ||
+          lastOptions?.filtersUpdatedAt < options.filtersUpdatedAt
+        ) {
+          const removeRuleIds = await getDynamicRulesIds(FIXES_ID_RANGE);
 
-          let addRules = await fetch(
-            `${ENGINE_CONFIGS_ROOT_URL}/dnr-fixes-v2/allowed-lists.json`,
-          )
-            .then((res) =>
+          try {
+            console.info('[dnr] Updating dynamic fixes rules...');
+
+            const list = await fetch(
+              `${ENGINE_CONFIGS_ROOT_URL}/dnr-fixes-v2/allowed-lists.json`,
+            ).then((res) =>
               res.ok
                 ? res.json()
                 : Promise.reject(
@@ -84,53 +90,75 @@ if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') {
                       `Failed to fetch allowed lists: ${res.statusText}`,
                     ),
                   ),
-            )
-            .then((list) => fetch(list.dnr.url))
-            .then((res) =>
-              res.ok
-                ? res.json()
-                : Promise.reject(
-                    new Error(`Failed to fetch DNR rules: ${res.statusText}`),
-                  ),
             );
 
-          if (__PLATFORM__ === 'safari') {
-            addRules = addRules.reduce((acc, rule) => {
-              try {
-                acc.push(convertToSafariFormat(rule));
-              } catch {
-                // Ignore rules that cannot be converted
+            if (list.dnr.checksum !== resources.checksums['dnr-fixes']) {
+              let addRules = await fetch(list.dnr.url).then((res) =>
+                res.ok
+                  ? res.json()
+                  : Promise.reject(
+                      new Error(`Failed to fetch DNR rules: ${res.statusText}`),
+                    ),
+              );
+
+              if (__PLATFORM__ === 'safari') {
+                addRules = addRules.reduce((acc, rule) => {
+                  try {
+                    acc.push(convertToSafariFormat(rule));
+                  } catch {
+                    // Ignore rules that cannot be converted
+                  }
+                  return acc;
+                }, []);
               }
-              return acc;
-            }, []);
+
+              await chrome.declarativeNetRequest.updateDynamicRules({
+                removeRuleIds: await getDynamicRulesIds(FIXES_ID_RANGE),
+                addRules: addRules.map((rule, index) => ({
+                  ...rule,
+                  id: FIXES_ID_RANGE.start + index,
+                })),
+              });
+
+              console.info(
+                '[dnr] Updated dynamic fixes rules:',
+                list.dnr.checksum,
+              );
+              await store.set(resources, {
+                checksums: { [DNR_FIXES_KEY]: list.dnr.checksum },
+              });
+            }
+          } catch (e) {
+            console.error('[dnr] Error while updating dynamic fixes rules:', e);
+
+            // If no dynamic rules are applied, it means that initial fetch failed.
+            // As a fallback we need to add static fixes rules.
+            if (!removeRuleIds.length) {
+              console.warn('[dnr] Falling back to static fixes rules');
+              ids.push('fixes');
+
+              await store.set(resources, {
+                checksums: { [DNR_FIXES_KEY]: 'filesystem' },
+              });
+            }
           }
-
-          await chrome.declarativeNetRequest.updateDynamicRules({
-            addRules: addRules.map((rule, index) => ({
-              ...rule,
-              id: FIXES_ID_RANGE.start + index,
-            })),
-          });
-
-          console.info('[dnr] Updated dynamic fixes rules');
-        } catch (e) {
-          console.error('[dnr] Error while updating dynamic fixes rules:', e);
-
-          // As a fallback, add the static fixes rules from the resources
-          ids.push('fixes');
         }
-      }
-    } else {
-      if (!enabledRulesetIds.includes('fixes')) {
+      } else if (resources.checksums[DNR_FIXES_KEY]) {
         // Remove all dynamic fixes rules
         const removeRuleIds = await getDynamicRulesIds(FIXES_ID_RANGE);
         if (removeRuleIds.length) {
           await chrome.declarativeNetRequest.updateDynamicRules({
             removeRuleIds,
           });
+          await store.set(resources, {
+            checksums: { [DNR_FIXES_KEY]: null },
+          });
+
           console.info('[dnr] Removed dynamic fixes rules');
         }
       }
+    } else if (ids.length) {
+      ids.push('fixes');
     }
 
     const enableRulesetIds = [];

--- a/src/background/exceptions.js
+++ b/src/background/exceptions.js
@@ -17,6 +17,11 @@ import Options from '/store/options.js';
 import * as OptionsObserver from '/utils/options-observer.js';
 import * as trackerdb from '/utils/trackerdb.js';
 import convert from '/utils/dnr-converter.js';
+import {
+  EXCEPTIONS_ID_RANGE,
+  EXCEPTIONS_RULE_PRIORITY,
+  getDynamicRulesIds,
+} from '/utils/dnr.js';
 
 // Migrate exceptions from old format
 // TODO: Remove this in the next version
@@ -84,19 +89,17 @@ async function updateFilters() {
 
       rules.push({
         ...rule,
-        priority: 2000000 + rule.priority,
+        priority: EXCEPTIONS_RULE_PRIORITY + rule.priority,
       });
     }
   }
 
   const addRules = rules.map((rule, index) => ({
     ...rule,
-    id: 2000000 + index,
+    id: EXCEPTIONS_RULE_PRIORITY + index,
   }));
 
-  const removeRuleIds = (await chrome.declarativeNetRequest.getDynamicRules())
-    .filter(({ id }) => id >= 2000000)
-    .map(({ id }) => id);
+  const removeRuleIds = await getDynamicRulesIds(EXCEPTIONS_ID_RANGE);
 
   if (addRules.length || removeRuleIds.length) {
     await chrome.declarativeNetRequest.updateDynamicRules({

--- a/src/background/paused.js
+++ b/src/background/paused.js
@@ -15,9 +15,14 @@ import Options, { GLOBAL_PAUSE_ID } from '/store/options.js';
 import * as OptionsObserver from '/utils/options-observer.js';
 import ManagedConfig from '/store/managed-config';
 
+import {
+  getDynamicRulesIds,
+  PAUSED_ID_RANGE,
+  PAUSED_RULE_PRIORITY,
+} from '/utils/dnr.js';
+
 // Pause / unpause hostnames
 const PAUSED_ALARM_PREFIX = 'options:revoke';
-const PAUSED_RULE_PRIORITY = 10000000;
 
 const ALL_RESOURCE_TYPES = [
   'main_frame',
@@ -75,10 +80,7 @@ OptionsObserver.addListener('paused', async (paused, lastPaused) => {
       (__PLATFORM__ === 'chromium' &&
         (await store.resolve(ManagedConfig)).disableUserControl))
   ) {
-    const removeRuleIds = (await chrome.declarativeNetRequest.getDynamicRules())
-      .filter(({ id }) => id <= 3)
-      .map(({ id }) => id);
-
+    const removeRuleIds = await getDynamicRulesIds(PAUSED_ID_RANGE);
     const hostnames = Object.keys(paused);
 
     let globalPause = false;

--- a/src/background/paused.js
+++ b/src/background/paused.js
@@ -136,7 +136,7 @@ OptionsObserver.addListener('paused', async (paused, lastPaused) => {
               ],
         removeRuleIds,
       });
-      console.log('[dnr] Pause rules updated');
+      console.log('[dnr] Pause rules updated:', hostnames.join(', '));
     } else if (removeRuleIds.length) {
       await chrome.declarativeNetRequest.updateDynamicRules({
         removeRuleIds,

--- a/src/pages/settings/components/devtools.js
+++ b/src/pages/settings/components/devtools.js
@@ -20,7 +20,9 @@ import Config, {
   FLAG_FIREFOX_CONTENT_SCRIPT_SCRIPTLETS,
   FLAG_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED,
   FLAG_EXTENDED_SELECTORS,
+  FLAG_DYNAMIC_DNR_FIXES,
 } from '/store/config.js';
+import Resources from '/store/resources.js';
 
 const VERSION = chrome.runtime.getManifest().version;
 
@@ -85,6 +87,7 @@ async function testConfigFlag(host) {
       FLAG_FIREFOX_CONTENT_SCRIPT_SCRIPTLETS,
       FLAG_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED,
       FLAG_EXTENDED_SELECTORS,
+      FLAG_DYNAMIC_DNR_FIXES,
     ].join(', '),
   );
   if (!flags) return;
@@ -126,12 +129,13 @@ export default {
   counter: 0,
   options: store(Options),
   config: store(Config),
+  resources: store(Resources),
   updatedAt: ({ options }) =>
     store.ready(options) &&
     options.filtersUpdatedAt &&
     formatDate(options.filtersUpdatedAt),
   visible: false,
-  render: ({ visible, counter, updatedAt, config }) => html`
+  render: ({ visible, counter, config, resources, updatedAt }) => html`
     <template layout="column gap:3">
       ${
         (visible || counter > 5) &&
@@ -227,6 +231,22 @@ export default {
                 <ui-button onclick="${refresh}" layout="shrink:0">
                   <button>Refresh</button>
                 </ui-button>
+              </div>
+              <ui-line></ui-line>
+            `}
+            ${store.ready(resources) &&
+            html`
+              <div layout="column gap">
+                <ui-text type="headline-s">Resource Checksums</ui-text>
+                <div>
+                  ${Object.entries(resources.checksums).map(
+                    ([key, value]) => html`
+                      <ui-text type="body-m" color="secondary">
+                        ${key}: ${value}
+                      </ui-text>
+                    `,
+                  )}
+                </div>
               </div>
               <ui-line></ui-line>
             `}

--- a/src/store/config.js
+++ b/src/store/config.js
@@ -22,6 +22,7 @@ export const FLAG_FIREFOX_CONTENT_SCRIPT_SCRIPTLETS =
 export const FLAG_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED =
   'chromium-inject-cosmetics-on-response-started';
 export const FLAG_EXTENDED_SELECTORS = 'extended-selectors';
+export const FLAG_DYNAMIC_DNR_FIXES = 'dynamic-dnr-fixes';
 
 const Config = {
   enabled: true,

--- a/src/store/options.js
+++ b/src/store/options.js
@@ -40,6 +40,8 @@ export const SYNC_OPTIONS = [
   'theme',
 ];
 
+export const REPORT_OPTIONS = [...SYNC_OPTIONS, 'filtersUpdatedAt'];
+
 export const SYNC_PROTECTED_OPTIONS = [...SYNC_OPTIONS, 'exceptions', 'paused'];
 
 export const ENGINES = [

--- a/src/store/resources.js
+++ b/src/store/resources.js
@@ -1,0 +1,35 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { store } from 'hybrids';
+
+const Resources = {
+  checksums: store.record(''),
+
+  [store.connect]: {
+    get: async () =>
+      chrome.storage.local
+        .get('resources')
+        .then(({ resources = {} }) => resources),
+    set: async (_, values) => {
+      await chrome.storage.local.set({
+        resources:
+          __PLATFORM__ === 'firefox'
+            ? JSON.parse(JSON.stringify(values))
+            : values,
+      });
+
+      return values;
+    },
+  },
+};
+
+export default Resources;

--- a/src/utils/dnr.js
+++ b/src/utils/dnr.js
@@ -1,0 +1,24 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+export const PAUSED_ID_RANGE = { start: 1, end: 1_000_000 };
+export const CUSTOM_FILTERS_ID_RANGE = { start: 1_000_000, end: 2_000_000 };
+export const EXCEPTIONS_ID_RANGE = { start: 2_000_000, end: 3_000_000 };
+export const FIXES_ID_RANGE = { start: 3_000_000, end: 4_000_000 };
+
+export const PAUSED_RULE_PRIORITY = 10_000_000;
+export const EXCEPTIONS_RULE_PRIORITY = 2_000_000;
+
+export async function getDynamicRulesIds(type) {
+  return (await chrome.declarativeNetRequest.getDynamicRules())
+    .filter((rule) => rule.id >= type.start && rule.id < type.end)
+    .map((rule) => rule.id);
+}

--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -35,3 +35,5 @@ export const REVIEW_PAGE_URL = (() => {
   // Chrome
   return 'https://mygho.st/ReviewChromePanel';
 })();
+
+export const ENGINE_CONFIGS_ROOT_URL = `https://${debugMode ? 'staging-' : ''}cdn.ghostery.com/adblocker/configs`;


### PR DESCRIPTION
Fixes #2476

Adds runtime fetch of the fixes DNR rules. 

For the compatibility layer, it falls back to the static rules `dnr-fixes.json` if the processing URL fails.

~~As there is no other way to detect if the dynamic fixes are applied, the code checks if there are any rules from the range. It means that the update/fetch procedure would run every time options are updated if there are no rules at all (I assumed this would never happen).~~

BIG UPDATE

* The `Resources` model has been added to keep `checksums` record (can keep more metadata in the future). 
* The checksum is also saved for every adblocker engine
* The code checks if the checksum is there, or if it has changed
* The broken page report options dump has been updated with added checksums and flags. From now on, the options only contain changed values (defaults are omitted).