### PR TITLE
Release v10.5.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghostery-extension",
-  "version": "10.5.10",
+  "version": "10.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ghostery-extension",
-      "version": "10.5.10",
+      "version": "10.5.11",
       "license": "GPL-3.0",
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.20.0",
@@ -1313,7 +1313,6 @@
     "node_modules/@ghostery/scriptlets": {
       "version": "1.0.0",
       "resolved": "git+ssh://git@github.com/ghostery/scriptlets.git#ddab0c800c71156fa9778ccbfc151991ea68b993",
-      "integrity": "sha512-RFXIKRkWZ0x5rYOcg5ja4xgCpCuuGV5MiNlxG3gB3OAMBP0LfDmy7KKzGfZTMv0rCEmOax0NxSb2cJxozh/AfQ==",
       "license": "GPL-3.0"
     },
     "node_modules/@ghostery/url-parser": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ghostery-extension",
   "private": true,
-  "version": "10.5.10",
+  "version": "10.5.11",
   "type": "module",
   "scripts": {
     "build": "node scripts/build.js",

--- a/xcode/Ghostery.xcodeproj/project.pbxproj
+++ b/xcode/Ghostery.xcodeproj/project.pbxproj
@@ -930,7 +930,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = T3NRR7XMGG;
@@ -951,7 +951,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MARKETING_VERSION = 10.5.10;
+				MARKETING_VERSION = 10.5.11;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -994,7 +994,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = T3NRR7XMGG;
@@ -1009,7 +1009,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MARKETING_VERSION = 10.5.10;
+				MARKETING_VERSION = 10.5.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -1093,7 +1093,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.6.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.7;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1129,7 +1129,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.6.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.7;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1228,7 +1228,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1265,7 +1265,7 @@
 				CODE_SIGN_ENTITLEMENTS = "macOS (App)/Ghostery – Privacy Ad Blocker.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;


### PR DESCRIPTION
aa1a9766775f69f7dd192bf36a62fea3ca842a04 chore(deps): bump @ghostery/scriptlets from `de28503` to `ddab0c8` (#2714)
030174c21e98416372335e7350b5a7bab0b5ea45 fix(e2e): managed config test for `trustedDomains` list
088f87abe0bc7ceb2ab0f9c3b53362d21c632df0 fix(pause-assistant): remove redudant addition of paused domains
33edc038505e649b671d4901aacc8873a8387a8f fix(managed): resolve options based on managed config
f8be1ed6d33379d08248303a001f5f39063772f7 fix(paused): update condition for rule updates in managed mode

Testing focus: pause feature, pause assistant