### PR TITLE
chore(deps): change dependabot schedule from daily to weekly on Fridays

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,8 @@ updates:
       - dependency-name: 'tldts-experimental'
       - dependency-name: '@sentry/browser'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+      day: 'friday'
       time: '07:00'
     open-pull-requests-limit: 99
     groups:


### PR DESCRIPTION
As we usually have a release once a week, we can change the dependency update schedule to run on Friday mornings. We can see that some of our production dependencies update very often (like once a day), so we can avoid too many PRs, which bring nothing (they are overwritten by the latest update).