### PR TITLE
fix(managed): disable actions for domains from `trustedDomains`

### DIFF
--- a/src/pages/panel/components/pause.js
+++ b/src/pages/panel/components/pause.js
@@ -66,10 +66,11 @@ function simulateClickOnEnter(host, event) {
 export default {
   paused: { value: false, reflect: true },
   global: { value: false, reflect: true },
+  managed: false,
   revokeAt: 0,
   pauseType: 1,
   pauseList: { value: false, reflect: true },
-  render: ({ paused, pauseType, pauseList, revokeAt }) => html`
+  render: ({ paused, managed, revokeAt, pauseType, pauseList }) => html`
     <template layout="grid relative">
       <button
         id="main"
@@ -78,6 +79,7 @@ export default {
         layout@390px="height:7"
         onclick="${!pauseList && dispatchAction}"
         data-qa="button:pause"
+        inert="${managed}"
       >
         <div id="label" layout="grow row center gap shrink overflow">
           <ui-icon name="pause"></ui-icon>
@@ -91,33 +93,37 @@ export default {
             </ui-text>`}
           </div>
         </div>
-        <div
-          id="type"
-          role="button"
-          tabindex="${paused ? '-1' : '0'}"
-          layout="row center self:stretch width:14"
-          onclick="${!paused && !pauseList && openPauseList}"
-          onkeypress="${!paused && !pauseList && simulateClickOnEnter}"
-          data-qa="button:${paused ? 'resume' : 'pause-type'}"
-        >
-          ${paused
-            ? html`
-                <ui-icon name="play"></ui-icon>
-                <ui-text
-                  type="label-m"
-                  layout="margin:left:0.5"
-                  color="inherit"
-                >
-                  Resume
-                </ui-text>
-              `
-            : html`
-                <ui-text type="label-m" layout="grow" color="inherit">
-                  ${PAUSE_TYPES.find(({ value }) => value === pauseType).label}
-                </ui-text>
-                <ui-icon name="chevron-down"></ui-icon>
-              `}
-        </div>
+        ${!managed &&
+        html`
+          <div
+            id="type"
+            role="button"
+            tabindex="${paused ? '-1' : '0'}"
+            layout="row center self:stretch width:14"
+            onclick="${!paused && !pauseList && openPauseList}"
+            onkeypress="${!paused && !pauseList && simulateClickOnEnter}"
+            data-qa="button:${paused ? 'resume' : 'pause-type'}"
+          >
+            ${paused
+              ? html`
+                  <ui-icon name="play"></ui-icon>
+                  <ui-text
+                    type="label-m"
+                    layout="margin:left:0.5"
+                    color="inherit"
+                  >
+                    Resume
+                  </ui-text>
+                `
+              : html`
+                  <ui-text type="label-m" layout="grow" color="inherit">
+                    ${PAUSE_TYPES.find(({ value }) => value === pauseType)
+                      .label}
+                  </ui-text>
+                  <ui-icon name="chevron-down"></ui-icon>
+                `}
+          </div>
+        `}
       </button>
       <slot></slot>
       ${pauseList &&

--- a/src/pages/panel/views/main.js
+++ b/src/pages/panel/views/main.js
@@ -280,6 +280,7 @@ export default {
                 onaction="${globalPause ? revokeGlobalPause : togglePause}"
                 paused="${paused || globalPause}"
                 global="${globalPause}"
+                managed="${paused?.managed}"
                 revokeAt="${globalPause?.revokeAt || paused?.revokeAt}"
                 data-qa="component:pause"
               >

--- a/src/pages/settings/views/website-details.js
+++ b/src/pages/settings/views/website-details.js
@@ -109,16 +109,19 @@ export default {
               <settings-protection-status
                 revokeAt="${paused.revokeAt}"
               ></settings-protection-status>
-              <ui-action>
-                <button layout@768px="order:1">
-                  <ui-icon
-                    name="trash"
-                    layout="size:2.5"
-                    color="tertiary"
-                    onclick="${revokePaused}"
-                  ></ui-icon>
-                </button>
-              </ui-action>
+              ${!paused.managed &&
+              html`
+                <ui-action>
+                  <button layout@768px="order:1">
+                    <ui-icon
+                      name="trash"
+                      layout="size:2.5"
+                      color="tertiary"
+                      onclick="${revokePaused}"
+                    ></ui-icon>
+                  </button>
+                </ui-action>
+              `}
             </div>
           `}
         </div>

--- a/src/pages/settings/views/websites.js
+++ b/src/pages/settings/views/websites.js
@@ -53,9 +53,10 @@ export default {
 
     const websites = Object.entries(options.paused)
       .filter(({ id }) => id !== GLOBAL_PAUSE_ID)
-      .map(([id, { revokeAt }]) => ({
+      .map(([id, { revokeAt, managed }]) => ({
         id,
         revokeAt,
+        managed,
         exceptions: new Set(),
         counter: 0,
       }));
@@ -158,18 +159,21 @@ export default {
                           <ui-text type="label-l" ellipsis>
                             ${item.id}
                           </ui-text>
-                          <ui-action>
-                            <button
-                              layout@768px="order:1"
-                              onclick="${revokeCallback(item)}"
-                            >
-                              <ui-icon
-                                name="trash"
-                                layout="size:3"
-                                color="tertiary"
-                              ></ui-icon>
-                            </button>
-                          </ui-action>
+                          ${!item.managed &&
+                          html`
+                            <ui-action>
+                              <button
+                                layout@768px="order:1"
+                                onclick="${revokeCallback(item)}"
+                              >
+                                <ui-icon
+                                  name="trash"
+                                  layout="size:3"
+                                  color="tertiary"
+                                ></ui-icon>
+                              </button>
+                            </ui-action>
+                          `}
                           <ui-line
                             layout="area:2"
                             layout@768px="hidden"

--- a/tests/e2e/spec/managed.spec.js
+++ b/tests/e2e/spec/managed.spec.js
@@ -54,8 +54,11 @@ describe('Managed Configuration', function () {
     await browser.url(PAGE_URL);
 
     await switchToPanel(async function () {
+      const pauseButton = await getExtensionElement('button:pause');
+      await expect(pauseButton).toBeDisplayed();
+
       const resumeButton = await getExtensionElement('button:resume');
-      await expect(resumeButton).toBeDisplayed();
+      await expect(resumeButton).not.toBeDisplayed();
 
       await getExtensionElement('button:detailed-view').click();
 
@@ -74,8 +77,8 @@ describe('Managed Configuration', function () {
     await browser.url(PAGE_URL);
 
     await switchToPanel(async function () {
-      const resumeButton = await getExtensionElement('button:resume');
-      await expect(resumeButton).not.toBeDisplayed();
+      const resumeButton = await getExtensionElement('button:pause-type');
+      await expect(resumeButton).toBeDisplayed();
     });
   });
 


### PR DESCRIPTION
The resume action or deleting the domain from the list in the settings page should be disabled. 

When `trustedDomains` is used, the listed domain will always resolve to be in the `options.paused` list. The resume or remove action does not work (as it can't). 

Usually, the `disableUserControl` is used in pairs with `trustedDomains`, but if the first is not set, we must disable those actions in the panel and settings page.