### PR TITLE
Update country config

### DIFF
--- a/src/background/reporting/config.js
+++ b/src/background/reporting/config.js
@@ -215,6 +215,7 @@ function platformSpecificSettings() {
         'pt',
         'sg',
         'nz',
+        'ng',
       ],
       PATTERNS_URL: `https://cdn2.ghostery.com/${URL_INFIX}wtm-chrome-desktop/patterns.json`,
       CHANNEL: 'chrome-desktop',


### PR DESCRIPTION
Nigeria now has enough Ghostery users to stop masking the country information.