### PR TITLE
fix(autoconsent): remove auto-generated rules from build

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -385,6 +385,22 @@ const buildPromise = build({
     },
   },
   plugins: [
+    {
+      name: 'transform-autoconsent-rules',
+      load(id) {
+        if (id.endsWith('@duckduckgo/autoconsent/rules/rules.json')) {
+          const rules = JSON.parse(readFileSync(id, 'utf-8'));
+          const result = [];
+
+          for (const rule of rules.autoconsent) {
+            if (!rule.name.startsWith('auto_')) {
+              result.push(rule);
+            }
+          }
+          return JSON.stringify({ autoconsent: result });
+        }
+      },
+    },
     // Keep offscreen documents from @whotracksme/reporting
     {
       name: 'copy-reporting-assets',


### PR DESCRIPTION
Our filter list for Never-consent contains allow rules for selected CMPs. Recently, the `autoconsent` library introduced [automatically generated rules](https://github.com/duckduckgo/autoconsent/tree/main/rules/generated) for a significant number of sites. As the feature looks promising, we are not currently utilizing the feature, as our block rules hide most of the CMPs covered by those autoconsent rules.

The more significant impact is a huge `rules.json` file, which is transferred by the message to each page - occupying over 5MB in memory and almost 3MB in the filesystem (currently the largest file in the extension).

This PR removes auto-generated rules from the autoconsent configuration, keeping general CMPs untouched.

We can consider adding those, but without a similar change in our filter lists, it is pointless.