### PR TITLE
fix(managed): Add fallback source for Chromium

### DIFF
--- a/src/store/managed-config.js
+++ b/src/store/managed-config.js
@@ -32,13 +32,33 @@ const ManagedConfig = {
     if (__PLATFORM__ !== 'firefox' && (isOpera() || isWebkit())) return {};
 
     try {
-      if (debugMode) {
-        const { debugManagedConfig } =
-          await chrome.storage.local.get('debugManagedConfig');
-        if (debugManagedConfig) return debugManagedConfig;
+      // Firefox uses filesystem configuration on every platform
+      // and throws if storage.managed is not available,
+      // so we can skip fallback for it
+      let managedConfig = await chrome.storage.managed.get().catch((e) => {
+        // Allow fallback in debug mode (for e2e tests)
+        if (debugMode) return {};
+        throw e;
+      });
+
+      // Chromium-based browsers just return an empty object,
+      // and it might be available later (especially on the browser restart),
+      // so we try to read it with fallback from local storage
+      if (__PLATFORM__ !== 'firefox' || debugMode) {
+        if (Object.keys(managedConfig).length) {
+          // Save local version for fallback usage
+          // Don't await - we don't need to block on this
+          chrome.storage.local.set({ managedConfig });
+        } else {
+          // Try to get local version as fallback
+          const { managedConfig: fallbackConfig } =
+            await chrome.storage.local.get('managedConfig');
+
+          managedConfig = fallbackConfig;
+        }
       }
 
-      return (await chrome.storage.managed.get()) || {};
+      return managedConfig || {};
     } catch {
       return {};
     }

--- a/tests/e2e/spec/managed.spec.js
+++ b/tests/e2e/spec/managed.spec.js
@@ -21,16 +21,16 @@ import {
   waitForIdleBackgroundTasks,
 } from '../utils.js';
 
-async function setManagedOptions(options) {
+async function setManagedConfig(config) {
   await browser.url(getExtensionPageURL('panel'));
 
-  await browser.execute((managedOptions) => {
-    if (managedOptions) {
-      chrome.storage.local.set({ debugManagedConfig: managedOptions });
+  await browser.execute((managedConfig) => {
+    if (managedConfig) {
+      chrome.storage.local.set({ managedConfig });
     } else {
-      chrome.storage.local.remove('debugManagedConfig');
+      chrome.storage.local.remove('managedConfig');
     }
-  }, options);
+  }, config);
 
   await waitForIdleBackgroundTasks();
 
@@ -38,18 +38,18 @@ async function setManagedOptions(options) {
   await reloadExtension();
 }
 
-async function cleanManagedOptions() {
-  await setManagedOptions();
+async function cleanManagedConfig() {
+  await setManagedConfig();
 }
 
 describe('Managed Configuration', function () {
   before(enableExtension);
-  after(cleanManagedOptions);
+  after(cleanManagedConfig);
 
   it('pauses domains added to `trustedDomains`', async function () {
     const TRACKER_IDS = ['facebook_connect', 'pinterest_conversion_tracker'];
 
-    await setManagedOptions({ trustedDomains: [PAGE_DOMAIN] });
+    await setManagedConfig({ trustedDomains: [PAGE_DOMAIN] });
 
     await browser.url(PAGE_URL);
 
@@ -71,7 +71,7 @@ describe('Managed Configuration', function () {
       ).not.toBeDisplayed();
     }
 
-    await setManagedOptions({ trustedDomains: [] });
+    await setManagedConfig({ trustedDomains: [] });
 
     await browser.url(PAGE_URL);
 
@@ -84,7 +84,7 @@ describe('Managed Configuration', function () {
     await openPanel();
     await expect(getExtensionElement('button:menu')).toBeDisplayed();
 
-    await setManagedOptions({ disableUserControl: true });
+    await setManagedConfig({ disableUserControl: true });
 
     await openPanel();
     await expect(getExtensionElement('button:menu')).not.toBeDisplayed();


### PR DESCRIPTION
Fixes #2817. 

I checked the linked extension's sources, and it looks like they had startup issues only on browser restart when the extension starts for the very first time. The issues are based on Chromium 98 (https://github.com/EFForg/privacybadger/issues/2832).

Our users have never reported an issue with displaying onboarding when it is disabled. However, we had an issue with an already working instance, where the pin-it notification has been shown. The only source of that was the absence of the managed storage data when the SW restarts.

I am against polling the managed storage. Our data model is different, and it would extend the loading time of the `ManagedConfig` model, which is an essential path for loading `Options`. 

However, we can keep the latest fetched options as a fallback source. The only drawback of that approach is one additional call to local storage.


