### PR TITLE
fix: clean up adblocker & improve remote config flags sync access

### DIFF
--- a/src/pages/onboarding/index.js
+++ b/src/pages/onboarding/index.js
@@ -37,7 +37,7 @@ Promise.all([store.resolve(Options), store.resolve(ManagedConfig)]).then(
     });
 
     mount(document.body, {
-      stack: router([Main, Success]),
+      stack: router(terms ? [Success] : [Main, Success]),
       render: ({ stack }) => html`
         <template layout="grid height::100%">
           <onboarding-layout>${stack}</onboarding-layout>

--- a/src/store/config.js
+++ b/src/store/config.js
@@ -101,6 +101,11 @@ const Config = {
     },
   },
 };
+
+chrome.storage.onChanged.addListener((changes) => {
+  if (changes['config']) store.clear(Config, false);
+});
+
 export default Config;
 
 export async function dismissAction(domain, action) {
@@ -112,6 +117,19 @@ export async function dismissAction(domain, action) {
   });
 }
 
-chrome.storage.onChanged.addListener((changes) => {
-  if (changes['config']) store.clear(Config, false);
-});
+export function resolveFlag(id) {
+  const promise = new Promise((resolve) => {
+    store.resolve(Config).then(
+      (config) => {
+        const value = config.hasFlag(id);
+
+        promise.enabled = value;
+        resolve(value);
+      },
+      () => resolve(false),
+    );
+  });
+
+  promise.enabled = false;
+  return promise;
+}

--- a/tests/e2e/spec/advanced.spec.js
+++ b/tests/e2e/spec/advanced.spec.js
@@ -51,7 +51,6 @@ describe('Advanced Features', function () {
   before(enableExtension);
 
   after(async () => {
-    await setCustomFilters([]);
     await setPrivacyToggle('custom-filters', false);
   });
 


### PR DESCRIPTION
* Added `resolveFlag` function to simplify synchronous access to remote config flags
* Clean up of `adblocker.js` body to group code by its function (cosmetics, network,etc)
*  Modified the onboarding flow to automatically skip the main setup step for users who have already accepted terms, directing them straight to the success page
*  Enhanced test utilities to better handle already-enabled extensions and added automatic extension reload after enabling to ensure proper configuration synchronization.