### PR TITLE
fix(e2e): add `CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED` flag

### DIFF
--- a/tests/e2e/wdio.conf.js
+++ b/tests/e2e/wdio.conf.js
@@ -32,6 +32,7 @@ import {
   FLAG_FIREFOX_CONTENT_SCRIPT_SCRIPTLETS,
   FLAG_EXTENDED_SELECTORS,
   FLAG_DYNAMIC_DNR_FIXES,
+  FLAG_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED,
 } from '../../src/utils/config-types.js';
 
 export const WEB_EXT_PATH = path.join(process.cwd(), 'web-ext-artifacts');
@@ -65,6 +66,7 @@ export const argv = process.argv.slice(2).reduce(
       FLAG_FIREFOX_CONTENT_SCRIPT_SCRIPTLETS,
       FLAG_EXTENDED_SELECTORS,
       FLAG_DYNAMIC_DNR_FIXES,
+      FLAG_CHROMIUM_INJECT_COSMETICS_ON_RESPONSE_STARTED,
     ],
   },
 );


### PR DESCRIPTION
#2860 fixed the issue with `onResponseStarted` injection. We should bring back testing the feature in e2e tests.