### PR TITLE
fix(e2e): prevent leaking node environment from wdio to child process

### DIFF
--- a/src/background/paused.js
+++ b/src/background/paused.js
@@ -13,7 +13,7 @@ import { store } from 'hybrids';
 
 import Options, { GLOBAL_PAUSE_ID } from '/store/options.js';
 import * as OptionsObserver from '/utils/options-observer.js';
-import ManagedConfig from '/store/managed-config';
+import ManagedConfig, { TRUSTED_DOMAINS_NONE_ID } from '/store/managed-config';
 
 import {
   getDynamicRulesIds,
@@ -77,7 +77,8 @@ OptionsObserver.addListener('paused', async (paused, lastPaused) => {
     (lastPaused ||
       // Managed mode can update the rules at any time - so we need to update
       // the rules even if the paused state hasn't changed
-      (await store.resolve(ManagedConfig)).trustedDomains.length > 0)
+      (await store.resolve(ManagedConfig)).trustedDomains[0] !==
+        TRUSTED_DOMAINS_NONE_ID)
   ) {
     const removeRuleIds = await getDynamicRulesIds(PAUSED_ID_RANGE);
     const hostnames = Object.keys(paused);

--- a/src/pages/panel/components/pause.js
+++ b/src/pages/panel/components/pause.js
@@ -97,7 +97,8 @@ export default {
           tabindex="${paused ? '-1' : '0'}"
           layout="row center self:stretch width:14"
           onclick="${!paused && !pauseList && openPauseList}"
-          onkeypress=${!paused && !pauseList && simulateClickOnEnter}
+          onkeypress="${!paused && !pauseList && simulateClickOnEnter}"
+          data-qa="button:${paused ? 'resume' : 'pause-type'}"
         >
           ${paused
             ? html`

--- a/src/store/managed-config.js
+++ b/src/store/managed-config.js
@@ -14,12 +14,14 @@ import { store } from 'hybrids';
 import { isOpera, isWebkit } from '/utils/browser-info.js';
 import { debugMode } from '/utils/debug.js';
 
+export const TRUSTED_DOMAINS_NONE_ID = '<none>';
+
 const ManagedConfig = {
   disableOnboarding: false,
   disableUserControl: false,
   disableUserAccount: false,
   disableTrackersPreview: false,
-  trustedDomains: [String],
+  trustedDomains: [TRUSTED_DOMAINS_NONE_ID],
 
   [store.connect]: async () => {
     if (isOpera() || isWebkit()) return {};

--- a/tests/e2e/spec/index.spec.js
+++ b/tests/e2e/spec/index.spec.js
@@ -9,8 +9,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
+import './managed.spec.js';
 import './main.spec.js';
 import './advanced.spec.js';
 import './panel.spec.js';
 import './whotracksme.spec.js';
-import './managed.spec.js';

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -130,5 +130,22 @@ export async function reloadExtension() {
     await browser.switchWindow('about:blank');
   }
 
-  await browser.pause(5000);
+  await browser.pause(3000);
+
+  await browser.waitUntil(
+    async () => {
+      const title = await browser.getTitle();
+      if (title !== 'Ghostery panel') {
+        await browser.url(getExtensionPageURL('panel'));
+        return false;
+      }
+
+      return true;
+    },
+    { timeout: 10000, timeoutMsg: 'Panel did not load' },
+  );
+
+  await waitForIdleBackgroundTasks();
+
+  await browser.url('about:blank');
 }

--- a/tests/e2e/wdio.update.conf.js
+++ b/tests/e2e/wdio.update.conf.js
@@ -38,7 +38,6 @@ import * as wdio from './wdio.conf.js';
 export const config = {
   ...wdio.config,
   specs: ['spec/index.spec.js'],
-  exclude: ['spec/_onboarding.spec.js'],
   onPrepare: async (config, capabilities) => {
     if (wdio.argv.clean) {
       rmSync(wdio.WEB_EXT_PATH, { recursive: true, force: true });


### PR DESCRIPTION
Fixes an issue where the build within the wdio process differs from running the build standalone. 

In short, `process.env` is shared between main and child processes, so if the main process sets something, it influences the child process. In this case, the `process.env.NODE_ENV` is set to `test` by the `wdio` command.