### PR TITLE
fix(config): update macOS deployment target to 14.6

### DIFF
--- a/xcode/Ghostery.xcodeproj/project.pbxproj
+++ b/xcode/Ghostery.xcodeproj/project.pbxproj
@@ -1241,7 +1241,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MACOSX_DEPLOYMENT_TARGET = 14.6;
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
 				OTHER_LDFLAGS = (
 					"-framework",
@@ -1278,7 +1278,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MACOSX_DEPLOYMENT_TARGET = 14.6;
 				MARKETING_VERSION = "$(MARKETING_VERSION)";
 				OTHER_LDFLAGS = (
 					"-framework",


### PR DESCRIPTION
We have to bump the macOS target, as current last supported version of Safari on macOS 13 is 18.5, which we have deprected recently.

The xcode chooses `14.6` when macOS Sonoma is selected. 