### PR TITLE
fix(ci): resolve GPG setup error in release workflow

### DIFF
--- a/.github/workflows/release-v3.yml
+++ b/.github/workflows/release-v3.yml
@@ -57,14 +57,16 @@ jobs:
 
       - name: Setup GPG
         run: |
-          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --yes --import
+          mkdir -p ~/.gnupg
+          chmod 700 ~/.gnupg
           echo "trust-model always" >> ~/.gnupg/gpg.conf
           echo "no-tty" >> ~/.gnupg/gpg.conf
           echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
           echo "default-cache-ttl 3600" >> ~/.gnupg/gpg-agent.conf
           echo "max-cache-ttl 7200" >> ~/.gnupg/gpg-agent.conf
           echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
-          gpg-connect-agent reloadagent /bye
+          gpg-connect-agent reloadagent /bye || true
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --yes --pinentry-mode loopback --import
           echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --batch --yes --pinentry-mode loopback --passphrase-fd 0 --sign --local-user 7541C764E251DA408BD645A2F8A0BDD7B2021F1E --output /dev/null /dev/null
 
       - name: Export GPG public key


### PR DESCRIPTION
Configure GPG directory and settings before importing key to prevent "Inappropriate ioctl for device" error in non-interactive CI environment.

fixes https://github.com/ghostery/ghostery-extension/issues/7