### PR TITLE
fix(pause-assistant): disable the feature when `disableUserControl` option is set

### DIFF
--- a/src/background/pause-assistant.js
+++ b/src/background/pause-assistant.js
@@ -13,6 +13,7 @@ import { store } from 'hybrids';
 import { parse } from 'tldts-experimental';
 
 import Config from '/store/config.js';
+import ManagedConfig from '/store/managed-config.js';
 import Options from '/store/options.js';
 
 import {
@@ -24,6 +25,9 @@ import * as OptionsObserver from '/utils/options-observer.js';
 import { openNotification } from './notifications.js';
 
 async function updatePausedDomains(config, lastConfig) {
+  const managedConfig = await store.resolve(ManagedConfig);
+  if (managedConfig.disableUserControl) return;
+
   const options = await store.resolve(Options);
 
   let paused = {};
@@ -83,6 +87,9 @@ OptionsObserver.addListener('pauseAssistant', async (value, lastValue) => {
 chrome.webNavigation.onCompleted.addListener(async (details) => {
   if (details.frameId === 0) {
     if (!(await store.resolve(Options)).pauseAssistant) return;
+
+    const managedConfig = await store.resolve(ManagedConfig);
+    if (managedConfig.disableUserControl) return;
 
     const config = await store.resolve(Config);
     if (!config.hasFlag(FLAG_PAUSE_ASSISTANT)) return;

--- a/src/store/options.js
+++ b/src/store/options.js
@@ -213,6 +213,16 @@ async function manage(options) {
 
     // Clear out the paused state, to overwrite with the current managed state
     options.paused = {};
+  } else {
+    // The user has control, so we need to remove only managed paused domains
+    // as they are overwritten by `trustedDomains` option below
+    if (options.paused) {
+      for (const domain of Object.keys(options.paused)) {
+        if (options.paused[domain].managed === true) {
+          delete options.paused[domain];
+        }
+      }
+    }
   }
 
   if (managed.disableUserAccount === true) {
@@ -223,16 +233,8 @@ async function manage(options) {
     options.wtmSerpReport = false;
   }
 
-  // Clean previous managed paused domains
-  if (options.paused) {
-    for (const domain of Object.keys(options.paused)) {
-      if (options.paused[domain].managed === true) {
-        delete options.paused[domain];
-      }
-    }
-  }
-
-  // Apply trusted domains if they are configured (they are empty or contain real domains)
+  // Apply trusted domains if they are configured
+  // (`trustedDomains` is empty or contain real domains)
   if (managed.trustedDomains[0] !== TRUSTED_DOMAINS_NONE_ID) {
     options.paused ||= {};
     managed.trustedDomains.forEach((domain) => {


### PR DESCRIPTION
Fixes #2835

* Disables the assistant when `disableUserControl` option is set
* Minor fix - refactor paused managed domains clean up to runs only when `disableUserControl` is not set - otherwise the whole `options.paused` is reset to an empty object 