### PR TITLE
fix(e2e): streamline onboarding tests

### DIFF
--- a/tests/e2e/spec/onboarding.spec.js
+++ b/tests/e2e/spec/onboarding.spec.js
@@ -18,35 +18,29 @@ import {
 } from '../utils.js';
 
 describe('Onboarding', function () {
-  beforeEach(async function () {
-    await browser.url('about:blank');
-  });
-
   it('keeps ghostery disabled', async function () {
+    await browser.url('about:blank');
     await browser.url(getExtensionPageURL('onboarding'));
 
-    if (!(await getExtensionElement('view:success').isDisplayed())) {
-      await getExtensionElement('button:skip').click();
-      await expect(getExtensionElement('view:skip')).toBeDisplayed();
+    await getExtensionElement('button:skip').click();
+    await expect(getExtensionElement('view:skip')).toBeDisplayed();
 
-      await openPanel();
-      await expect(getExtensionElement('button:enable')).toBeDisplayed();
-    }
+    await openPanel();
+    await expect(getExtensionElement('button:enable')).toBeDisplayed();
   });
 
   if (browser.isChromium) {
     it('shows the dialog with Privacy Policy', async function () {
+      await browser.url('about:blank');
       await browser.url(getExtensionPageURL('onboarding'));
 
-      if (!(await getExtensionElement('view:success').isDisplayed())) {
-        await getExtensionElement('text:description', 'a:last-of-type').click();
+      await getExtensionElement('text:description', 'a:last-of-type').click();
 
-        await expect(
-          getExtensionElement('text:privacy-policy', 'p'),
-        ).toBeDisplayed();
-      }
+      await expect(
+        getExtensionElement('text:privacy-policy', 'p'),
+      ).toBeDisplayed();
     });
   }
 
-  it('enables ghostery', enableExtension);
+  it('enables ghostery', () => enableExtension({ force: true }));
 });

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -90,11 +90,14 @@ export async function reloadExtension() {
   await browser.url('about:blank');
 }
 
-export async function enableExtension() {
+export async function enableExtension({ force = false } = {}) {
+  await browser.url('about:blank');
   await browser.url(getExtensionPageURL('onboarding'));
 
-  if (!(await getExtensionElement('view:success').isDisplayed())) {
-    await getExtensionElement('button:enable').click();
+  const enableButton = await getExtensionElement('button:enable');
+
+  if (force || (await enableButton.isDisplayed())) {
+    await enableButton.click();
 
     if (argv.flags.includes(FLAG_MODES)) {
       await expect(getExtensionElement('view:filtering-mode')).toBeDisplayed();

--- a/tests/e2e/wdio.conf.js
+++ b/tests/e2e/wdio.conf.js
@@ -84,9 +84,15 @@ export function buildForChrome() {
 
 export const config = {
   specs: [
-    // Onboarding tests should run first to avoid interference with other tests
-    // Notifications must run after onboarding to ensure a clean state for triggering notifications
-    ['spec/onboarding.spec.js', 'spec/notifications.spec.js', 'spec/*.spec.js'],
+    [
+      // Onboarding tests should run first to avoid interference with other tests
+      'spec/onboarding.spec.js',
+      // Notifications must run after onboarding to ensure
+      // a clean state for triggering notifications
+      'spec/notifications.spec.js',
+      // Other tests
+      'spec/*.spec.js',
+    ],
   ],
   reporters: [
     [

--- a/tests/e2e/wdio.update.conf.js
+++ b/tests/e2e/wdio.update.conf.js
@@ -39,7 +39,9 @@ import { setupTestPage } from './page/server.js';
 export const config = {
   ...wdio.config,
   exclude: [
-    // The `attribution.spec.js` tests relates to the code running only on the first install
+    // The onboarding spec must be skipped as the extension is already installed and enabled
+    './spec/onboarding.spec.js',
+    // The attribution spec relates to the code running only on the first install
     // and can't be run during the update process.
     './spec/attribution.spec.js',
   ],


### PR DESCRIPTION
* Force running tests in onboarding spec (it runs first, so the extension must be disabled to test if enabling works properly)
* Try to fix Firefox random errors by minor changes to `enableExtension()` logic