### PR TITLE
fix(dnr): check `regexFilters` support for dynamic fixes

### DIFF
--- a/src/background/dnr.js
+++ b/src/background/dnr.js
@@ -101,6 +101,19 @@ if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') {
                     ),
               );
 
+              for (const [index, rule] of addRules.entries()) {
+                if (rule.condition.regexFilter) {
+                  const { isSupported } =
+                    await chrome.declarativeNetRequest.isRegexSupported({
+                      regex: rule.condition.regexFilter,
+                    });
+
+                  if (!isSupported) {
+                    addRules.splice(index, 1);
+                  }
+                }
+              }
+
               if (__PLATFORM__ === 'safari') {
                 addRules = addRules.reduce((acc, rule) => {
                   try {


### PR DESCRIPTION
Dynamic DNR fixes bypass the converter, so check for support of the `regexFilter` syntax must be added here too.

Currently, it looks like only Safari is affected (the ruleset from today runs in Chrome without the check).