### PR TITLE
fix(e2e): improve `wdio:update` command

### DIFF
--- a/tests/e2e/spec/custom-filters.spec.js
+++ b/tests/e2e/spec/custom-filters.spec.js
@@ -15,6 +15,7 @@ import {
   setPrivacyToggle,
   openPanel,
   setCustomFilters,
+  switchFrame,
 } from '../utils.js';
 
 import { PAGE_DOMAIN, PAGE_URL } from '../wdio.conf.js';
@@ -88,18 +89,13 @@ describe('Custom Filters', function () {
     await browser.url(PAGE_URL);
     await expect($('#custom-filter')).not.toBeDisplayed();
 
-    await browser.switchFrame($('#iframe-static'));
+    await switchFrame($('#iframe-static'));
     await expect($('#custom-filter')).not.toBeDisplayed();
 
-    // wait for dynamic and local iframes to load
-    await browser.pause(1000);
-
-    await browser.switchFrame(null);
-    await browser.switchFrame($('#iframe-dynamic'));
+    await switchFrame($('#iframe-dynamic'));
     await expect($('#custom-filter')).not.toBeDisplayed();
 
-    await browser.switchFrame(null);
-    await browser.switchFrame($('#iframe-local'));
+    await switchFrame($('#iframe-local'));
     await expect($('#custom-filter')).not.toBeDisplayed();
 
     await browser.switchFrame(null);

--- a/tests/e2e/spec/experimental.spec.js
+++ b/tests/e2e/spec/experimental.spec.js
@@ -13,8 +13,9 @@ import { $, browser, expect } from '@wdio/globals';
 import { enableExtension, setPrivacyToggle } from '../utils.js';
 
 describe('Experimental Features', function () {
+  before(enableExtension);
+
   describe('Disable fixes filters', function () {
-    before(enableExtension);
     before(async function () {
       await setPrivacyToggle('experimental-filters', true);
     });

--- a/tests/e2e/spec/main.spec.js
+++ b/tests/e2e/spec/main.spec.js
@@ -17,6 +17,7 @@ import {
   openPanel,
   waitForIdleBackgroundTasks,
   expectAdsBlocked,
+  switchFrame,
   ADBLOCKING_GLOBAL_SELECTOR,
   ADBLOCKING_URL_SELECTOR,
   TRACKER_IDS,
@@ -68,20 +69,15 @@ describe('Main Features', function () {
       await expect($(ADBLOCKING_GLOBAL_SELECTOR)).toBeDisplayed();
       await expect($(ADBLOCKING_URL_SELECTOR)).toBeDisplayed();
 
-      await browser.switchFrame($('#iframe-static'));
+      await switchFrame($('#iframe-static'));
       await expect($(ADBLOCKING_GLOBAL_SELECTOR)).toBeDisplayed();
       await expect($(ADBLOCKING_URL_SELECTOR)).toBeDisplayed();
 
-      // wait for dynamic and local iframes to load
-      await browser.pause(1000);
-
-      await browser.switchFrame(null);
-      await browser.switchFrame($('#iframe-dynamic'));
+      await switchFrame($('#iframe-dynamic'));
       await expect($(ADBLOCKING_GLOBAL_SELECTOR)).toBeDisplayed();
       await expect($(ADBLOCKING_URL_SELECTOR)).toBeDisplayed();
 
-      await browser.switchFrame(null);
-      await browser.switchFrame($('#iframe-local'));
+      await switchFrame($('#iframe-local'));
       await expect($(ADBLOCKING_GLOBAL_SELECTOR)).toBeDisplayed();
       await expect($(ADBLOCKING_URL_SELECTOR)).toBeDisplayed();
 
@@ -93,34 +89,28 @@ describe('Main Features', function () {
         await setPrivacyToggle('ad-blocking', true);
         await browser.url(PAGE_URL);
       });
-      afterEach(async function () {
-        await browser.switchFrame(null);
-      });
 
       it('main frame of the page', expectAdsBlocked);
 
       it('subframe of the page', async function () {
-        const iframe = await $('#iframe-static');
-        await browser.switchFrame(iframe);
-
+        await switchFrame($('#iframe-static'));
         await expectAdsBlocked();
+
+        await browser.switchFrame(null);
       });
 
       it('dynamic subframe of the page', async function () {
-        // Wait for iframe to load
-        await browser.pause(1000);
-
-        const dynamicIframe = await $('#iframe-dynamic');
-        await browser.switchFrame(dynamicIframe);
-
+        await switchFrame($('#iframe-dynamic'));
         await expectAdsBlocked();
+
+        await browser.switchFrame(null);
       });
 
       it('local subframe of the page', async function () {
-        const localIframe = await $('#iframe-local');
-        await browser.switchFrame(localIframe);
-
+        await switchFrame($('#iframe-local'));
         await expectAdsBlocked();
+
+        await browser.switchFrame(null);
       });
     });
 

--- a/tests/e2e/spec/notifications.spec.js
+++ b/tests/e2e/spec/notifications.spec.js
@@ -27,8 +27,8 @@ describe('Notifications', function () {
       const url = 'notifications/pin-it.html';
       const iframe = $('>>>iframe#ghostery-notification-iframe');
 
-      await expect(iframe).toBeDisplayed();
       await expect(iframe).toHaveAttribute('src', expect.stringContaining(url));
+      await expect(iframe).toBeDisplayed();
     }
 
     // The "review" notification is displayed after 30 days of usage,
@@ -40,8 +40,8 @@ describe('Notifications', function () {
       const url = 'notifications/review.html';
       const iframe = $('>>>iframe#ghostery-notification-iframe');
 
-      await expect(iframe).toBeDisplayed();
       await expect(iframe).toHaveAttribute('src', expect.stringContaining(url));
+      await expect(iframe).toBeDisplayed();
     }
 
     // After pin-it and review notifications have been displayed,

--- a/tests/e2e/spec/zapped.spec.js
+++ b/tests/e2e/spec/zapped.spec.js
@@ -19,6 +19,7 @@ import {
   openPanel,
   waitForIdleBackgroundTasks,
   expectAdsBlocked,
+  switchFrame,
   ADBLOCKING_GLOBAL_SELECTOR,
   ADBLOCKING_URL_SELECTOR,
   TRACKER_IDS,
@@ -61,20 +62,15 @@ if (argv.flags.includes(FLAG_MODES)) {
       await expect($(ADBLOCKING_GLOBAL_SELECTOR)).toBeDisplayed();
       await expect($(ADBLOCKING_URL_SELECTOR)).toBeDisplayed();
 
-      await browser.switchFrame($('#iframe-static'));
+      await switchFrame($('#iframe-static'));
       await expect($(ADBLOCKING_GLOBAL_SELECTOR)).toBeDisplayed();
       await expect($(ADBLOCKING_URL_SELECTOR)).toBeDisplayed();
 
-      // wait for dynamic and local iframes to load
-      await browser.pause(1000);
-
-      await browser.switchFrame(null);
-      await browser.switchFrame($('#iframe-dynamic'));
+      await switchFrame($('#iframe-dynamic'));
       await expect($(ADBLOCKING_GLOBAL_SELECTOR)).toBeDisplayed();
       await expect($(ADBLOCKING_URL_SELECTOR)).toBeDisplayed();
 
-      await browser.switchFrame(null);
-      await browser.switchFrame($('#iframe-local'));
+      await switchFrame($('#iframe-local'));
       await expect($(ADBLOCKING_GLOBAL_SELECTOR)).toBeDisplayed();
       await expect($(ADBLOCKING_URL_SELECTOR)).toBeDisplayed();
 
@@ -122,34 +118,28 @@ if (argv.flags.includes(FLAG_MODES)) {
       before(async function () {
         await browser.url(PAGE_URL);
       });
-      afterEach(async function () {
-        await browser.switchFrame(null);
-      });
 
       it('main frame of the page', expectAdsBlocked);
 
       it('subframe of the page', async function () {
-        const iframe = await $('#iframe-static');
-        await browser.switchFrame(iframe);
-
+        await switchFrame($('#iframe-static'));
         await expectAdsBlocked();
+
+        await browser.switchFrame(null);
       });
 
       it('dynamic subframe of the page', async function () {
-        // Wait for iframe to load
-        await browser.pause(1000);
-
-        const dynamicIframe = await $('#iframe-dynamic');
-        await browser.switchFrame(dynamicIframe);
-
+        await switchFrame($('#iframe-dynamic'));
         await expectAdsBlocked();
+
+        await browser.switchFrame(null);
       });
 
       it('local subframe of the page', async function () {
-        const localIframe = await $('#iframe-local');
-        await browser.switchFrame(localIframe);
-
+        await switchFrame($('#iframe-local'));
         await expectAdsBlocked();
+
+        await browser.switchFrame(null);
       });
 
       it('displays the page in Websites section of the settings page', async function () {

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -200,3 +200,10 @@ export async function setCustomFilters(filters, callback) {
 
   await getExtensionElement('button:back').click();
 }
+
+export async function switchFrame(frameElement) {
+  await browser.switchFrame(null);
+  await frameElement.waitForExist({ timeout: 5000 });
+
+  await browser.switchFrame(frameElement);
+}


### PR DESCRIPTION
>WebDriver Bidi command "script.callFunction" failed with error: invalid argument - Expected "type" to be a string, got [object Undefined] undefined

https://github.com/webdriverio/webdriverio/issues/14514
https://github.com/webdriverio/webdriverio/issues/14082

I have found several bugs reported to WDIO with similar error messages. All of them were about using the `switchFrame` method. This PR creates a custom helper method to switch frames, so running tests should be more reliable on Firefox.