### PR TITLE
fix(adblocker): resolve local subframe url to main frame

### DIFF
--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -446,8 +446,13 @@ chrome.webNavigation.onCommitted.addListener(
 chrome.runtime.onMessage.addListener((msg, sender) => {
   if (msg.action === 'injectCosmetics' && sender.tab) {
     // Generate details object for the sender argument
+
+    // Resolve url for the frame/subframe
+    // Local frames (about:blank, data:, etc.) do not have a proper URL
+    const url = !sender.url.startsWith('http') ? sender.origin : sender.url;
+
     const details = {
-      url: sender.url,
+      url,
       tabId: sender.tab.id,
       frameId: sender.frameId,
     };

--- a/tests/e2e/page/iframe.html
+++ b/tests/e2e/page/iframe.html
@@ -17,5 +17,10 @@
       URL-based Selector: [data-ad-name]
       <div data-ad-name="test" style="background: violet"></div>
     </section>
+
+    <section>
+      ID-based selector: #custom-filter
+      <div id="custom-filter" style="background: blue"></div>
+    </section>
   </body>
 </html>

--- a/tests/e2e/page/styles.css
+++ b/tests/e2e/page/styles.css
@@ -11,12 +11,12 @@ section {
 
 section > * {
   display: block;
-  width: 40px;
-  height: 40px;
+  width: 20px;
+  height: 20px;
 }
 
 iframe {
   width: 100%;
-  height: 100px;
+  height: 150px;
   border: none;
 }

--- a/tests/e2e/spec/advanced.spec.js
+++ b/tests/e2e/spec/advanced.spec.js
@@ -50,11 +50,11 @@ async function setCustomFilters(filters, callback) {
 describe('Advanced Features', function () {
   before(enableExtension);
 
-  after(async () => {
-    await setPrivacyToggle('custom-filters', false);
-  });
-
   describe('Custom Filters', function () {
+    after(async () => {
+      await setPrivacyToggle('custom-filters', false);
+    });
+
     it('disables custom filters', async function () {
       await setCustomFilters([`${PAGE_DOMAIN}###custom-filter`]);
       await setPrivacyToggle('custom-filters', false);
@@ -116,6 +116,20 @@ describe('Advanced Features', function () {
       await setCustomFilters([`${PAGE_DOMAIN}###custom-filter`]);
 
       await browser.url(PAGE_URL);
+      await expect($('#custom-filter')).not.toBeDisplayed();
+
+      await browser.switchFrame($('#iframe-static'));
+      await expect($('#custom-filter')).not.toBeDisplayed();
+
+      // wait for dynamic and local iframes to load
+      await browser.pause(1000);
+
+      await browser.switchFrame(null);
+      await browser.switchFrame($('#iframe-dynamic'));
+      await expect($('#custom-filter')).not.toBeDisplayed();
+
+      await browser.switchFrame(null);
+      await browser.switchFrame($('#iframe-local'));
       await expect($('#custom-filter')).not.toBeDisplayed();
     });
 


### PR DESCRIPTION
Local frames (about:blank, data:, etc.) do not have a proper URL, so we have to resolve to the `sender.origin` field of the message listener argument.

The `sender.origin` is widely supported in all platforms: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/MessageSender#browser_compatibility