### PR TITLE
fix(devtools): reload extension when clearing storage

### DIFF
--- a/src/background/devtools.js
+++ b/src/background/devtools.js
@@ -11,8 +11,6 @@
 
 import { store } from 'hybrids';
 
-import DailyStats from '/store/daily-stats';
-import Options from '/store/options.js';
 import Config from '/store/config.js';
 
 import { deleteDatabases } from '/utils/indexeddb.js';
@@ -35,18 +33,11 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
             console.error('[devtools] Error removing indexedDBs:', e);
           });
 
-          console.info('[devtools] Clearing store cache');
-          try {
-            store.clear(Options);
-            store.clear(DailyStats);
-            store.clear(Config);
-          } catch (e) {
-            console.error('[devtools] Error clearing store cache:', e);
-          }
+          // Close source tab
+          chrome.tabs.remove(sender.tab.id);
 
-          await store.resolve(Options);
-
-          sendResponse('Storage cleared');
+          // Reload extension to ensure all in-memory state is cleared
+          chrome.runtime.reload();
         } catch (e) {
           sendResponse(`[devtools] Error clearing storage: ${e}`);
         }


### PR DESCRIPTION
The extension should be reloaded at the end of the storage clearing process. 

Currently, engines are still kept in the memory after clearing IndexedDB. As it could be fixed by adding another removal action, it can happen again in the future with other features (not yet implemented). 

Instead of adding more and more clear functions to clean up SW memory, we can reload the extension (it also cleans up opened pages).