### PR TITLE
fix: feed redirect resource path option

### DIFF
--- a/src/pages/dnr-converter/index.js
+++ b/src/pages/dnr-converter/index.js
@@ -17,7 +17,9 @@ import convertWithAdguard from '@ghostery/urlfilter2dnr/adguard';
 
 export async function convert(filters) {
   try {
-    return await convertWithAdguard(filters);
+    return await convertWithAdguard(filters, {
+      resourcesPath: '/rule_resources/redirects',
+    });
   } catch (err) {
     console.error('Error converting filters:', err);
     return {

--- a/src/utils/dnr-converter.js
+++ b/src/utils/dnr-converter.js
@@ -28,7 +28,9 @@ export default async function convert(filters) {
       const { default: convertWithAdguard } = await import(
         '@ghostery/urlfilter2dnr/adguard'
       );
-      result = await convertWithAdguard(filters);
+      result = await convertWithAdguard(filters, {
+        resourcesPath: '/rule_resources/redirects',
+      });
 
       result.rules = result.rules.reduce((acc, r) => {
         try {


### PR DESCRIPTION
fixes https://github.com/ghostery/ghostery-extension/issues/2630

`urlfilter2dnr`'s `convertWithAdguard` requires `opts.resourcesPath` to be provided to update the resources' path for DNR.
The options are highly likely to be shared but I put in both places as it's not expected to be updated often.