### PR TITLE
Fixed "Uncaught TypeError: filter.isScriptInject is not a function"

### DIFF
--- a/src/background/logger.js
+++ b/src/background/logger.js
@@ -71,7 +71,7 @@ chrome.runtime.onConnect.addListener(async (port) => {
         { filter },
         { url, request, filterType, callerContext },
       ) {
-        if (filter.isScriptInject()) {
+        if (filterType === FilterType.COSMETIC && filter.isScriptInject()) {
           filter = String(filter);
           const scriptInjectArgumentIndex =
             filter.indexOf('+js(') + 4; /* '+js('.length */


### PR DESCRIPTION
`isScriptInject` only exists for cosmetic filters. On network filters, it is undefined.