### PR TITLE
fix(e2e): set explicitly no flags & minor setup fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
     inputs:
       flags:
@@ -45,7 +44,7 @@ jobs:
       - name: Test - Firefox
         run: npm run wdio -- --target=firefox ${{ github.event.inputs.flags && format('--flags={0}', github.event.inputs.flags) || '' }}
   e2e-update:
-    needs: lint
+    needs: e2e
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -61,10 +60,9 @@ jobs:
 
       - name: Test - Firefox
         run: npm run wdio:update -- --target=firefox ${{ github.event.inputs.flags && format('--flags={0}', github.event.inputs.flags) || '' }}
-  e2e-package:
-    needs: [e2e, e2e-update]
+  e2e-no-flags:
+    needs: e2e
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'package')
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -75,7 +73,7 @@ jobs:
         run: npm ci
 
       - name: Test - Chrome
-        run: npm run wdio -- --target=chrome
+        run: npm run wdio -- --target=chrome --flags=
 
       - name: Test - Firefox
-        run: npm run wdio -- --target=firefox
+        run: npm run wdio -- --target=firefox --flags=

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -30,9 +30,7 @@ export function getExtensionElement(id, query) {
 
 async function sendMessage(msg) {
   if ((await browser.getUrl()).startsWith('http')) {
-    throw new Error(
-      'Background idle state must be checked from the extension context',
-    );
+    throw new Error('Message can only be sent from the extension context');
   }
 
   const result = await browser.execute(
@@ -137,14 +135,11 @@ export async function openPanel() {
   });
 }
 
-export async function setConfigFlags(flags, force = false) {
-  if (!force && !flags.length) return;
-
-  await browser.url(getExtensionPageURL('panel'));
-
+export async function setConfigFlags(flags) {
   try {
     console.log('Setting config flags:', flags);
 
+    await browser.url(getExtensionPageURL('panel'));
     await sendMessage({ action: 'e2e:setConfigFlags', flags });
 
     // Reload the extension to apply the new config flags

--- a/tests/e2e/wdio.update.conf.js
+++ b/tests/e2e/wdio.update.conf.js
@@ -23,10 +23,8 @@ import { execSync } from 'node:child_process';
 import { $, expect } from '@wdio/globals';
 
 import {
-  enableExtension,
   getExtensionElement,
   getExtensionPageURL,
-  setConfigFlags,
   waitForIdleBackgroundTasks,
 } from './utils.js';
 import * as wdio from './wdio.conf.js';
@@ -121,7 +119,9 @@ export const config = {
     await wdio.config.before(capabilities, specs, browser);
 
     try {
-      await enableExtension();
+      // Enable the extension
+      await browser.url(getExtensionPageURL('onboarding'));
+      await getExtensionElement('button:enable').click();
 
       // Reload extension with the source
       switch (capabilities.browserName) {
@@ -165,11 +165,6 @@ export const config = {
       await waitForIdleBackgroundTasks();
 
       console.log('Extension updated...');
-
-      // TODO: Remove this once the production version supports setting config flags
-      // For now we need to set flags again, as the production build uses remote config
-      // Expected version: v10.5.18
-      await setConfigFlags(wdio.argv.flags, true);
     } catch (e) {
       console.error('Error while updating extension', e);
 


### PR DESCRIPTION
By default, the `wdio` command uses all flags. To run without them, we need to set no flags explicitly. 

I've moved a few minor fixes for setup e2e tests from #2882 - it might be better to have them separated from a feature PR.

As I've found it important to check tests without flags lately, I expect it is better to run them in every PR. I've updated relations, so the `e2e` runs first (if it fails, all other must fail too) and then the rest (`e2e-update` and `e2e-no-flags`)