### PR TITLE
fix(utils): unused urls clean up

### DIFF
--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -17,10 +17,6 @@ export const GHOSTERY_DOMAIN = debugMode ? 'ghosterystage.com' : 'ghostery.com';
 export const TERMS_AND_CONDITIONS_URL = `https://www.${GHOSTERY_DOMAIN}/privacy/ghostery-terms-and-conditions?utm_source=gbe&utm_campaign=onboarding`;
 export const HOME_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/`;
 
-export const SIGNON_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/signin`;
-export const CREATE_ACCOUNT_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/register`;
-export const ACCOUNT_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/account`;
-
 export const WTM_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/whotracksme`;
 export const SUPPORT_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/support`;
 export const WHATS_NEW_PAGE_URL = `https://www.${GHOSTERY_DOMAIN}/blog/ghostery-extension-v10-5?embed=1&utm_campaign=whatsnew`;


### PR DESCRIPTION
I am not sure how, but the https://github.com/ghostery/ghostery-extension/commit/bd5679c08b6e3116b129940fa7685000124da3c8#diff-2f58fd8ed6d4d858d17f8297d7739f9a7e1ca31b63e18f8e97532843ca9dcf18 brought back already removed URLs. It must have been while merging with the main branch.