### PR TITLE
feat(panel): update top navigation layout and add link to logger

### DIFF
--- a/src/pages/panel/components/actions-button.js
+++ b/src/pages/panel/components/actions-button.js
@@ -26,18 +26,16 @@ export default {
       }
 
       ui-button {
-        white-space: wrap;
-        text-align: center;
         height: auto;
         font: var(--font-label-s);
       }
 
       ui-button ::slotted(*) {
-        display: flex;
-        flex-flow: column nowrap;
+        display: grid;
+        justify-items: start;
         align-items: center;
-        justify-content: center;
-        padding: 12px 8px;
+        grid-template-columns: min-content 1fr min-content;
+        padding: 4px 8px;
       }
     `,
 };

--- a/src/pages/panel/components/actions-icon.js
+++ b/src/pages/panel/components/actions-icon.js
@@ -13,17 +13,15 @@ import { html } from 'hybrids';
 
 export default {
   name: '',
-  color: '',
-  render: ({ name, color }) =>
+  render: ({ name }) =>
     html`
-      <template layout="block padding">
-        <ui-icon name="${name}" color="${color}" layout="size:3">
+      <template layout="block padding:6px ::background:brand-primary">
+        <ui-icon name="${name}" color="brand-primary" layout="size:3">
           <slot></slot>
         </ui-icon>
       </template>
     `.css`
       :host {
-        background: var(--background-${color});
         border-radius: 50%;
       }
     `,

--- a/src/pages/panel/components/actions.js
+++ b/src/pages/panel/components/actions.js
@@ -15,10 +15,10 @@ export default {
   hostname: '',
   open: false,
   render: ({ hostname, open }) => html`
-    <template layout="block">
+    <template layout="contents">
       <div
         id="button"
-        layout="fixed layer:100 top:0 left:0 right:0 height:6 row center"
+        layout="absolute layer:100 top:0 left:0 right:0 height:6 row center"
         layout@390px="height:7"
       >
         <ui-button size="s" slot="button" onclick="${html.set('open', !open)}">
