### PR TITLE
fix(trackers-preview): wheel position on bing result pages

### DIFF
--- a/src/content_scripts/trackers-preview.css
+++ b/src/content_scripts/trackers-preview.css
@@ -11,7 +11,7 @@
 
 .wtm-tracker-wheel-container {
   position: relative;
-  z-index: 100000;
+  z-index: 1;
   display: inline-flex;
   visibility: visible;
   align-items: center;


### PR DESCRIPTION
Fixes #2609

The problematic CSS rule was created for Bing result pages. Please test if both Bing and Google are fine now.