### PR TITLE
fix(devtools): pernament local feature flags

### DIFF
--- a/src/background/config.js
+++ b/src/background/config.js
@@ -87,9 +87,10 @@ export default async function syncConfig() {
         flags[name] = null;
         continue;
       }
+
       // Generate local percentage only once for each flag
       const percentage =
-        flags[name]?.percentage || Math.floor(Math.random() * 100) + 1;
+        flags[name]?.percentage ?? Math.floor(Math.random() * 100) + 1;
 
       flags[name] = {
         percentage,

--- a/src/pages/settings/components/devtools.js
+++ b/src/pages/settings/components/devtools.js
@@ -103,7 +103,13 @@ async function testConfigDomain() {
 
 function toggleFlag(name) {
   return async (host, event) => {
-    await setConfig({ flags: { [name]: { enabled: event.target.checked } } });
+    await setConfig({
+      flags: {
+        [name]: event.target.checked
+          ? { percentage: 0, enabled: event.target.checked }
+          : null,
+      },
+    });
   };
 }
 


### PR DESCRIPTION
It changes the logic, so the feature flag enabled on local instance keeps its value after syncing remote configuration.