### PR TITLE
fix(github-actions): add debug build to package creation

### DIFF
--- a/.github/workflows/artifact-upload.yml
+++ b/.github/workflows/artifact-upload.yml
@@ -31,12 +31,16 @@ jobs:
         run: npm ci
         working-directory: .
       - name: Build packages
-        run: npm run package -- --simple
+        run: |
+          npm run package -- --simple
+          npm run package -- --simple --debug
       - name: Uncompress packages
         run: |
           for PLATFORM in firefox chromium; do
             mkdir web-ext-artifacts/ghostery-$PLATFORM
             unzip "web-ext-artifacts/ghostery-$PLATFORM.zip" -d "web-ext-artifacts/ghostery-$PLATFORM"
+            mkdir "web-ext-artifacts/ghostery-$PLATFORM-debug"
+            unzip "web-ext-artifacts/ghostery-$PLATFORM-debug.zip" -d "web-ext-artifacts/ghostery-$PLATFORM-debug"
           done
       - name: Upload Chromium build
         uses: actions/upload-artifact@v4
@@ -44,9 +48,21 @@ jobs:
           name: ghostery-chromium-${{ env.VERSION }}-${{ env.SHA }}
           path: web-ext-artifacts/ghostery-chromium/*
           if-no-files-found: error
+      - name: Upload Chromium debug build
+        uses: actions/upload-artifact@v4
+        with:
+          name: ghostery-chromium-${{ env.VERSION }}-${{ env.SHA }}-debug
+          path: web-ext-artifacts/ghostery-chromium-debug/*
+          if-no-files-found: error
       - name: Upload Firefox build
         uses: actions/upload-artifact@v4
         with:
           name: ghostery-firefox-${{ env.VERSION }}-${{ env.SHA }}
           path: web-ext-artifacts/ghostery-firefox/*
+          if-no-files-found: error
+      - name: Upload Firefox debug build
+        uses: actions/upload-artifact@v4
+        with:
+          name: ghostery-firefox-${{ env.VERSION }}-${{ env.SHA }}-debug
+          path: web-ext-artifacts/ghostery-firefox-debug/*
           if-no-files-found: error

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -4,12 +4,16 @@ set -e
 
 SHA=''
 SIMPLE=''
+DEBUG=''
 for val in $@; do
   if [ $val == '--simple' ]; then
     SIMPLE=1
   fi
   if [ $val == '--sha' ]; then
     SHA=$(git rev-parse --short HEAD)
+  fi
+  if [ $val == '--debug' ]; then
+    DEBUG='--debug'
   fi
 done
 
@@ -22,13 +26,16 @@ for PLATFORM in firefox chromium; do
   echo "##################################"
   echo
 
-  npm run build -- $PLATFORM --silent
+  npm run build -- $PLATFORM --silent $DEBUG
   NAME="ghostery-$PLATFORM"
   if ! [ $SIMPLE ]; then
     NAME+="-$VERSION"
     if [ $SHA ]; then
       NAME+="-$SHA"
     fi
+  fi
+  if [ $DEBUG ]; then
+    NAME+="-debug"
   fi
   NAME+=".zip"
 


### PR DESCRIPTION
Some of the new features require running the extension in debug mode for testing. This PR adds builds in debug mode, when the `package` label is used.