### PR TITLE
chore(tests): add e2e job without feature flags for `package` labeled PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
     inputs:
       flags:
@@ -60,3 +61,21 @@ jobs:
 
       - name: Test - Firefox
         run: npm run wdio:update -- --target=firefox ${{ github.event.inputs.flags && format('--flags={0}', github.event.inputs.flags) || '' }}
+  e2e-package:
+    needs: [e2e, e2e-update]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'package')
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: '.tool-versions'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test - Chrome
+        run: npm run wdio -- --target=chrome
+
+      - name: Test - Firefox
+        run: npm run wdio -- --target=firefox


### PR DESCRIPTION
The PR adds a job to run end-to-end tests without flags when the "package" label is present. It should be sufficient to run those tests on extension using a package label, like we do with each release pull request. Currently, most flags are set to 100% (we are keeping the flags for safety reasons). 

* Added a new `e2e-package` job that runs Chrome and Firefox end-to-end tests when a pull request has the "package" label. This job depends on the completion of the existing `e2e` and `e2e-update` jobs and only runs for relevant PRs.