### PR TITLE
feat(onboarding):  installation survey for Brave

### DIFF
--- a/src/background/onboarding.js
+++ b/src/background/onboarding.js
@@ -33,18 +33,7 @@ if (__PLATFORM__ === 'chromium' && getBrowser().name === 'brave') {
     async function braveSurvey(terms, lastTerms) {
       // Trigger only when user just have accepted terms
       if (lastTerms === false && terms === true) {
-        const [tab] = await chrome.tabs.query({
-          url: chrome.runtime.getURL('/pages/onboarding/index.html'),
-        });
-
-        const callback = async (tabId) => {
-          if (tabId === tab?.id) {
-            chrome.tabs.create({ url: BRAVE_SURVEY_URL, active: true });
-            chrome.tabs.onRemoved.removeListener(callback);
-          }
-        };
-
-        chrome.tabs.onRemoved.addListener(callback);
+        chrome.tabs.create({ url: BRAVE_SURVEY_URL, active: true });
       }
     },
   );

--- a/src/background/pin-it.js
+++ b/src/background/pin-it.js
@@ -18,7 +18,15 @@ import { getBrowser } from '/utils/browser-info.js';
 
 import { openNotification } from './notifications.js';
 
-if (__PLATFORM__ === 'chromium' && getBrowser() !== 'oculus') {
+const browser = getBrowser();
+
+if (
+  __PLATFORM__ === 'chromium' &&
+  browser.name !== 'oculus' &&
+  // This is temporary check to avoid showing the notification in Brave browser
+  // TODO: Remove this check when Brave survey is no longer needed
+  browser.name !== 'brave'
+) {
   chrome.webNavigation.onCompleted.addListener(async (details) => {
     if (
       details.frameId !== 0 ||


### PR DESCRIPTION
Fixes https://github.com/ghostery/journal/issues/547

I tried a number of different ways, but the `onbeforeunload` event only allows opening a prompt. Messages to the background script are not sent (the tab is closed before the event can go out). We also cannot rely on the `tabId` returned when we open onboarding, as it might be closed and open again.

After all, the simplest and reliable way is to listen for `terms` change and removal of tabs. 