### PR TITLE
Experiment: panel in sidebar

### DIFF
--- a/src/manifest.chromium.json
+++ b/src/manifest.chromium.json
@@ -16,7 +16,8 @@
     "tabs",
     "activeTab",
     "webRequest",
-    "offscreen"
+    "offscreen",
+    "sidePanel"
   ],
   "host_permissions": ["http://*/*", "https://*/*", "ws://*/*", "wss://*/*"],
   "icons": {
@@ -30,6 +31,9 @@
     },
     "default_title": "Ghostery",
     "default_popup": "pages/panel/index.html"
+  },
+  "side_panel": {
+    "default_path": "pages/panel/index.html"
   },
   "options_ui": {
     "page": "pages/settings/index.html",

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -36,6 +36,16 @@
     "default_title": "Ghostery",
     "default_popup": "pages/panel/index.html"
   },
+  "sidebar_action": {
+    "default_title": "Ghostery",
+    "default_panel": "pages/panel/index.html",
+    "default_icon": {
+      "32": "icons/icon.svg",
+      "64": "icons/icon.svg",
+      "128": "icons/icon.svg"
+    },
+    "open_at_install": false
+  },
   "options_ui": {
     "page": "pages/settings/index.html",
     "open_in_tab": true


### PR DESCRIPTION
This is a POC of running Ghostery Panel in browser sidebar.

TODO:
* [ ] adjust UI for sidebar's minimum width
* [ ] update tabs stats while switching tabs