### PR TITLE
fix(e2e): prevent arguments serialization issue on Firefox

### DIFF
--- a/tests/e2e/spec/managed.spec.js
+++ b/tests/e2e/spec/managed.spec.js
@@ -24,13 +24,19 @@ import {
 async function setManagedConfig(config) {
   await browser.url(getExtensionPageURL('panel'));
 
-  await browser.execute((managedConfig) => {
-    if (managedConfig) {
-      chrome.storage.local.set({ managedConfig });
-    } else {
-      chrome.storage.local.remove('managedConfig');
-    }
-  }, config);
+  await browser.execute(
+    (managedConfigStr) => {
+      const managedConfig = managedConfigStr
+        ? JSON.parse(managedConfigStr)
+        : null;
+      if (managedConfig) {
+        chrome.storage.local.set({ managedConfig });
+      } else {
+        chrome.storage.local.remove('managedConfig');
+      }
+    },
+    config ? JSON.stringify(config) : null,
+  );
 
   await waitForIdleBackgroundTasks();
 

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -43,9 +43,9 @@ async function sendMessage(msg) {
 
   const result = await browser.execute(
     browser.isChromium
-      ? (msg) => chrome.runtime.sendMessage(msg)
-      : (msg) => browser.runtime.sendMessage(msg),
-    msg,
+      ? (msg) => chrome.runtime.sendMessage(JSON.parse(msg))
+      : (msg) => browser.runtime.sendMessage(JSON.parse(msg)),
+    JSON.stringify(msg),
   );
 
   if (result !== 'done') {


### PR DESCRIPTION
This PR fixes an issue where E2E tests were failing on Firefox in CI with the error: `WebDriver Bidi command "script.callFunction" failed with error: invalid argument - Expected "type" to be a string, got [object Undefined] undefined`.

This error occurs when passing complex objects or `undefined` as arguments to the browser.execute when using the WebDriver BiDi protocol in Firefox. The `RemoteValue` deserializer seems to fail with certain object structures.