### PR TITLE
chore(tests): split test into separate jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -20,9 +20,31 @@ jobs:
 
       - name: Lint
         run: npm run lint
+  e2e:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: '.tool-versions'
 
-      - name: Test - installated extension
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test - Installed Extension
         run: npm run wdio
+  e2e-update:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: '.tool-versions'
 
-      - name: Test - updated extension
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test - Updated Extension
         run: npm run wdio:update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Test - Installed Extension
-        run: npm run wdio
+      - name: Test - Chrome
+        run: npm run wdio -- --target=chrome
+
+      - name: Test - Firefox
+        run: npm run wdio -- --target=firefox
   e2e-update:
     needs: lint
     runs-on: ubuntu-latest
@@ -46,5 +49,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Test - Updated Extension
-        run: npm run wdio:update
+      - name: Test - Chrome
+        run: npm run wdio:update -- --target=chrome
+
+      - name: Test - Firefox
+        run: npm run wdio:update -- --target=firefox

--- a/tests/e2e/wdio.update.conf.js
+++ b/tests/e2e/wdio.update.conf.js
@@ -42,6 +42,8 @@ export const config = {
     if (wdio.argv.clean) {
       rmSync(wdio.WEB_EXT_PATH, { recursive: true, force: true });
       mkdirSync(wdio.WEB_EXT_PATH, { recursive: true });
+    } else if (!existsSync(wdio.WEB_EXT_PATH)) {
+      mkdirSync(wdio.WEB_EXT_PATH, { recursive: true });
     }
 
     try {


### PR DESCRIPTION
Splitting tests into separate actions makes much faster rerun failed action. It should also speed up the whole process.