### PR TITLE
fix(panel): expand popup window at scrollable container on iOS

### DIFF
--- a/src/pages/panel/components/container.js
+++ b/src/pages/panel/components/container.js
@@ -40,6 +40,7 @@ export default {
     value: () => html`
       <template layout="row height::0 relative">
         <div
+          part="scrollable"
           id="scroll"
           onscroll="${updateShadow}"
           layout="grow overflow:x:hidden overflow:y:auto"

--- a/src/pages/panel/styles.css
+++ b/src/pages/panel/styles.css
@@ -23,3 +23,9 @@ body[platform-name='ios'] {
     max-height: 600px;
   }
 }
+
+@media screen and (max-height: 450px) {
+  body[platform-name='ios'] panel-container::part(scrollable) {
+    overflow-y: hidden;
+  }
+}


### PR DESCRIPTION
Without the fix, if the panel is in "list" mode, swiping up on the scrollable container (a list of trackers) does not expand the pop-up view, but only scrolls the content. As a result, there is no way to see the content below. The only way is to swipe up from a place that is not scrollable.