### PR TITLE
fix(dnr): dynamic import of converter module in Safari

### DIFF
--- a/src/utils/dnr-converter.js
+++ b/src/utils/dnr-converter.js
@@ -25,7 +25,7 @@ export default async function convert(filters) {
         filters,
       });
     } else if (__PLATFORM__ === 'safari') {
-      const convertWithAdguard = await import(
+      const { default: convertWithAdguard } = await import(
         '@ghostery/urlfilter2dnr/adguard'
       );
       result = await convertWithAdguard(filters);


### PR DESCRIPTION
### Bug
<img width="1452" height="424" alt="image" src="https://github.com/user-attachments/assets/d28ed3f4-2c29-47db-9475-0b1fa781a06a" />

### Reason
<img width="450" height="336" alt="Zrzut ekranu 2025-08-5 o 15 57 10" src="https://github.com/user-attachments/assets/02af8e5f-e7dd-4c79-b339-c3ae9b13fba8" />

### Solution
<img width="317" height="565" alt="Zrzut ekranu 2025-08-5 o 16 01 19" src="https://github.com/user-attachments/assets/4af3dcaf-50e7-4601-8641-9176dd507157" />