### PR TITLE
Update @ghostery/urlfilter2dnr to v1.6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@ghostery/adblocker-webextension": "^2.13.3",
         "@ghostery/config": "^0.0.5",
         "@ghostery/scriptlets": "github:ghostery/scriptlets",
-        "@ghostery/urlfilter2dnr": "^1.6.3",
+        "@ghostery/urlfilter2dnr": "^1.6.5",
         "@github/relative-time-element": "^5.0.0",
         "@sentry/browser": "^10.32.1",
         "@whotracksme/reporting": "^7.10.0",
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@adguard/agtree": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@adguard/agtree/-/agtree-3.2.2.tgz",
-      "integrity": "sha512-Z0Z+zMf6POCG64BUK5Iif36pAj09vMNT3qZruiUj631EDDo3hiVBHTg9kBG62Qp+94zjO/QrAiKKTilN47cfwg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@adguard/agtree/-/agtree-3.4.3.tgz",
+      "integrity": "sha512-T838KvYtWu3K6whQ46YLaIXYA7PbszX9QRp4dvNfF8iWdp98tcKHxXWslBwUN1DkcBOqqj4rrkarLmcwT2iAbg==",
       "license": "MIT",
       "dependencies": {
         "@adguard/css-tokenizer": "^1.2.0",
@@ -70,15 +70,6 @@
       },
       "engines": {
         "node": ">=22"
-      }
-    },
-    "node_modules/@adguard/agtree/node_modules/zod": {
-      "version": "3.24.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
-      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@adguard/css-tokenizer": {
@@ -107,26 +98,26 @@
       }
     },
     "node_modules/@adguard/scriptlets": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/@adguard/scriptlets/-/scriptlets-2.2.9.tgz",
-      "integrity": "sha512-q3hHnjy7RKbRWa6HJ4zIOjUjtIV2myB1nQOrpTk39DrTde9cgpV5avQxl1msWhdeq/KvXh8dG8+yJSfesjcDQg==",
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/@adguard/scriptlets/-/scriptlets-2.2.14.tgz",
+      "integrity": "sha512-IY5iy0gaNQq0YEFpdp9yb6zNmjQXFB3Hox84rKBCFZAJWw0AP4OQsZErH6IqpaAkBrA96KVXWKHYc09WdyOxyg==",
       "license": "GPL-3.0",
       "dependencies": {
-        "@adguard/agtree": "^3.2.2",
+        "@adguard/agtree": "^3.4.3",
         "@types/trusted-types": "^2.0.7",
         "js-yaml": "^3.14.1"
       }
     },
     "node_modules/@adguard/tsurlfilter": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/@adguard/tsurlfilter/-/tsurlfilter-3.4.5.tgz",
-      "integrity": "sha512-wYGjjN+IJUE9kBvgCaHCphDxNTSxnwWjmzwXY9bUI0DjdXv8lhsJd1QtZfbz/yFt3CilrTCGPoDvShZkaBz05g==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@adguard/tsurlfilter/-/tsurlfilter-3.5.2.tgz",
+      "integrity": "sha512-A0p9aCeOl+g9HrXi/g90dYFki+7+jNK/Nsn+CLknAYQcc0cFVHktdE+uNOa5+Ep7RIh1u85+zs9sNJc5R8zWaQ==",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@adguard/agtree": "^3.2.2",
+        "@adguard/agtree": "^3.4.3",
         "@adguard/css-tokenizer": "^1.2.0",
         "@adguard/logger": "^2.0.0",
-        "@adguard/scriptlets": "^2.2.8",
+        "@adguard/scriptlets": "^2.2.14",
         "cidr-tools": "^6.4.1",
         "commander": "^12.1.0",
         "is-cidr": "4.0.2",
