### PR TITLE
fix(managed): paused rules & minor clean up

### DIFF
--- a/src/background/config.js
+++ b/src/background/config.js
@@ -12,8 +12,6 @@
 import { store } from 'hybrids';
 
 import Config from '/store/config.js';
-import Options from '/store/options.js';
-import ManagedConfig from '/store/managed-config.js';
 
 import { CDN_URL } from '/utils/urls.js';
 import * as OptionsObserver from '/utils/options-observer.js';
@@ -97,10 +95,6 @@ export default async function syncConfig() {
 
     // Update the config
     await store.set(Config, { domains, flags, updatedAt: Date.now() });
-
-    // Managed options relays on the config, so we need to invalidate them
-    const managedConfig = await store.resolve(ManagedConfig);
-    if (managedConfig.disableUserControl) store.clear(Options);
 
     console.log('[config] Remote config synced');
   } catch (e) {

--- a/src/background/helpers.js
+++ b/src/background/helpers.js
@@ -63,6 +63,13 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 
       return true;
     }
+
+    case 'reloadExtension': {
+      setTimeout(() => chrome.runtime.reload(), 2000);
+      sendResponse('done');
+
+      break;
+    }
   }
 
   return false;

--- a/src/background/paused.js
+++ b/src/background/paused.js
@@ -77,8 +77,7 @@ OptionsObserver.addListener('paused', async (paused, lastPaused) => {
     (lastPaused ||
       // Managed mode can update the rules at any time - so we need to update
       // the rules even if the paused state hasn't changed
-      (__PLATFORM__ !== 'firefox' &&
-        (await store.resolve(ManagedConfig)).disableUserControl))
+      (await store.resolve(ManagedConfig)).trustedDomains.length > 0)
   ) {
     const removeRuleIds = await getDynamicRulesIds(PAUSED_ID_RANGE);
     const hostnames = Object.keys(paused);

--- a/src/background/serp.js
+++ b/src/background/serp.js
@@ -15,7 +15,6 @@ import { parse } from 'tldts-experimental';
 import trackersPreviewCSS from '/content_scripts/trackers-preview.css?raw';
 
 import Options, { getPausedDetails } from '/store/options.js';
-import ManagedConfig from '/store/managed-config.js';
 
 import { isSerpSupported } from '/utils/opera.js';
 import { getWTMStats } from '/utils/wtm-stats.js';
@@ -78,12 +77,8 @@ const SERP_URL_REGEXP =
 chrome.webNavigation.onCommitted.addListener(async (details) => {
   if (details.url.match(SERP_URL_REGEXP)) {
     const options = await store.resolve(Options);
-    const managedConfig = await store.resolve(ManagedConfig);
 
-    const trackersPreview =
-      options.wtmSerpReport && !managedConfig.disableTrackersPreview;
-
-    if (trackersPreview) {
+    if (options.wtmSerpReport) {
       chrome.scripting.insertCSS({
         target: {
           tabId: details.tabId,
@@ -92,10 +87,10 @@ chrome.webNavigation.onCommitted.addListener(async (details) => {
       });
     }
 
-    if (trackersPreview || options.serpTrackingPrevention) {
+    if (options.wtmSerpReport || options.serpTrackingPrevention) {
       const files = [];
 
-      if (trackersPreview) {
+      if (options.wtmSerpReport) {
         files.push('/content_scripts/trackers-preview.js');
       }
 

--- a/src/background/sync.js
+++ b/src/background/sync.js
@@ -11,7 +11,6 @@
 import { store } from 'hybrids';
 
 import Options, { SYNC_OPTIONS } from '/store/options.js';
-import ManagedConfig from '/store/managed-config.js';
 
 import { isOpera, isSafari } from '/utils/browser-info.js';
 import debounce from '/utils/debounce.js';
@@ -20,16 +19,8 @@ import * as OptionsObserver from '/utils/options-observer.js';
 const syncOptions = debounce(
   async function (options, lastOptions) {
     try {
-      const { disableUserControl, disableUserAccount } =
-        await store.resolve(ManagedConfig);
-
       // Return if sync is disabled
-      if (
-        !options.terms ||
-        !options.sync ||
-        disableUserAccount ||
-        disableUserControl
-      ) {
+      if (!options.terms || !options.sync) {
         return;
       }
 

--- a/src/pages/settings/views/whotracksme.js
+++ b/src/pages/settings/views/whotracksme.js
@@ -118,9 +118,7 @@ export default {
               </ui-toggle>
             `}
             <ui-toggle
-              value="${managedConfig.disableTrackersPreview
-                ? false
-                : options.wtmSerpReport}"
+              value="${options.wtmSerpReport}"
               onchange="${html.set(options, 'wtmSerpReport')}"
               data-qa="toggle:wtmSerpReport"
               disabled="${managedConfig.disableTrackersPreview}"

--- a/src/store/managed-config.js
+++ b/src/store/managed-config.js
@@ -12,6 +12,7 @@
 import { store } from 'hybrids';
 
 import { isOpera, isWebkit } from '/utils/browser-info.js';
+import { debugMode } from '/utils/debug.js';
 
 const ManagedConfig = {
   disableOnboarding: false,
@@ -24,6 +25,12 @@ const ManagedConfig = {
     if (isOpera() || isWebkit()) return {};
 
     try {
+      if (debugMode) {
+        const { debugManagedConfig } =
+          await chrome.storage.local.get('debugManagedConfig');
+        if (debugManagedConfig) return debugManagedConfig;
+      }
+
       return (await chrome.storage.managed.get()) || {};
     } catch {
       return {};

--- a/src/store/options.js
+++ b/src/store/options.js
@@ -228,6 +228,14 @@ async function manage(options) {
     }
   }
 
+  if (managed.disableUserAccount === true) {
+    options.sync = false;
+  }
+
+  if (managed.disableTrackersPreview === true) {
+    options.wtmSerpReport = false;
+  }
+
   managed.trustedDomains.forEach((domain) => {
     options.paused ||= {};
     options.paused[domain] = { revokeAt: 0 };

--- a/src/store/options.js
+++ b/src/store/options.js
@@ -14,10 +14,6 @@ import { store } from 'hybrids';
 import { DEFAULT_REGIONS } from '/utils/regions.js';
 import { isOpera, isSafari } from '/utils/browser-info.js';
 
-import Config, {
-  ACTION_PAUSE_ASSISTANT,
-  FLAG_PAUSE_ASSISTANT,
-} from './config.js';
 import CustomFilters from './custom-filters.js';
 import ManagedConfig from './managed-config.js';
 
@@ -216,16 +212,6 @@ async function manage(options) {
 
     // Clear out the paused state, to overwrite with the current managed state
     options.paused = {};
-
-    // Add paused domains from the config
-    const config = await store.resolve(Config);
-    if (config.hasFlag(FLAG_PAUSE_ASSISTANT)) {
-      for (const [domain, { actions }] of Object.entries(config.domains)) {
-        if (actions.includes(ACTION_PAUSE_ASSISTANT)) {
-          options.paused[domain] = { revokeAt: 0, assist: true };
-        }
-      }
-    }
   }
 
   if (managed.disableUserAccount === true) {

--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -39,7 +39,7 @@ export const BECOME_A_CONTRIBUTOR_PAGE_URL = isSafari()
   ? 'ghosteryapp://www.ghostery.com'
   : 'https://www.ghostery.com/become-a-contributor';
 
-export const ENGINE_CONFIGS_ROOT_URL = `https://${debugMode ? 'staging-' : ''}cdn.ghostery.com/adblocker/configs`;
+export const ENGINE_CONFIGS_ROOT_URL = `https://${stagingMode ? 'staging-' : ''}cdn.ghostery.com/adblocker/configs`;
 
 export const CDN_URL = stagingMode
   ? 'https://staging-cdn.ghostery.com/'

--- a/tests/e2e/spec/index.spec.js
+++ b/tests/e2e/spec/index.spec.js
@@ -13,3 +13,4 @@ import './main.spec.js';
 import './advanced.spec.js';
 import './panel.spec.js';
 import './whotracksme.spec.js';
+import './managed.spec.js';

--- a/tests/e2e/spec/managed.spec.js
+++ b/tests/e2e/spec/managed.spec.js
@@ -1,0 +1,92 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { browser, expect, $ } from '@wdio/globals';
+
+import { PAGE_DOMAIN, PAGE_URL } from '../wdio.conf.js';
+import {
+  enableExtension,
+  switchToPanel,
+  getExtensionElement,
+  getExtensionPageURL,
+  reloadExtension,
+} from '../utils.js';
+
+async function setManagedOptions(options) {
+  await browser.url(getExtensionPageURL('panel'));
+
+  await browser.execute((managedOptions) => {
+    if (managedOptions) {
+      chrome.storage.local.set({ debugManagedConfig: managedOptions });
+    } else {
+      chrome.storage.local.remove('debugManagedConfig');
+    }
+  }, options);
+
+  // Reload extension to pick up managed config changes
+  await reloadExtension();
+}
+
+async function cleanManagedOptions() {
+  await setManagedOptions();
+}
+
+describe('Managed Configuration', function () {
+  before(enableExtension);
+  afterEach(cleanManagedOptions);
+
+  it('pauses domain when added to `trustedDomains`', async function () {
+    const TRACKER_IDS = ['facebook_connect', 'pinterest_conversion_tracker'];
+
+    await setManagedOptions({ trustedDomains: [PAGE_DOMAIN] });
+
+    // Navigate to settings page to let managed config take effect
+    await browser.url(getExtensionPageURL('settings'));
+
+    // Navigate to websites link by clicking on it
+    const websitesLink = await $('a[href*="websites"]');
+    await websitesLink.click();
+
+    // Check if PAGE_URL appears in the websites table
+    // Look for text content containing PAGE_URL
+    const pageText = await $('body').getText();
+    await expect(pageText.includes(PAGE_DOMAIN)).toBe(true);
+
+    await browser.url(PAGE_URL);
+
+    await switchToPanel(async function () {
+      await getExtensionElement('button:detailed-view').click();
+
+      for (const trackerId of TRACKER_IDS) {
+        await expect(
+          getExtensionElement(`icon:tracker:${trackerId}:blocked`),
+        ).not.toBeDisplayed();
+        await expect(
+          getExtensionElement(`icon:tracker:${trackerId}:modified`),
+        ).not.toBeDisplayed();
+      }
+    });
+  });
+
+  it('hides menu in panel when `disableUserControl` is enabled', async function () {
+    await switchToPanel(async () => {
+      const menuButton = await getExtensionElement('button:menu');
+      await expect(menuButton).toBeDisplayed();
+    });
+
+    await setManagedOptions({ disableUserControl: true });
+
+    await switchToPanel(async () => {
+      const menuButton = await getExtensionElement('button:menu');
+      await expect(menuButton).not.toBeDisplayed();
+    });
+  });
+});

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -108,3 +108,27 @@ export async function switchToPanel(fn) {
   if (error) throw error;
   return result;
 }
+
+export async function reloadExtension() {
+  await browser.url('about:blank');
+
+  await browser[browser.isFirefox ? 'newWindow' : 'url'](
+    getExtensionPageURL('panel'),
+  );
+
+  const result = await browser.execute(
+    browser.isChromium
+      ? () => chrome.runtime.sendMessage({ action: 'reloadExtension' })
+      : () => browser.runtime.sendMessage({ action: 'reloadExtension' }),
+  );
+
+  if (result !== 'done') {
+    throw new Error(`Background tasks did not respond with "done": ${result}`);
+  }
+
+  if (browser.isFirefox) {
+    await browser.switchWindow('about:blank');
+  }
+
+  await browser.pause(5000);
+}

--- a/tests/e2e/wdio.conf.js
+++ b/tests/e2e/wdio.conf.js
@@ -179,6 +179,10 @@ export const config = {
         // Get the extension ID from extensions settings page
         await browser.url('chrome://extensions');
 
+        // Enable developer mode for reloading extension
+        await $('>>>#devMode').click();
+        await browser.pause(2000);
+
         const extensionId = await $('>>>extensions-item').getAttribute('id');
         setExtensionBaseUrl(`chrome-extension://${extensionId}/pages`);
       }

--- a/tests/e2e/wdio.update.conf.js
+++ b/tests/e2e/wdio.update.conf.js
@@ -126,7 +126,6 @@ export const config = {
       switch (capabilities.browserName) {
         case 'chrome': {
           await browser.url('chrome://extensions');
-          await $('>>>#devMode').click();
 
           renameSync(wdio.CHROME_PATH, `${wdio.CHROME_PATH}-old`);
           cpSync(`${wdio.CHROME_PATH}-source`, wdio.CHROME_PATH, {


### PR DESCRIPTION
* Fixes issue with updating a list of paused domains in managed mode, when `disableUserControl` is not turned on. The PR changes the condition to check the existence of `trustedDomains` in managed mode instead of relying on `disableUserControl`.
* Sets options related to managed config, rather than relying on config directly - much cleaner code
* Removes redundant action described in #2713

REBASE on merge
