### PR TITLE
feat(safari): merge chromium and safari platforms

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -155,7 +155,14 @@ const config = {
   resolve: {
     preserveSymlinks: true,
   },
-  define: { __PLATFORM__: JSON.stringify(argv.target) },
+  define: {
+    __PLATFORM__: JSON.stringify(
+      // Safari must use separate manifest (loaded from above), as it does not support
+      // the 'webRequest' API but the `__PLATFORM__` should return 'chromium' as
+      // the Edge on iOS/iPadOS uses the same build as for Edge Desktop
+      argv.target === 'safari' ? 'chromium' : argv.target,
+    ),
+  },
   build: {
     outDir: options.outDir,
     assetsDir: '',

--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -19,6 +19,7 @@ import scriptlets from '@ghostery/scriptlets';
 
 import Options, { ENGINES, getPausedDetails } from '/store/options.js';
 
+import { isWebkit } from '/utils/browser-info.js';
 import * as exceptions from '/utils/exceptions.js';
 import * as engines from '/utils/engines.js';
 import * as trackerdb from '/utils/trackerdb.js';
@@ -134,7 +135,7 @@ function pause(ms) {
 
 export async function reloadMainEngine() {
   // Delay the reload to avoid UI freezes in Firefox and Safari
-  if (__PLATFORM__ !== 'chromium') await pause(1000);
+  if (__PLATFORM__ === 'firefox' || isWebkit()) await pause(1000);
 
   const enabledEngines = getEnabledEngines(options);
   const resolvedEngines = (
@@ -581,7 +582,7 @@ if (__PLATFORM__ === 'firefox') {
   );
 }
 
-if (__PLATFORM__ === 'chromium') {
+if (__PLATFORM__ !== 'firefox') {
   let ENABLE_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED = false;
 
   store.resolve(Config).then((config) => {

--- a/src/background/custom-filters.js
+++ b/src/background/custom-filters.js
@@ -169,7 +169,7 @@ export async function updateCustomFilters(input, options) {
   await reloadMainEngine();
 
   // Update DNR rules for Chromium and Safari
-  if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') {
+  if (__PLATFORM__ !== 'firefox') {
     const { rules, errors } = await convert(
       [...networkFilters].map((f) => f.toString()),
     );
@@ -197,7 +197,7 @@ OptionsObserver.addListener('customFilters', async (value, lastValue) => {
     const { text } = await store.resolve(CustomFilters);
     await updateCustomFilters(text, value);
   } else if (
-    (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') &&
+    __PLATFORM__ !== 'firefox' &&
     lastValue &&
     // Omit if `trustedScriptlets` is changed, as user then must click "save" button
     value.trustedScriptlets === lastValue.trustedScriptlets

--- a/src/background/dnr.js
+++ b/src/background/dnr.js
@@ -18,7 +18,7 @@ import { FIXES_ID_RANGE, getDynamicRulesIds } from '/utils/dnr.js';
 import * as OptionsObserver from '/utils/options-observer.js';
 import { ENGINE_CONFIGS_ROOT_URL } from '/utils/urls.js';
 
-if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') {
+if (__PLATFORM__ !== 'firefox') {
   const DNR_RESOURCES = chrome.runtime
     .getManifest()
     .declarative_net_request.rule_resources.filter(({ enabled }) => !enabled)

--- a/src/background/exceptions.js
+++ b/src/background/exceptions.js
@@ -76,7 +76,7 @@ async function updateFilters() {
   }
 }
 
-if (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') {
+if (__PLATFORM__ !== 'firefox') {
   // Update exceptions filters every time TrackerDB updates
   // It happens when all engines are updated
   OptionsObserver.addListener(

--- a/src/background/paused.js
+++ b/src/background/paused.js
@@ -73,11 +73,11 @@ OptionsObserver.addListener('paused', async (paused, lastPaused) => {
   // that this function is called before the user can change the paused state
   // in the panel or the settings page.
   if (
-    (__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') &&
+    __PLATFORM__ !== 'firefox' &&
     (lastPaused ||
       // Managed mode can update the rules at any time - so we need to update
       // the rules even if the paused state hasn't changed
-      (__PLATFORM__ === 'chromium' &&
+      (__PLATFORM__ !== 'firefox' &&
         (await store.resolve(ManagedConfig)).disableUserControl))
   ) {
     const removeRuleIds = await getDynamicRulesIds(PAUSED_ID_RANGE);

--- a/src/background/pin-it.js
+++ b/src/background/pin-it.js
@@ -14,7 +14,7 @@ import { store } from 'hybrids';
 import Options from '/store/options.js';
 import ManagedConfig from '/store/managed-config.js';
 
-import { getBrowser, getOS } from '/utils/browser-info.js';
+import { getBrowser, getOS, isWebkit } from '/utils/browser-info.js';
 
 import { openNotification } from './notifications.js';
 
@@ -22,9 +22,10 @@ const browser = getBrowser();
 const os = getOS();
 
 if (
-  __PLATFORM__ === 'chromium' &&
+  __PLATFORM__ !== 'firefox' &&
   browser.name !== 'oculus' &&
-  !(browser.name === 'edge' && (os === 'android' || os === 'ios'))
+  os !== 'android' &&
+  !isWebkit()
 ) {
   chrome.webNavigation.onCompleted.addListener(async (details) => {
     if (

--- a/src/background/reporting/webrequest-reporter.js
+++ b/src/background/reporting/webrequest-reporter.js
@@ -27,52 +27,50 @@ import urlReporter from './url-reporter.js';
 
 let webRequestReporter = null;
 
-if (__PLATFORM__ !== 'safari') {
-  let options = {};
-  OptionsObserver.addListener(function webRequestReporting(value) {
-    options = value;
-  });
+let options = {};
+OptionsObserver.addListener(function webRequestReporting(value) {
+  options = value;
+});
 
-  let remoteConfig;
-  store.resolve(Config).then((remote) => {
-    remoteConfig = remote;
-  });
+let remoteConfig;
+store.resolve(Config).then((remote) => {
+  remoteConfig = remote;
+});
 
-  webRequestReporter = new RequestReporter(config.request, {
-    onMessageReady: urlReporter.forwardRequestReporterMessage.bind(urlReporter),
-    countryProvider: urlReporter.countryProvider,
-    trustedClock: communication.trustedClock,
-    isRequestAllowed: (state) => {
-      const hostname = state.tabUrlParts.hostname;
-      return (
-        !options.blockTrackers ||
-        !!getPausedDetails(options, hostname) ||
-        remoteConfig?.hasAction(
-          hostname,
-          ACTION_DISABLE_ANTITRACKING_MODIFICATION,
-        )
-      );
-    },
-    onTrackerInteraction: (event, state) => {
-      if (event === 'observed') {
-        return;
-      }
-
-      const request = Request.fromRequestDetails({
-        url: state.url,
-        originUrl: state.tabUrl,
-      });
-      request.modified = true;
-
-      updateTabStats(state.tabId, [request]);
-    },
-  });
-
-  chrome.runtime.onMessage.addListener((msg, sender) => {
-    if (msg.action === 'mousedown') {
-      webRequestReporter.recordClick(msg.event, msg.context, msg.href, sender);
+webRequestReporter = new RequestReporter(config.request, {
+  onMessageReady: urlReporter.forwardRequestReporterMessage.bind(urlReporter),
+  countryProvider: urlReporter.countryProvider,
+  trustedClock: communication.trustedClock,
+  isRequestAllowed: (state) => {
+    const hostname = state.tabUrlParts.hostname;
+    return (
+      !options.blockTrackers ||
+      !!getPausedDetails(options, hostname) ||
+      remoteConfig?.hasAction(
+        hostname,
+        ACTION_DISABLE_ANTITRACKING_MODIFICATION,
+      )
+    );
+  },
+  onTrackerInteraction: (event, state) => {
+    if (event === 'observed') {
+      return;
     }
-  });
-}
+
+    const request = Request.fromRequestDetails({
+      url: state.url,
+      originUrl: state.tabUrl,
+    });
+    request.modified = true;
+
+    updateTabStats(state.tabId, [request]);
+  },
+});
+
+chrome.runtime.onMessage.addListener((msg, sender) => {
+  if (msg.action === 'mousedown') {
+    webRequestReporter.recordClick(msg.event, msg.context, msg.href, sender);
+  }
+});
 
 export default webRequestReporter;

--- a/src/background/serp.js
+++ b/src/background/serp.js
@@ -24,7 +24,7 @@ import { isOpera } from '/utils/browser-info.js';
 import { openNotification } from './notifications.js';
 
 // Opera SERP notification
-if (__PLATFORM__ === 'chromium' && isOpera()) {
+if (__PLATFORM__ !== 'firefox' && isOpera()) {
   const NOTIFICATION_DELAY = 7 * 24 * 60 * 60 * 1000; // 7 days in milliseconds
   const NOTIFICATION_SHOW_LIMIT = 4;
 

--- a/src/background/sync.js
+++ b/src/background/sync.js
@@ -13,7 +13,7 @@ import { store } from 'hybrids';
 import Options, { SYNC_OPTIONS } from '/store/options.js';
 import ManagedConfig from '/store/managed-config.js';
 
-import { isOpera } from '/utils/browser-info.js';
+import { isOpera, isSafari } from '/utils/browser-info.js';
 import debounce from '/utils/debounce.js';
 import * as OptionsObserver from '/utils/options-observer.js';
 
@@ -106,7 +106,7 @@ const syncOptions = debounce(
 
 // Opera provides chrome.storage.sync API, but it does not sync data between browsers
 // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/sync#browser_compatibility
-if (__PLATFORM__ !== 'safari' && !isOpera()) {
+if (!isOpera() && !isSafari()) {
   // Sync options on startup and when options change
   OptionsObserver.addListener(function sync(options, lastOptions) {
     syncOptions(options, lastOptions);

--- a/src/pages/onboarding/views/success.js
+++ b/src/pages/onboarding/views/success.js
@@ -22,7 +22,7 @@ import pinExtensionOpera from '../assets/pin-extension-opera.jpg';
 let screenshotURL = '';
 let type = '';
 
-if (__PLATFORM__ === 'chromium') {
+if (__PLATFORM__ !== 'firefox') {
   const { name } = getBrowser();
 
   if (name === 'chrome' || name === 'brave' || name === 'yandex') {
@@ -50,7 +50,7 @@ export default {
           </ui-text>
         </section>
       </ui-card>
-      ${__PLATFORM__ === 'chromium' &&
+      ${__PLATFORM__ !== 'firefox' &&
       screenshotURL &&
       html`
         <ui-card>

--- a/src/pages/panel/store/notification.js
+++ b/src/pages/panel/store/notification.js
@@ -14,7 +14,7 @@ import { store, msg } from 'hybrids';
 import Options from '/store/options.js';
 
 import { isSerpSupported } from '/utils/opera.js';
-import { isOpera } from '/utils/browser-info.js';
+import { isOpera, isSafari } from '/utils/browser-info.js';
 import { BECOME_A_CONTRIBUTOR_PAGE_URL, REVIEW_PAGE_URL } from '/utils/urls';
 
 const NOTIFICATIONS = {
@@ -22,10 +22,9 @@ const NOTIFICATIONS = {
     icon: 'triangle',
     type: 'danger',
     text: msg`Due to browser restrictions and additional permissions missing, Ghostery is not able to protect you.`,
-    url:
-      __PLATFORM__ === 'safari'
-        ? 'https://www.ghostery.com/blog/how-to-install-extensions-in-safari?utm_source=gbe&utm_campaign=safaripermissions'
-        : 'https://www.ghostery.com/support?utm_source=gbe&utm_campaign=permissions',
+    url: isSafari()
+      ? 'https://www.ghostery.com/blog/how-to-install-extensions-in-safari?utm_source=gbe&utm_campaign=safaripermissions'
+      : 'https://www.ghostery.com/support?utm_source=gbe&utm_campaign=permissions',
     action: msg`Get help`,
   },
   opera: {
@@ -65,11 +64,7 @@ const Notification = {
     if (!terms) return NOTIFICATIONS.terms;
 
     // Opera SERP support notification
-    if (
-      __PLATFORM__ === 'chromium' &&
-      isOpera() &&
-      !(await isSerpSupported())
-    ) {
+    if (__PLATFORM__ !== 'firefox' && isOpera() && !(await isSerpSupported())) {
       return NOTIFICATIONS.opera;
     }
 

--- a/src/pages/panel/views/main.js
+++ b/src/pages/panel/views/main.js
@@ -29,6 +29,7 @@ import ProtectionStatus from './protection-status.js';
 import ReportForm from './report-form.js';
 import ReportConfirm from './report-confirm.js';
 import WhoTracksMe from './whotracksme.js';
+import { isWebkit } from '/utils/browser-info.js';
 
 const SETTINGS_URL = chrome.runtime.getURL(
   '/pages/settings/index.html#@settings-privacy',
@@ -343,8 +344,7 @@ export default {
                   ontypechange="${setStatsType}"
                   layout="margin:1.5:1.5:1"
                 >
-                  ${__PLATFORM__ === 'safari' ||
-                  options.panel.statsType === 'graph'
+                  ${isWebkit() || options.panel.statsType === 'graph'
                     ? html`
                         <ui-tooltip position="bottom" slot="actions">
                           <span slot="content">WhoTracks.Me Reports</span>

--- a/src/pages/settings/components/devtools.js
+++ b/src/pages/settings/components/devtools.js
@@ -209,7 +209,7 @@ export default {
               </div>
             </div>
           `}
-          ${(__PLATFORM__ === 'chromium' || __PLATFORM__ === 'safari') &&
+          ${__PLATFORM__ !== 'firefox' &&
           html`
             <div layout="column gap items:start" translate="no">
               <ui-text type="headline-s">Enabled DNR rulesets</ui-text>

--- a/src/pages/settings/index.js
+++ b/src/pages/settings/index.js
@@ -25,18 +25,8 @@ import './styles.css';
 // we must redirect to onboarding if terms are not accepted
 Promise.all([store.resolve(Options), store.resolve(ManagedConfig)])
   .then(([{ terms }, managedConfig]) => {
-    if (!terms || managedConfig.disableUserControl)
+    if (!terms || managedConfig.disableUserControl) {
       throw new Error('Access denied');
-
-    // Safari has a bug where the back button doesn't work properly
-    // when the page is loaded from a background page by the chrome.tabs.update API
-    // In the result the `popstate` event is not fired and the router cannot
-    // re-create the previous state correctly
-    if (__PLATFORM__ === 'safari') {
-      const backFn = history.back.bind(history);
-      history.back = () => {
-        setTimeout(backFn, 200);
-      };
     }
 
     // Sync options with background

--- a/src/pages/settings/utils/backup.js
+++ b/src/pages/settings/utils/backup.js
@@ -43,7 +43,7 @@ export async function exportToFile() {
     type: 'application/json',
   });
 
-  if (__PLATFORM__ === 'safari') {
+  if (__PLATFORM__ !== 'firefox') {
     const browserInfo = await getBrowserInfo();
 
     if (browserInfo.os === 'ios' || browserInfo.os === 'ipados') {

--- a/src/pages/settings/views/my-ghostery.js
+++ b/src/pages/settings/views/my-ghostery.js
@@ -15,7 +15,7 @@ import Options from '/store/options.js';
 
 import * as backup from '../utils/backup.js';
 import ManagedConfig from '/store/managed-config.js';
-import { isOpera } from '/utils/browser-info.js';
+import { isOpera, isWebkit } from '/utils/browser-info.js';
 
 async function importSettings(host, event) {
   try {
@@ -47,8 +47,8 @@ export default {
             ${store.ready(managedConfig) &&
             !managedConfig.disableUserAccount &&
             html`
-              ${__PLATFORM__ !== 'safari' &&
-              !isOpera() &&
+              ${!isOpera() &&
+              !isWebkit() &&
               html`
                 <ui-toggle
                   value="${options.sync}"

--- a/src/store/managed-config.js
+++ b/src/store/managed-config.js
@@ -11,7 +11,7 @@
 
 import { store } from 'hybrids';
 
-import { isOpera } from '/utils/browser-info.js';
+import { isOpera, isWebkit } from '/utils/browser-info.js';
 
 const ManagedConfig = {
   disableOnboarding: false,
@@ -21,7 +21,7 @@ const ManagedConfig = {
   trustedDomains: [String],
 
   [store.connect]: async () => {
-    if (__PLATFORM__ === 'safari' || isOpera()) return {};
+    if (isOpera() || isWebkit()) return {};
 
     try {
       return (await chrome.storage.managed.get()) || {};

--- a/src/store/options.js
+++ b/src/store/options.js
@@ -12,7 +12,7 @@
 import { store } from 'hybrids';
 
 import { DEFAULT_REGIONS } from '/utils/regions.js';
-import { isOpera } from '/utils/browser-info.js';
+import { isOpera, isSafari } from '/utils/browser-info.js';
 
 import Config, {
   ACTION_PAUSE_ASSISTANT,
@@ -70,7 +70,7 @@ const Options = {
   // WhoTracks.Me
   wtmSerpReport: true,
   trackerWheel: false,
-  ...(__PLATFORM__ !== 'safari' ? { trackerCount: true } : {}),
+  ...(!isSafari() ? { trackerCount: true } : {}),
   pauseAssistant: true,
 
   // Onboarding
@@ -78,10 +78,10 @@ const Options = {
   feedback: true,
   onboarding: {
     shown: 0,
-    ...(__PLATFORM__ === 'chromium' && isOpera()
+    ...(__PLATFORM__ !== 'firefox' && isOpera()
       ? { serpShownAt: 0, serpShown: 0 }
       : {}),
-    ...(__PLATFORM__ === 'chromium' ? { pinIt: false } : {}),
+    ...(__PLATFORM__ !== 'firefox' ? { pinIt: false } : {}),
   },
 
   // UI
@@ -118,7 +118,7 @@ const Options = {
       }
 
       // Apply managed options for supported platforms
-      if (__PLATFORM__ === 'firefox' || __PLATFORM__ === 'chromium') {
+      if (__PLATFORM__ === 'firefox' || __PLATFORM__ !== 'firefox') {
         return manage(options);
       }
 

--- a/src/utils/browser-info.js
+++ b/src/utils/browser-info.js
@@ -21,15 +21,11 @@ function getUA() {
 }
 
 export function getBrowser() {
-  if (__PLATFORM__ === 'safari') {
-    return { name: 'safari', token: 'sf' };
-  }
-
   if (__PLATFORM__ === 'firefox') {
     return { name: 'firefox', token: 'ff' };
   }
 
-  if (__PLATFORM__ === 'chromium') {
+  if (__PLATFORM__ !== 'firefox') {
     // Brave's user agent detects as `Chrome`,
     // so we need to check for Brave specifically
     if (navigator.brave?.isBrave) {
@@ -43,6 +39,10 @@ export function getBrowser() {
     }
 
     const browser = getUA().browser.name;
+
+    if (browser.includes('Safari')) {
+      return { name: 'safari', token: 'sf' };
+    }
 
     if (browser.includes('Chrome')) {
       return { name: 'chrome', token: 'ch' };
@@ -77,6 +77,19 @@ export function isEdge() {
 
 export function isOpera() {
   return getBrowser().name === 'opera';
+}
+
+export function isSafari() {
+  return getBrowser().name === 'safari';
+}
+
+export function isWebkit() {
+  if (__PLATFORM__ === 'firefox') return false;
+
+  // Edge on iPadOS has OS detected as `ios`
+  if (isSafari() || getOS() === 'ios') return true;
+
+  return false;
 }
 
 export function getOS() {
@@ -118,8 +131,9 @@ export default async function getBrowserInfo() {
   };
 
   if (
-    __PLATFORM__ === 'safari' &&
+    __PLATFORM__ !== 'firefox' &&
     browserInfo.os === 'mac' &&
+    chrome.runtime.getPlatformInfo &&
     (await chrome.runtime.getPlatformInfo()).os === 'ios'
   ) {
     browserInfo.os = 'ipados';

--- a/src/utils/dnr-converter.js
+++ b/src/utils/dnr-converter.js
@@ -15,14 +15,14 @@ export default async function convert(filters) {
   let result;
 
   try {
-    if (__PLATFORM__ === 'chromium') {
+    if (chrome.offscreen) {
       await setupOffscreenDocument();
 
       result = await chrome.runtime.sendMessage({
         action: 'dnr-converter:convert',
         filters,
       });
-    } else if (__PLATFORM__ === 'safari') {
+    } else {
       const { default: convertWithAdguard } = await import(
         '@ghostery/urlfilter2dnr/adguard'
       );
@@ -31,13 +31,11 @@ export default async function convert(filters) {
       });
 
       result.errors = result.errors.map((e) => `DNR - ${e.message || e}`);
-    } else {
-      throw new Error('Unsupported platform for DNR conversion');
     }
   } catch (e) {
     return { errors: [e.message], rules: [] };
   } finally {
-    if (__PLATFORM__ === 'chromium') closeOffscreenDocument();
+    if (chrome.offscreen) closeOffscreenDocument();
   }
 
   for (const [index, rule] of result.rules.entries()) {

--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -9,7 +9,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import { isOpera, isEdge } from './browser-info.js';
+import { isOpera, isEdge, isSafari } from './browser-info.js';
 import { debugMode, stagingMode } from './debug.js';
 
 export const GHOSTERY_DOMAIN = debugMode ? 'ghosterystage.com' : 'ghostery.com';
@@ -25,10 +25,9 @@ export const SUPPORT_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/support`;
 export const WHATS_NEW_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/blog/ghostery-extension-v10-5?embed=1&utm_campaign=whatsnew`;
 
 export const REVIEW_PAGE_URL = (() => {
-  if (__PLATFORM__ === 'safari') return 'https://mygho.st/ReviewSafariPanel';
   if (__PLATFORM__ === 'firefox') return 'https://mygho.st/ReviewFirefoxPanel';
 
-  // Chromium-based browsers
+  if (isSafari()) return 'https://mygho.st/ReviewSafariPanel';
   if (isOpera()) return 'https://mygho.st/ReviewOperaPanel';
   if (isEdge()) return 'https://mygho.st/ReviewEdgePanel';
 
@@ -36,10 +35,9 @@ export const REVIEW_PAGE_URL = (() => {
   return 'https://mygho.st/ReviewChromePanel';
 })();
 
-export const BECOME_A_CONTRIBUTOR_PAGE_URL =
-  __PLATFORM__ === 'safari'
-    ? 'ghosteryapp://www.ghostery.com'
-    : 'https://www.ghostery.com/become-a-contributor';
+export const BECOME_A_CONTRIBUTOR_PAGE_URL = isSafari()
+  ? 'ghosteryapp://www.ghostery.com'
+  : 'https://www.ghostery.com/become-a-contributor';
 
 export const ENGINE_CONFIGS_ROOT_URL = `https://${debugMode ? 'staging-' : ''}cdn.ghostery.com/adblocker/configs`;
 


### PR DESCRIPTION
* Removes `safari` platform, but keeps the `manifest.safari.json` file. The Safari builds still need to be run with `npm run build safari`. Safari has a bug that prevents us from using a unified manifest from Chromium (`webRequest` permission)
* Replaces all `__PLATFORM__` checks targeting Firefox or non-Firefox platforms - we can rename it to be more general in the future
* The code that runs only in WebKit-based browsers (Safari, Edge on iOS) has a runtime check with the `isWebkit()` function or feature detection is used