### PR TITLE
fix(panel): open links in the same tab in Firefox Android

### DIFF
--- a/src/pages/panel/index.js
+++ b/src/pages/panel/index.js
@@ -31,18 +31,3 @@ chrome.runtime.sendMessage({ action: 'telemetry', event: 'engaged' });
 
 // Sync options with background
 chrome.runtime.sendMessage({ action: 'syncOptions' });
-
-// Close window when anchor is clicked
-document.addEventListener('click', (event) => {
-  let el = event.target;
-
-  while (el && !el.href) el = el.parentElement;
-  if (!el) return;
-
-  const { hostname, pathname } = new URL(el.href);
-
-  // Timeout is required to prevent from closing the window before the anchor is opened
-  if (hostname !== location.hostname || pathname !== location.pathname) {
-    setTimeout(window.close, 50);
-  }
-});

--- a/src/pages/settings/settings.js
+++ b/src/pages/settings/settings.js
@@ -11,7 +11,6 @@
 
 import { html, router, store } from 'hybrids';
 
-import { openTabWithUrl } from '/utils/tabs.js';
 import { HOME_PAGE_URL } from '/utils/urls.js';
 
 import Session from '/store/session.js';
@@ -152,7 +151,7 @@ export default {
                       <ui-button type="primary" layout="margin:top">
                         <a
                           href="${HOME_PAGE_URL}/become-a-contributor?utm_source=gbe&utm_campaign=settings-becomeacontributor"
-                          onclick="${openTabWithUrl}"
+                          target="_blank"
                         >
                           Become a Contributor
                         </a>

--- a/src/pages/settings/views/my-ghostery.js
+++ b/src/pages/settings/views/my-ghostery.js
@@ -11,8 +11,6 @@
 
 import { html, msg, store } from 'hybrids';
 
-import { openTabWithUrl } from '/utils/tabs.js';
-
 import Options from '/store/options.js';
 import Session from '/store/session.js';
 
@@ -123,10 +121,7 @@ export default {
                     </div>
                     <div layout="row gap">
                       <ui-button type="primary">
-                        <a
-                          href="${ACCOUNT_PAGE_URL}"
-                          onclick="${openTabWithUrl}"
-                        >
+                        <a href="${ACCOUNT_PAGE_URL}" target="_blank">
                           Account details
                           <ui-icon name="arrow-right-s"></ui-icon>
                         </a>

--- a/src/pages/settings/views/tracker-details.js
+++ b/src/pages/settings/views/tracker-details.js
@@ -16,7 +16,6 @@ import Options from '/store/options.js';
 import Tracker from '/store/tracker.js';
 
 import * as exceptions from '/utils/exceptions.js';
-import { openTabWithUrl } from '/utils/tabs.js';
 import { WTM_PAGE_URL } from '/utils/urls.js';
 
 import TrackerAddException from './tracker-add-exception.js';
@@ -236,7 +235,7 @@ export default {
                   <ui-text type="label-s" color="brand-primary" underline>
                     <a
                       href="${tracker.organization.websiteUrl}"
-                      onclick="${openTabWithUrl}"
+                      target="_blank"
                     >
                       ${tracker.organization.websiteUrl}
                     </a>
@@ -251,7 +250,7 @@ export default {
                     <ui-text type="label-s" color="brand-primary" underline>
                       <a
                         href="${tracker.organization.privacyPolicyUrl}"
-                        onclick="${openTabWithUrl}"
+                        target="_blank"
                       >
                         ${tracker.organization.privacyPolicyUrl}
                       </a>
@@ -273,7 +272,7 @@ export default {
                         href="${tracker.organization.contact.startsWith('http')
                           ? ''
                           : 'mailto:'}${tracker.organization.contact}"
-                        onclick="${openTabWithUrl}"
+                        target="_blank"
                       >
                         ${tracker.organization.contact}
                       </a>

--- a/src/utils/tabs.js
+++ b/src/utils/tabs.js
@@ -9,10 +9,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
+import { getOS } from './browser-info.js';
+
 export async function openTabWithUrl(host, event) {
   // Firefox does not support Tabs API in iframes (Trackers Preview)
-  if (__PLATFORM__ === 'firefox' && !chrome.tabs) {
+  // Firefox Android does not allow using `window.close()` in async event listeners
+  if (__PLATFORM__ === 'firefox' && (!chrome.tabs || getOS() === 'android')) {
     event.currentTarget.target = '_blank';
+    // Timeout is required to prevent from closing the window before the anchor is opened
+    setTimeout(() => window.close(), 50);
+
     return;
   }
 
@@ -31,6 +37,7 @@ export async function openTabWithUrl(host, event) {
         url: href !== tabs[0].url ? href : undefined,
       });
 
+      window.close();
       return;
     }
   } catch (e) {
@@ -38,6 +45,7 @@ export async function openTabWithUrl(host, event) {
   }
 
   chrome.tabs.create({ url: href });
+  window.close();
 }
 
 export async function getCurrentTab() {


### PR DESCRIPTION
The Firefox Android behavior for calling `window.close()` must have changed, as no longer we can call that function in any way when a user clicks on the link on the panel.

The only way to get fix the issue is to allow opening links in the popup window.

The PR also cleans up usage of `openTabWithUrl` not longer needed in settings page.