### PR TITLE
fix(safari): check `chrome.webRequest` support in runtime

### DIFF
--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -582,7 +582,7 @@ if (__PLATFORM__ === 'firefox') {
   );
 }
 
-if (__PLATFORM__ !== 'firefox') {
+if (__PLATFORM__ !== 'firefox' && chrome.webRequest?.onResponseStarted) {
   let ENABLE_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED = false;
 
   store.resolve(Config).then((config) => {

--- a/src/background/stats.js
+++ b/src/background/stats.js
@@ -383,7 +383,7 @@ if (__PLATFORM__ !== 'firefox') {
   });
 }
 
-if (__PLATFORM__ !== 'firefox') {
+if (__PLATFORM__ !== 'firefox' && chrome.webRequest) {
   // Gather stats for requests that are not main_frame
   chrome.webRequest.onBeforeRequest.addListener(
     (details) => {

--- a/src/manifest.safari.json
+++ b/src/manifest.safari.json
@@ -14,7 +14,8 @@
     "storage",
     "scripting",
     "tabs",
-    "activeTab"
+    "activeTab",
+    "webRequest"
   ],
   "host_permissions": ["http://*/*", "https://*/*", "ws://*/*", "wss://*/*"],
   "icons": {


### PR DESCRIPTION
For unknown reason Safari might not provide `chrome.webRequest` API on iPadOS 18.6.2.

However, from my testing, adding `webRequest` permission only shows error message in the extension settings, but the background page starts properly in iOS/iPadOS 18.6.2. 

The error message is gone in Safari 26 (macOS). 