### PR TITLE
fix(exceptions): improve domain toggle logic for exceptions

### DIFF
--- a/src/utils/exceptions.js
+++ b/src/utils/exceptions.js
@@ -57,8 +57,12 @@ export function toggleDomain(options, trackerId, domain, force = false) {
 
   let domains = [domain];
   if (exception) {
-    domains = exception.domains.includes(domain)
-      ? exception.domains.filter((d) => d !== domain || force)
+    const targetDomain = exception.domains.includes(domain)
+      ? domain
+      : exception.domains.find((d) => domain.endsWith(d));
+
+    domains = targetDomain
+      ? exception.domains.filter((d) => d !== targetDomain || force)
       : exception.domains.concat(domain);
   }
 


### PR DESCRIPTION
Fixes #2664. When toggling the exception on the subdomain, and only the top-level domain is set, it should be used.

## Testing

Example of top-level domain without `www` and subdomain: `wordpress.org` and `learn.wordpress.org`. 

Add an exception for GTM on the top level, open subdomain, and try to toggle the same exception. The status should change to "Blocked on all websites". 