@@ -145,15 +136,6 @@
       },
       "peerDependencies": {
         "@adguard/re2-wasm": "1.2.0"
-      }
-    },
-    "node_modules/@adguard/tsurlfilter/node_modules/zod": {
-      "version": "3.24.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
-      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -403,9 +385,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.3.tgz",
-      "integrity": "sha512-LKYxD2CIfocUFNREQ1yk+dW+8OH8CRqmgatBZYXb+XhuObO8wsDpEoCNri5bKld9cnj8xukqZjxSX8p1YiRF8Q==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.6.tgz",
+      "integrity": "sha512-kz2fAQ5UzjV7X7D3ySxmj3vRq89dTpqOZWv76Z6pNPztkwb/0Yj1Mtx1xFrYj6mbIHysxtBot8J4o0JLCblcFw==",
       "license": "MIT",
       "dependencies": {
         "core-js-pure": "^3.43.0"
@@ -1196,18 +1178,30 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eyeo/webext-ad-filtering-solution": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/@eyeo/webext-ad-filtering-solution/-/webext-ad-filtering-solution-1.23.1.tgz",
-      "integrity": "sha512-l+3p1NG2O6iIa1LZNLZ6m94wxtdvu3kmcx0EzdnJBc3wo8RWPK0sYDZ/Kh1BnCPvRf8bO+crHiwg6l0yBW1tow==",
+    "node_modules/@eyeo/remote-configuration-validator": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eyeo/remote-configuration-validator/-/remote-configuration-validator-0.7.0.tgz",
+      "integrity": "sha512-IaluuGyqtKqoH2KwOihiP3QbcwtTbH8TK1fd8204zmbxHGJhEWJ98fa/gqBNFYz+60rQopi4PMZ/TESz4SPTPw==",
       "license": "GPL-3.0",
-      "workspaces": [
-        "./adblockpluscore"
-      ],
       "dependencies": {
+        "json-rules-engine": "7.3.1",
+        "jsonschema": "^1.4.1"
+      }
+    },
+    "node_modules/@eyeo/webext-ad-filtering-solution": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@eyeo/webext-ad-filtering-solution/-/webext-ad-filtering-solution-3.0.2.tgz",
+      "integrity": "sha512-ybb1FUwTe5uioC9gNMmoYrYBS766K69pXfXYxw6MJTbUGtwSWOiiN4dkB1LsUKu4q/kZLhlXpEBSO+4fs+4ybg==",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "@eyeo/remote-configuration-validator": "*",
+        "@sentry/browser": "8.54.0",
+        "json-rules-engine": "7.3.1",
+        "jsonpath-plus": "10.3.0",
         "pako": "^2.1.0",
+        "semver": "7.7.2",
+        "tar": "^6.1.10",
         "uuid": "^9.0.0",
-        "webextension-polyfill": "^0.8.0",
         "yargs": "^17.5.1"
       },
       "bin": {
@@ -1217,16 +1211,96 @@
         "subs-init": "scripts/initSubscriptions.js",
         "subs-merge": "scripts/mergeSubscriptions.js"
       },
-      "engines": {
-        "node": ">=18.16",
-        "npm": ">=9"
+      "peerDependencies": {
+        "webextension-polyfill": "*"
       }
     },
