### PR TITLE
fix(element-picker): prevent from hidding elements using `visibility` rule

### DIFF
--- a/src/content_scripts/element-picker.js
+++ b/src/content_scripts/element-picker.js
@@ -18,6 +18,7 @@ const PICKER_STYLES = `
   width: 0;
   height: 0;
   display: block;
+  visibility: visible;
   pointer-events: none;
   border-radius: 4px;
   border: 1.5px dashed #715DEE;
@@ -30,6 +31,7 @@ const POPUP_STYLES = `
   position: fixed;
   z-index: 2147483647;
   display: block;
+  visibility: visible;
   padding: 0;
   bottom: 16px;
   right: 16px;
@@ -67,6 +69,7 @@ const POPUP_IFRAME_STYLES = `
   pointer-events: all;
   user-select: none;
   -webkit-user-select: none;
+  visibility: visible;
 `;
 
 const OVERLAY_STYLES = `
@@ -74,6 +77,7 @@ const OVERLAY_STYLES = `
   inset: 0;
   z-index: 2147483645;
   display: block;
+  visibility: visible;
   cursor: default !important;
 `;
 


### PR DESCRIPTION
Fixes #2887. The site is using a kind of selector:

```css
:not(:defined) { visibility: hidden }
```

The above rule hides custom elements until they are defined. This is common practice. The custom element for the element picker is just a container, and it is never defined. We have to overwrite the rule.

From my testing, the element picker works fine again on reddit.com with the fix.