### PR TITLE
fix(adblocker): utilize `documentId` for cosmetics injection

### DIFF
--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -230,6 +230,18 @@ export const setup = asyncSetup('adblocker', [
   ),
 ]);
 
+function resolveInjectionTarget(details) {
+  const target = { tabId: details.tabId };
+
+  if (details.documentId) {
+    target.documentIds = [details.documentId];
+  } else {
+    target.frameIds = [details.frameId];
+  }
+
+  return target;
+}
+
 const scriptletGlobals = {
   // Request a real extension resource to obtain a dynamic ID to the resource.
   // Redirect resources are defined with `use_dynamic_url` restriction.
@@ -240,7 +252,7 @@ const scriptletGlobals = {
     .slice(0, -6),
 };
 
-function injectScriptlets(filters, tabId, frameId, hostname) {
+function injectScriptlets(filters, hostname, details) {
   let contentScript = '';
   for (const filter of filters) {
     const parsed = filter.parseScript();
@@ -281,10 +293,7 @@ function injectScriptlets(filters, tabId, frameId, hostname) {
         world:
           chrome.scripting.ExecutionWorld?.MAIN ??
           (__PLATFORM__ === 'firefox' ? undefined : 'MAIN'),
-        target: {
-          tabId,
-          frameIds: [frameId],
-        },
+        target: resolveInjectionTarget(details),
         func,
         args,
       },
@@ -307,25 +316,17 @@ function injectScriptlets(filters, tabId, frameId, hostname) {
   }
 }
 
-function injectStyles(styles, tabId, frameId) {
-  const target = { tabId };
-
-  if (frameId !== undefined) {
-    target.frameIds = [frameId];
-  } else {
-    target.allFrames = true;
-  }
-
+function injectStyles(styles, details) {
   chrome.scripting
     .insertCSS({
       css: styles,
       origin: 'USER',
-      target,
+      target: resolveInjectionTarget(details),
     })
     .catch((e) => console.warn('[adblocker] failed to inject CSS', e));
 }
 
-let EXTENDED_SELECTORS = resolveFlag(FLAG_EXTENDED_SELECTORS);
+const EXTENDED_SELECTORS = resolveFlag(FLAG_EXTENDED_SELECTORS);
 
 async function injectCosmetics(details, config) {
   const { bootstrap: isBootstrap = false, scriptletsOnly } = config;
@@ -361,6 +362,8 @@ async function injectCosmetics(details, config) {
 
   const engine = engines.get(engines.MAIN_ENGINE);
 
+  // Domain specific cosmetic filters (scriptlets and styles)
+  // Execution: bootstrap, DOM mutations
   {
     const { matches } = engine.matchCosmeticFilters({
       domain,
@@ -397,7 +400,7 @@ async function injectCosmetics(details, config) {
     }
 
     if (isBootstrap) {
-      injectScriptlets(scriptFilters, tabId, frameId, hostname);
+      injectScriptlets(scriptFilters, hostname, details);
     }
 
     if (scriptletsOnly) {
@@ -414,7 +417,7 @@ async function injectCosmetics(details, config) {
     });
 
     if (styles) {
-      injectStyles(styles, tabId, frameId);
+      injectStyles(styles, details);
     }
 
     if (EXTENDED_SELECTORS.enabled && extended && extended.length > 0) {
@@ -426,13 +429,13 @@ async function injectCosmetics(details, config) {
     }
   }
 
-  if (frameId === 0 && isBootstrap) {
+  // Global cosmetic filters (styles only)
+  // Execution: bootstrap
+  if (isBootstrap) {
     const { styles } = engine.getCosmeticsFilters({
       domain,
       hostname,
       url,
-
-      // This needs to be done only once per tab
       getBaseRules: true,
       getInjectionRules: false,
       getExtendedRules: false,
@@ -440,7 +443,7 @@ async function injectCosmetics(details, config) {
       getRulesFromHostname: false,
     });
 
-    injectStyles(styles, tabId);
+    injectStyles(styles, details);
   }
 }
 


### PR DESCRIPTION
Relates to #2836.

This PR adds support for the `documentId` option of the `webNavigation.onCommited` event. This DOES NOT FIX the issue with `webRequest.onResponseStarted` event - it will break as before (explained in the https://github.com/ghostery/ghostery-extension/issues/2836#issuecomment-3496445543 comment).

Using `documentId` requires a logic change for applying global styles injection, as it can point to only a single frame at a time. Because of that, the logic must run for each frame on bootstrap, not only for the main frame. I expect that the call for global styles is quick (it does not relate to the page address, doesn't it?), and the performance mitigation only applies to the subframes, so we can keep the code unified for both platforms (I expect Firefox could have an old version, but it would complicate the code significantly). 