### PR TITLE
fix(platform): update platform checks to improve code tree-shaking

### DIFF
--- a/src/background/config.js
+++ b/src/background/config.js
@@ -28,7 +28,7 @@ function filter(item) {
     // Possible values: 'chromium', 'firefox', 'webkit'
     if (check && Array.isArray(platform)) {
       check = platform.includes(
-        __PLATFORM__ === 'chromium' && isWebkit() ? 'webkit' : __PLATFORM__,
+        __PLATFORM__ !== 'firefox' && isWebkit() ? 'webkit' : __PLATFORM__,
       );
     }
 

--- a/src/background/sync.js
+++ b/src/background/sync.js
@@ -12,7 +12,7 @@ import { store } from 'hybrids';
 
 import Options, { SYNC_OPTIONS } from '/store/options.js';
 
-import { isOpera, isSafari } from '/utils/browser-info.js';
+import { isOpera, isWebkit } from '/utils/browser-info.js';
 import debounce from '/utils/debounce.js';
 import * as OptionsObserver from '/utils/options-observer.js';
 
@@ -97,7 +97,7 @@ const syncOptions = debounce(
 
 // Opera provides chrome.storage.sync API, but it does not sync data between browsers
 // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/sync#browser_compatibility
-if (!isOpera() && !isSafari()) {
+if (__PLATFORM__ === 'firefox' || (!isOpera() && !isWebkit())) {
   // Sync options on startup and when options change
   OptionsObserver.addListener(function sync(options, lastOptions) {
     syncOptions(options, lastOptions);

--- a/src/pages/panel/store/notification.js
+++ b/src/pages/panel/store/notification.js
@@ -27,9 +27,10 @@ const NOTIFICATIONS = {
     icon: 'triangle',
     type: 'danger',
     text: msg`Due to browser restrictions and additional permissions missing, Ghostery is not able to protect you.`,
-    url: isSafari()
-      ? 'https://www.ghostery.com/blog/how-to-install-extensions-in-safari?utm_source=gbe&utm_campaign=safaripermissions'
-      : 'https://www.ghostery.com/support?utm_source=gbe&utm_campaign=permissions',
+    url:
+      __PLATFORM__ !== 'firefox' && isSafari()
+        ? 'https://www.ghostery.com/blog/how-to-install-extensions-in-safari?utm_source=gbe&utm_campaign=safaripermissions'
+        : 'https://www.ghostery.com/support?utm_source=gbe&utm_campaign=permissions',
     action: msg`Get help`,
   },
   opera: {
@@ -86,7 +87,7 @@ const Notification = {
     if (!panel.notifications) return null;
 
     // Edge mobile notification for Edge desktop users
-    if (isEdge() && !isMobile()) {
+    if (__PLATFORM__ !== 'firefox' && isEdge() && !isMobile()) {
       return NOTIFICATIONS.edgeMobile;
     }
 

--- a/src/pages/settings/views/my-ghostery.js
+++ b/src/pages/settings/views/my-ghostery.js
@@ -47,8 +47,7 @@ export default {
             ${store.ready(managedConfig) &&
             !managedConfig.disableUserAccount &&
             html`
-              ${!isOpera() &&
-              !isWebkit() &&
+              ${(__PLATFORM__ === 'firefox' || (!isOpera() && !isWebkit())) &&
               html`
                 <ui-toggle
                   value="${options.sync}"

--- a/src/store/options.js
+++ b/src/store/options.js
@@ -67,7 +67,7 @@ const Options = {
   // WhoTracks.Me
   wtmSerpReport: true,
   trackerWheel: false,
-  ...(!isSafari() ? { trackerCount: true } : {}),
+  ...(__PLATFORM__ === 'firefox' || !isSafari() ? { trackerCount: true } : {}),
   pauseAssistant: true,
 
   // Onboarding

--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -35,9 +35,10 @@ export const REVIEW_PAGE_URL = (() => {
   return 'https://mygho.st/ReviewChromePanel';
 })();
 
-export const BECOME_A_CONTRIBUTOR_PAGE_URL = isSafari()
-  ? 'ghosteryapp://www.ghostery.com'
-  : 'https://www.ghostery.com/become-a-contributor';
+export const BECOME_A_CONTRIBUTOR_PAGE_URL =
+  __PLATFORM__ !== 'firefox' && isSafari()
+    ? 'ghosteryapp://www.ghostery.com'
+    : 'https://www.ghostery.com/become-a-contributor';
 
 export const ENGINE_CONFIGS_ROOT_URL = `https://${stagingMode ? 'staging-' : ''}cdn.ghostery.com/adblocker/configs`;
 


### PR DESCRIPTION
The PR udpates conditions where we can first check the `__PLATFORM__` flag value to properly tree-shake code. 

There is also a fix for `sync.js` and related settings page to match the same condition (`isWebkit()` rather than `isSafari()`).