### PR TITLE
feat(onboarding): installation survey

### DIFF
--- a/src/background/onboarding.js
+++ b/src/background/onboarding.js
@@ -8,17 +8,45 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
+import { store } from 'hybrids';
+import { FLAG_ONBOARDING_SURVEY } from '@ghostery/config';
+
+import Config from '/store/config.js';
+import Options from '/store/options.js';
+
+import { isBrave } from '/utils/browser-info.js';
 import { debugMode } from '/utils/debug';
 import * as OptionsObserver from '/utils/options-observer.js';
 
-OptionsObserver.addListener('onboarding', (onboarding) => {
+export const SURVEY_URL =
+  'https://blocksurvey.io/install-survey-postonboarding-R6q0d5dGR9OY6202iNPmGQ?v=o';
+
+OptionsObserver.addListener('onboarding', async (onboarding) => {
   if (!onboarding.shown) {
     // The onboarding page should not be shown in debug mode especially for the e2e tests
     // which fails if after initializing the extension additional tabs are opened
     if (debugMode) return;
 
-    chrome.tabs.create({
+    const tab = await chrome.tabs.create({
       url: chrome.runtime.getURL('/pages/onboarding/index.html'),
     });
+
+    if (!isBrave()) {
+      // Add listener to show survey after onboarding tab is closed
+      chrome.tabs.onRemoved.addListener(async function listener(closedTabId) {
+        if (closedTabId === tab.id) {
+          chrome.tabs.onRemoved.removeListener(listener);
+
+          const config = await store.resolve(Config);
+          const options = await store.resolve(Options);
+
+          if (!options.terms || !config.hasFlag(FLAG_ONBOARDING_SURVEY)) {
+            return;
+          }
+
+          chrome.tabs.create({ url: SURVEY_URL });
+        }
+      });
+    }
   }
 });

--- a/src/background/pin-it.js
+++ b/src/background/pin-it.js
@@ -17,6 +17,7 @@ import ManagedConfig from '/store/managed-config.js';
 import { getBrowser, getOS, isWebkit } from '/utils/browser-info.js';
 
 import { openNotification } from './notifications.js';
+import { SURVEY_URL } from './onboarding.js';
 
 const browser = getBrowser();
 const os = getOS();
@@ -45,9 +46,11 @@ if (
       managedConfig.disableUserControl ||
       managedConfig.disableOnboarding ||
       // The notification was already shown
-      onboarding.pinIt
+      onboarding.pinIt ||
+      // Opened page is the onboarding survey
+      details.url === SURVEY_URL
     ) {
-      return false;
+      return;
     }
 
     openNotification({

--- a/src/utils/browser-info.js
+++ b/src/utils/browser-info.js
@@ -67,6 +67,10 @@ export function getBrowser() {
   }
 }
 
+export function isBrave() {
+  return getBrowser().name === 'brave';
+}
+
 export function isFirefox() {
   return getBrowser().name === 'firefox';
 }


### PR DESCRIPTION
Fixes https://github.com/ghostery/journal/issues/615

The survey is triggered for all browsers except Brave when a user closes the onboarding page while Ghostery has been enabled and the feature flag is turned on (`onboarding-survey`). 

For the safest solution, the listener for tab removal is attached when the onboarding is shown automatically after the installation. This code runs only once if the onboarding page is successfully displayed.

### Testing

Before closing the onboarding page, but after enabling Ghostery, open the Settings page and enable the `onboarding-survey` feature flag. Then, go back to the onboarding page and close the tab. You should see the survey page.