### PR TITLE
chore(release): GPG setup and signing process in release workflow

### DIFF
--- a/.github/workflows/release-v3.yml
+++ b/.github/workflows/release-v3.yml
@@ -57,12 +57,15 @@ jobs:
 
       - name: Setup GPG
         run: |
-          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --import
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --yes --import
           echo "trust-model always" >> ~/.gnupg/gpg.conf
-          echo "use-agent" >> ~/.gnupg/gpg.conf
+          echo "no-tty" >> ~/.gnupg/gpg.conf
+          echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
           echo "default-cache-ttl 3600" >> ~/.gnupg/gpg-agent.conf
           echo "max-cache-ttl 7200" >> ~/.gnupg/gpg-agent.conf
-          echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --batch --passphrase-fd 0 --sign --local-user 7541C764E251DA408BD645A2F8A0BDD7B2021F1E /dev/null
+          echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+          gpg-connect-agent reloadagent /bye
+          echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --batch --yes --pinentry-mode loopback --passphrase-fd 0 --sign --local-user 7541C764E251DA408BD645A2F8A0BDD7B2021F1E --output /dev/null /dev/null
 
       - name: Export GPG public key
         run: |
@@ -70,8 +73,8 @@ jobs:
 
       - name: Create PGP signatures
         run: |
-          gpg --detach-sign --armor --local-user 7541C764E251DA408BD645A2F8A0BDD7B2021F1E "ghostery-extension-${{ env.VERSION }}.zip"
-          gpg --detach-sign --armor --local-user 7541C764E251DA408BD645A2F8A0BDD7B2021F1E "ghostery-extension-${{ env.VERSION }}.tar.gz"
+          echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --batch --yes --pinentry-mode loopback --passphrase-fd 0 --detach-sign --armor --local-user 7541C764E251DA408BD645A2F8A0BDD7B2021F1E "ghostery-extension-${{ env.VERSION }}.zip"
+          echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --batch --yes --pinentry-mode loopback --passphrase-fd 0 --detach-sign --armor --local-user 7541C764E251DA408BD645A2F8A0BDD7B2021F1E "ghostery-extension-${{ env.VERSION }}.tar.gz"
 
       - name: Upload PGP signature for zip
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
1. Setup GPG step:
Added --batch --yes flags to make GPG operations non-interactive
Added no-tty and pinentry-mode loopback to the GPG configuration
Added allow-loopback-pinentry to the GPG agent configuration
Used --pinentry-mode loopback and --output /dev/null for the test signing operation
Added gpg-connect-agent reloadagent /bye to reload the GPG agent with new settings
2. Create PGP signatures step:
Added the same non-interactive flags (--batch --yes --pinentry-mode loopback --passphrase-fd 0) to ensure the signing operations don't try to prompt for input