### PR TITLE
fix(element-picker): force reload selectors when engine version mismatch

### DIFF
--- a/src/background/element-picker.js
+++ b/src/background/element-picker.js
@@ -19,9 +19,17 @@ import { setup, reloadMainEngine } from './adblocker.js';
 
 // Observe element picker selectors to update the adblocker engine
 store.observe(ElementPickerSelectors, async (_, model, lastModel) => {
-  if (!lastModel) return;
-
   let entries = Object.entries(model.hostnames);
+
+  // Skip update if there is no change in selectors
+  // and the engine is initialized if there are selectors.
+  // The engine can be `null` if adblocker detects version mismatch.
+  if (
+    !lastModel &&
+    (entries.length ? await engines.init(engines.ELEMENT_PICKER_ENGINE) : true)
+  ) {
+    return;
+  }
 
   if (entries.length) {
     const elementPickerFilters = entries.reduce(
@@ -40,8 +48,15 @@ store.observe(ElementPickerSelectors, async (_, model, lastModel) => {
       cosmeticFilters,
       config: (await engines.init(engines.FIXES_ENGINE)).config,
     });
+
+    console.log(
+      `[element-picker] Engine updated with ${
+        elementPickerFilters.length
+      } selectors for ${entries.length} hostnames`,
+    );
   } else {
     engines.remove(engines.ELEMENT_PICKER_ENGINE);
+    console.log('[element-picker] No selectors - engine removed');
   }
 
   setup.pending && (await setup.pending);


### PR DESCRIPTION
This PR fixes the issue when adblocker library updates, so loading the element picker engine trhows an error about version mistach. 

We have to force reload the engine if this happens.

I tested the change by updating production build with older version of adblocker by `npm run start:update chromium v10.5.6`. 

As the result, the selector runs correctly with the fix, but it does not if we update without it.