### PR TITLE
fix(pause-assistant): remove redudant addition of paused domains

### DIFF
--- a/src/background/config.js
+++ b/src/background/config.js
@@ -12,8 +12,6 @@
 import { store } from 'hybrids';
 
 import Config from '/store/config.js';
-import Options from '/store/options.js';
-import ManagedConfig from '/store/managed-config.js';
 
 import { CDN_URL } from '/utils/urls.js';
 import * as OptionsObserver from '/utils/options-observer.js';
@@ -97,10 +95,6 @@ export default async function syncConfig() {
 
     // Update the config
     await store.set(Config, { domains, flags, updatedAt: Date.now() });
-
-    // Managed options relays on the config, so we need to invalidate them
-    const managedConfig = await store.resolve(ManagedConfig);
-    if (managedConfig.disableUserControl) store.clear(Options);
 
     console.log('[config] Remote config synced');
   } catch (e) {

--- a/src/store/options.js
+++ b/src/store/options.js
@@ -14,10 +14,6 @@ import { store } from 'hybrids';
 import { DEFAULT_REGIONS } from '/utils/regions.js';
 import { isOpera, isSafari } from '/utils/browser-info.js';
 
-import Config, {
-  ACTION_PAUSE_ASSISTANT,
-  FLAG_PAUSE_ASSISTANT,
-} from './config.js';
 import CustomFilters from './custom-filters.js';
 import ManagedConfig from './managed-config.js';
 
@@ -216,16 +212,6 @@ async function manage(options) {
 
     // Clear out the paused state, to overwrite with the current managed state
     options.paused = {};
-
-    // Add paused domains from the config
-    const config = await store.resolve(Config);
-    if (config.hasFlag(FLAG_PAUSE_ASSISTANT)) {
-      for (const [domain, { actions }] of Object.entries(config.domains)) {
-        if (actions.includes(ACTION_PAUSE_ASSISTANT)) {
-          options.paused[domain] = { revokeAt: 0, assist: true };
-        }
-      }
-    }
   }
 
   managed.trustedDomains.forEach((domain) => {


### PR DESCRIPTION
I've found redundant logic - leftover from the initial logic of the Pause Assistant - It did not pause the domain upfront at that time.

In current logic, this line https://github.com/ghostery/ghostery-extension/blob/main/src/background/pause-assistant.js#L42 adds the domain from the remote config upfront regardless of the state of the `ManagedConfig`.