-    "node_modules/@eyeo/webext-ad-filtering-solution/node_modules/webextension-polyfill": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.8.0.tgz",
-      "integrity": "sha512-a19+DzlT6Kp9/UI+mF9XQopeZ+n2ussjhxHJ4/pmIGge9ijCDz7Gn93mNnjpZAk95T4Tae8iHZ6sSf869txqiQ==",
-      "license": "MPL-2.0"
+    "node_modules/@eyeo/webext-ad-filtering-solution/node_modules/@sentry-internal/browser-utils": {
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.54.0.tgz",
+      "integrity": "sha512-DKWCqb4YQosKn6aD45fhKyzhkdG7N6goGFDeyTaJFREJDFVDXiNDsYZu30nJ6BxMM7uQIaARhPAC5BXfoED3pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.54.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@eyeo/webext-ad-filtering-solution/node_modules/@sentry-internal/feedback": {
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.54.0.tgz",
+      "integrity": "sha512-nQqRacOXoElpE0L0ADxUUII0I3A94niqG9Z4Fmsw6057QvyrV/LvTiMQBop6r5qLjwMqK+T33iR4/NQI5RhsXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.54.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@eyeo/webext-ad-filtering-solution/node_modules/@sentry-internal/replay": {
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.54.0.tgz",
+      "integrity": "sha512-8xuBe06IaYIGJec53wUC12tY2q4z2Z0RPS2s1sLtbA00EvK1YDGuXp96IDD+HB9mnDMrQ/jW5f97g9TvPsPQUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.54.0",
+        "@sentry/core": "8.54.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@eyeo/webext-ad-filtering-solution/node_modules/@sentry-internal/replay-canvas": {
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.54.0.tgz",
+      "integrity": "sha512-K/On3OAUBeq/TV2n+1EvObKC+WMV9npVXpVyJqCCyn8HYMm8FUGzuxeajzm0mlW4wDTPCQor6mK9/IgOquUzCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "8.54.0",
+        "@sentry/core": "8.54.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@eyeo/webext-ad-filtering-solution/node_modules/@sentry/browser": {
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.54.0.tgz",
+      "integrity": "sha512-BgUtvxFHin0fS0CmJVKTLXXZcke0Av729IVfi+2fJ4COX8HO7/HAP02RKaSQGmL2HmvWYTfNZ7529AnUtrM4Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.54.0",
+        "@sentry-internal/feedback": "8.54.0",
+        "@sentry-internal/replay": "8.54.0",
+        "@sentry-internal/replay-canvas": "8.54.0",
+        "@sentry/core": "8.54.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@eyeo/webext-ad-filtering-solution/node_modules/@sentry/core": {
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.54.0.tgz",
+      "integrity": "sha512-03bWf+D1j28unOocY/5FDB6bUHtYlm6m6ollVejhg45ZmK9iPjdtxNWbrLsjT1WRym0Tjzowu+A3p+eebYEv0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@eyeo/webext-ad-filtering-solution/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@fluent/syntax": {
       "version": "0.19.0",
@@ -1313,15 +1387,15 @@
       }
     },
     "node_modules/@ghostery/urlfilter2dnr": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@ghostery/urlfilter2dnr/-/urlfilter2dnr-1.6.3.tgz",
-      "integrity": "sha512-p5glTbTf++197Wc/1GVR/UDY5ruxcPdpXqdPZv7diL1OkfRd2S63xHfdGLz2q0B/ONQgjgt/YEbLK6zJeWYmPA==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@ghostery/urlfilter2dnr/-/urlfilter2dnr-1.6.5.tgz",
+      "integrity": "sha512-b3z1d2Wp9vpTNROzgw8advp0O2iwDYaI7jJaky9yj2Y9H49u+ava7QXwo5Erf63rBbMlCIFeA/ZLCyw3RfaKmA==",
       "license": "GPL-3.0",
       "dependencies": {
         "@adguard/re2-wasm": "^1.2.0",
-        "@adguard/scriptlets": "^2.2.7",
-        "@adguard/tsurlfilter": "^3.4.0",
-        "@eyeo/webext-ad-filtering-solution": "^1.23.1"
+        "@adguard/scriptlets": "^2.2.14",
+        "@adguard/tsurlfilter": "^3.5.2",
+        "@eyeo/webext-ad-filtering-solution": "^3.0.2"
       }
     },
     "node_modules/@github/relative-time-element": {
@@ -2076,6 +2150,30 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
       }
     },
     "node_modules/@jspm/core": {
@@ -5266,6 +5364,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/chrome-launcher": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.0.tgz",
@@ -5672,9 +5779,9 @@
       "license": "MIT"
     },
     "node_modules/core-js-pure": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.45.0.tgz",
-      "integrity": "sha512-OtwjqcDpY2X/eIIg1ol/n0y/X8A9foliaNt1dSK0gV3J2/zw+89FcNG3mPK+N8YWts4ZFUPxnrAzsxs/lf8yDA==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.47.0.tgz",
+      "integrity": "sha512-BcxeDbzUrRnXGYIVAGFtcGQVNpFcUhVjr6W7F8XktvQW2iJP9e66GP6xdKotCRFlrxBvNIBrhwKteRXqMV86Nw==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -7150,6 +7257,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventemitter2": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
+      "license": "MIT"
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -7744,6 +7857,36 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -8161,6 +8304,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/hash-it": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/hash-it/-/hash-it-6.0.1.tgz",
+      "integrity": "sha512-qhl8+l4Zwi1eLlL3lja5ywmDQnBzLEJxd0QJoAVIgZpgQbdtVZrN5ypB0y3VHwBlvAalpcbM2/A6x7oUks5zNg==",
+      "license": "MIT"
     },
     "node_modules/he": {
       "version": "1.2.0",
@@ -9246,6 +9395,16 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -9286,6 +9445,30 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/json-rules-engine": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/json-rules-engine/-/json-rules-engine-7.3.1.tgz",
+      "integrity": "sha512-NyRTQZllvAt7AQ3g9P7/t4nIwlEB+EyZV7y8/WgXfZWSlpcDryt1UH9CsoU+Z+MDvj8umN9qqEcbE6qnk9JAHw==",
+      "license": "ISC",
+      "dependencies": {
+        "clone": "^2.1.2",
+        "eventemitter2": "^6.4.4",
+        "hash-it": "^6.0.0",
+        "jsonpath-plus": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/json-rules-engine/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -9323,6 +9506,33 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
+      "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/jsonschema": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
+      "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/jszip": {
@@ -9900,12 +10110,55 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/mlly": {
       "version": "1.8.0",
@@ -12929,6 +13182,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
@@ -12955,6 +13225,21 @@
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
       }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -15100,7 +15385,8 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.12.0.tgz",
       "integrity": "sha512-97TBmpoWJEE+3nFBQ4VocyCdLKfw54rFaJ6EVQYLBCXqCIpLSZkwGgASpv4oPt9gdKCJ80RJlcmNzNn008Ag6Q==",
-      "license": "MPL-2.0"
+      "license": "MPL-2.0",
+      "peer": true
     },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
@@ -15720,9 +16006,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
-      "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
+      "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
+      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -15730,15 +16016,15 @@
       }
     },
     "node_modules/zod-validation-error": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.5.3.tgz",
-      "integrity": "sha512-OT5Y8lbUadqVZCsnyFaTQ4/O2mys4tj7PqhdbBCp7McPwvIEKfPtdA6QfPeFQK2/Rz5LgwmAXRJTugBNBi0btw==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.5.4.tgz",
+      "integrity": "sha512-+hEiRIiPobgyuFlEojnqjJnhFvg4r/i3cqgcm67eehZf/WBaK3g6cD02YU9mtdVxZjv8CzCA9n/Rhrs3yAAvAw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
+        "zod": "^3.24.4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@ghostery/adblocker-webextension": "^2.13.3",
     "@ghostery/config": "^0.0.5",
     "@ghostery/scriptlets": "github:ghostery/scriptlets",
-    "@ghostery/urlfilter2dnr": "^1.6.3",
+    "@ghostery/urlfilter2dnr": "^1.6.5",
     "@github/relative-time-element": "^5.0.0",
     "@sentry/browser": "^10.32.1",
     "@whotracksme/reporting": "^7.10.0",


### PR DESCRIPTION
refs https://github.com/ghostery/urlfilter2dnr/pull/110

This update fixes a crucial bug that the converter cannot find the correct option start index regarding the regexp network filters and more. This directly affects the parsing phase of the filter and corrects wrong filters into the correct form.

Also, this update enables some missing regexp community filters such as `/\.[a-z]{2,6}\/[0-9a-zA-Z]{5,7}\.js$/$script,3p,match-case,from=analdin.com|bestjavporn.com|ero-anime.website|hdpornflix.com|javdock.com|javtiful.com|onscreens.me|supjav.com` appeared on https://github.com/ghostery/broken-page-reports/issues/2042. The library emitted wrong filter after the option modification so far.