### PR TITLE
feat(config): add version filter & support check

### DIFF
--- a/src/background/config.js
+++ b/src/background/config.js
@@ -13,30 +13,11 @@ import { store } from 'hybrids';
 
 import Config from '/store/config.js';
 
-import { isWebkit } from '/utils/browser-info.js';
+import { filter } from '/utils/config.js';
 import { CDN_URL } from '/utils/urls.js';
 import { debugMode } from '/utils/debug.js';
 
 const CONFIG_URL = CDN_URL + 'configs/v1.json';
-
-function filter(item) {
-  if (item.filter) {
-    const { platform } = item.filter;
-    let check = true;
-
-    // Browser check
-    // Possible values: 'chromium', 'firefox', 'webkit'
-    if (check && Array.isArray(platform)) {
-      check = platform.includes(
-        __PLATFORM__ !== 'firefox' && isWebkit() ? 'webkit' : __PLATFORM__,
-      );
-    }
-
-    return check;
-  }
-
-  return true;
-}
 
 const HALF_HOUR_IN_MS = 1000 * 60 * 30;
 

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,0 +1,68 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+import { isWebkit } from './browser-info.js';
+
+const SUPPORTED_FILTERS = ['version', 'platform'];
+
+export function filter(item) {
+  if (item.filter) {
+    // Ensure that the current environment supports all specified filters
+    // Otherwise, we return false and the item is filtered out.
+    let check = Object.keys(item.filter).every((key) => {
+      if (!SUPPORTED_FILTERS.includes(key)) {
+        console.warn(`[config] Unsupported filter key: ${key}`);
+        return false;
+      }
+
+      return true;
+    });
+
+    // Platform check
+    // Possible values: 'chromium', 'firefox', 'webkit'
+    if (check && Array.isArray(item.filter.platform)) {
+      check = item.filter.platform.includes(
+        __PLATFORM__ !== 'firefox' && isWebkit() ? 'webkit' : __PLATFORM__,
+      );
+    }
+
+    // Version check
+    // Checks that the extension version is equal or higher
+    if (check && typeof item.filter.version === 'string') {
+      const version = chrome.runtime
+        .getManifest()
+        .version.split('.')
+        .map((n) => parseInt(n, 10));
+
+      const filterVersion = item.filter.version
+        .split('.')
+        .map((n) => parseInt(n, 10));
+
+      for (let i = 0; i < filterVersion.length; i += 1) {
+        const v = version[i];
+        const f = filterVersion[i];
+
+        if (v > f) {
+          // check === true
+          break;
+        }
+
+        if (v < f) {
+          check = false;
+          break;
+        }
+      }
+    }
+
+    return check;
+  }
+
+  return true;
+}

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -1,0 +1,104 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert';
+
+import { filter } from '../../src/utils/config.js';
+
+describe('Remote config', () => {
+  before(() => {
+    global.chrome = { runtime: {} };
+  });
+
+  describe('filter()', () => {
+    it('should return false for unsupported filters', () => {
+      const originalWarn = console.warn;
+      let warnCalled = false;
+      console.warn = (msg) => {
+        if (msg.includes('Unsupported filter key')) {
+          warnCalled = true;
+        }
+      };
+
+      try {
+        assert.strictEqual(filter({ filter: { unsupported: 'check' } }), false);
+        assert.strictEqual(warnCalled, true);
+      } finally {
+        console.warn = originalWarn;
+      }
+    });
+
+    it('should return true if no filter is provided', () => {
+      assert.strictEqual(filter({}), true);
+    });
+
+    it('should return true if version matches exactly', () => {
+      global.chrome.runtime.getManifest = () => ({ version: '2.0.0' });
+      assert.strictEqual(filter({ filter: { version: '2.0.0' } }), true);
+    });
+
+    it('should return true if current version is higher', () => {
+      global.chrome.runtime.getManifest = () => ({ version: '2.1.0' });
+      assert.strictEqual(filter({ filter: { version: '2.0.0' } }), true);
+    });
+
+    it('should return false if current version is lower', () => {
+      global.chrome.runtime.getManifest = () => ({ version: '1.9.9' });
+      assert.strictEqual(filter({ filter: { version: '2.0.0' } }), false);
+    });
+
+    it('should handle multi-part versions correctly', () => {
+      global.chrome.runtime.getManifest = () => ({ version: '2.0.0' });
+      assert.strictEqual(filter({ filter: { version: '1.5.0' } }), true); // 2 > 1
+      assert.strictEqual(filter({ filter: { version: '2.0.1' } }), false); // 0 < 1
+    });
+
+    it('should return true if platform matches', () => {
+      global.__PLATFORM__ = 'chromium';
+      assert.strictEqual(filter({ filter: { platform: ['chromium'] } }), true);
+    });
+
+    it('should return false if platform does not match', () => {
+      global.__PLATFORM__ = 'chromium';
+      assert.strictEqual(filter({ filter: { platform: ['firefox'] } }), false);
+    });
+
+    it('should return true for firefox platform when set', () => {
+      global.__PLATFORM__ = 'firefox';
+      assert.strictEqual(filter({ filter: { platform: ['firefox'] } }), true);
+      assert.strictEqual(filter({ filter: { platform: ['chromium'] } }), false);
+    });
+
+    it('should combine version and platform checks', () => {
+      global.__PLATFORM__ = 'chromium';
+      global.chrome.runtime.getManifest = () => ({ version: '2.0.0' });
+
+      // Both match
+      assert.strictEqual(
+        filter({ filter: { version: '1.0.0', platform: ['chromium'] } }),
+        true,
+      );
+
+      // Version mismatch
+      assert.strictEqual(
+        filter({ filter: { version: '3.0.0', platform: ['chromium'] } }),
+        false,
+      );
+
+      // Platform mismatch
+      assert.strictEqual(
+        filter({ filter: { version: '1.0.0', platform: ['firefox'] } }),
+        false,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fixes #2981

* Adds `filter.version` option
* Adds check for supported filters, to prevent enabling flag or action for new unsupported option