### PR TITLE
fix(managed): force `pinIt` value when `disableOnboarding` is set

### DIFF
--- a/src/store/managed-config.js
+++ b/src/store/managed-config.js
@@ -24,7 +24,7 @@ const ManagedConfig = {
   trustedDomains: [TRUSTED_DOMAINS_NONE_ID],
 
   [store.connect]: async () => {
-    if (isOpera() || isWebkit()) return {};
+    if (__PLATFORM__ !== 'firefox' && (isOpera() || isWebkit())) return {};
 
     try {
       if (debugMode) {

--- a/src/store/options.js
+++ b/src/store/options.js
@@ -205,7 +205,7 @@ async function manage(options) {
 
   if (managed.disableOnboarding === true) {
     options.terms = true;
-    options.onboarding = { shown: 1 };
+    options.onboarding = { shown: 1, pinIt: true };
   }
 
   if (managed.disableUserControl === true) {


### PR DESCRIPTION
Fixes a race condition in managed config handling that could cause the "Pin It" notification to reappear after being dismissed.

Issue: When managed storage becomes temporarily unavailable, locally stored options (like onboarding.pinIt) can be cleared once managed storage recovers, causing dismissed notifications to reappear in a cyclic pattern.

Root Cause: The extension relies on managed storage for configuration, but temporary failures in the managed storage API (outside our control) can cause local storage state to be reset when the connection is restored.

Impact: Users in managed environments may experience repeated "Pin It" notifications even after dismissing them, due to the managed config sync clearing local storage state during recovery cycles.