@@ -36,14 +36,14 @@ export default {
       <div
         id="overlay"
         class="${{ open }}"
-        layout="fixed layer:1 inset top:6"
+        layout="absolute layer:1 inset top:6"
         onclick="${html.set('open', false)}"
       ></div>
       <div
         id="actions"
         class="${{ open }}"
         inert="${!open}"
-        layout="fixed layer:1 top:6 left:0 right:0 grid:3 gap padding:1.5"
+        layout="absolute layer:1 top:6 left:0 right:0 column gap:0.5 padding:1.5"
         onclick="${html.set('open', false)}"
       >
         <slot></slot>
@@ -80,7 +80,6 @@ export default {
     }
 
     #actions {
-      border-top: 1px solid var(--border-primary);
       background: var(--background-primary);
       transform: translateY(-100%);
       visibility: hidden;

--- a/src/pages/panel/views/main.js
+++ b/src/pages/panel/views/main.js
@@ -175,11 +175,7 @@ export default {
             ${stats.hostname &&
             managedConfig.disableUserControl &&
             html`<ui-text type="label-m">${stats.displayHostname}</ui-text>`}
-            <ui-action slot="icon">
-              <a href="https://www.ghostery.com" onclick="${openTabWithUrl}">
-                <ui-icon name="logo"></ui-icon>
-              </a>
-            </ui-action>
+            <ui-icon name="logo" slot="icon" layout="size:2.5"></ui-icon>
             ${!managedConfig.disableUserControl &&
             html`
               <ui-action slot="actions">
@@ -196,24 +192,41 @@ export default {
               <panel-actions-button
                 onclick="${openElementPicker}"
                 disabled="${paused}"
+                icon="hide-element"
               >
                 <button>
-                  <panel-actions-icon
-                    name="hide-element"
-                    color="success-primary"
-                  ></panel-actions-icon>
+                  <panel-actions-icon name="hide-element"></panel-actions-icon>
                   Hide content block
+                  <ui-icon
+                    name="chevron-right"
+                    color="tertiary"
+                    layout="size:2"
+                  ></ui-icon>
                 </button>
               </panel-actions-button>
               <panel-actions-button>
                 <a href="${router.url(ReportForm)}">
-                  <panel-actions-icon
-                    name="report"
-                    color="danger-primary"
-                  ></panel-actions-icon>
+                  <panel-actions-icon name="report"></panel-actions-icon>
                   Report a broken page
+                  <ui-icon
+                    name="chevron-right"
+                    color="tertiary"
+                    layout="size:2"
+                  ></ui-icon>
                 </a>
               </panel-actions-button>
+              ${!isWebkit() &&
+              html`<panel-actions-button>
+                <button onclick="${openLogger}">
+                  <panel-actions-icon name="open-book"></panel-actions-icon>
+                  View details logs
+                  <ui-icon
+                    name="chevron-right"
+                    color="tertiary"
+                    layout="size:2"
+                  ></ui-icon>
+                </button>
+              </panel-actions-button>`}
               <panel-actions-button>
                 <a
                   onclick="${openTabWithUrl}"
@@ -222,11 +235,13 @@ export default {
                       stats.hostname,
                   )}"
                 >
-                  <panel-actions-icon
-                    name="settings"
-                    color="wtm-primary"
-                  ></panel-actions-icon>
-                  Access website settings
+                  <panel-actions-icon name="settings"></panel-actions-icon>
+                  Open website settings
+                  <ui-icon
+                    name="link-external-m"
+                    color="tertiary"
+                    layout="size:2"
+                  ></ui-icon>
                 </a>
               </panel-actions-button>
             </panel-actions>
@@ -344,33 +359,14 @@ export default {
                   ontypechange="${setStatsType}"
                   layout="margin:1.5:1.5:1"
                 >
-                  ${isWebkit() || options.panel.statsType === 'graph'
-                    ? html`
-                        <ui-tooltip position="bottom" slot="actions">
-                          <span slot="content">WhoTracks.Me Reports</span>
-                          <ui-action-button layout="size:4.5">
-                            <a href="${router.url(WhoTracksMe)}">
-                              <ui-icon
-                                name="whotracksme"
-                                color="primary"
-                              ></ui-icon>
-                            </a>
-                          </ui-action-button>
-                        </ui-tooltip>
-                      `
-                    : html`
-                        <ui-tooltip position="bottom" slot="actions">
-                          <span slot="content" translate="no">Logger</span>
-                          <ui-action-button layout="size:4.5">
-                            <button onclick="${openLogger}">
-                              <ui-icon
-                                name="open-book"
-                                color="primary"
-                              ></ui-icon>
-                            </button>
-                          </ui-action-button>
-                        </ui-tooltip>
-                      `}
+                  <ui-tooltip position="bottom" slot="actions">
+                    <span slot="content">WhoTracks.Me Reports</span>
+                    <ui-action-button layout="size:4.5">
+                      <a href="${router.url(WhoTracksMe)}">
+                        <ui-icon name="whotracksme" color="primary"></ui-icon>
+                      </a>
+                    </ui-action-button>
+                  </ui-tooltip>
                   ${!stats.groupedTrackers.length &&
                   html`
                     <ui-list layout="grow margin:0.5:0" slot="list">


### PR DESCRIPTION
Fixes https://github.com/ghostery/collaboration-kalin/issues/47

I left the top bar layout unchanged (with a minor border update). The animation goes under the top bar, so we need to keep the icon, right menu, and top bar box shadow (as it is currently on the production). 

<img width="418" height="354" alt="Zrzut ekranu 2025-09-24 o 13 58 23" src="https://github.com/user-attachments/assets/f5efdc59-8f72-410b-b60d-1fe659436c67" />
