### PR TITLE
fix(logger): decode scriptlet arguments

### DIFF
--- a/src/background/logger.js
+++ b/src/background/logger.js
@@ -71,7 +71,17 @@ chrome.runtime.onConnect.addListener(async (port) => {
         { filter },
         { url, request, filterType, callerContext },
       ) {
-        filter = String(filter);
+        if (filter.isScriptInject()) {
+          filter = String(filter);
+          const scriptInjectArgumentIndex =
+            filter.indexOf('+js(') + 4; /* '+js('.length */
+          filter =
+            filter.slice(0, scriptInjectArgumentIndex) +
+            decodeURIComponent(filter.slice(scriptInjectArgumentIndex, -1)) +
+            ')';
+        } else {
+          filter = String(filter);
+        }
 
         let data = { filter, filterType, url, tabId: callerContext?.tabId };
 


### PR DESCRIPTION
Printed scriptlet filter in the filter logger should be decoded as we ship it encoded from our backend. This pull replaces the stringified filter line with decoded argument. The approach is selected not to interfere with stringification process of adblocker library.