### PR TITLE
fix(panel): hide logo and menu button when website actions are visible

### DIFF
--- a/src/pages/panel/components/actions.js
+++ b/src/pages/panel/components/actions.js
@@ -39,10 +39,17 @@ export default {
         </ui-button>
       </div>
       <div
-        id="overlay"
+        id="overlay-header"
+        class="${{ open }}"
+        layout="absolute layer:101 top:0 left:0 right:0 height:6"
+        layout@390px="height:7"
+      ></div>
+      <div
+        id="overlay-actions"
         class="${{ open }}"
         layout="absolute layer:1 inset top:6"
         onclick="${html.set('open', false)}"
+        inert="${!open}"
       ></div>
       <div
         id="actions"
@@ -71,15 +78,23 @@ export default {
       pointer-events: all;
     }
 
-    #overlay {
+    #overlay-header, #overlay-actions {
       opacity: 0;
       pointer-events: none;
       transition: opacity 0.2s ease-out;
+    }
+
+    #overlay-header {
+      background: var(--background-primary);
+    }
+
+    #overlay-actions {
       background: var(--component-custom-token-modal-overlay);
       backdrop-filter: blur(2px);
     }
 
-    #overlay.open {
+    #overlay-header.open,
+    #overlay-actions.open {
       opacity: 1;
       pointer-events: all;
     }


### PR DESCRIPTION
Fixes https://github.com/ghostery/collaboration-kalin/issues/76

I tried a few approaches, but this one makes no changes in the logic structure. Also, it does not touch other UI elements, but it adds an overlay layer on top of the header, so the logo and menu button hide when the website menu is open. There is no "going up" animation (as then it would touch those separated elements), but the final effect is achieved.


https://github.com/user-attachments/assets/d9903cfc-d336-4d91-a480-e2d280f36554

