### PR TITLE
test: enable disabled tests due to adblocker caps

### DIFF
--- a/tests/e2e/spec/adblocker.spec.js
+++ b/tests/e2e/spec/adblocker.spec.js
@@ -138,9 +138,11 @@ describe('Adblocker Capabilities', function () {
       ['nosiif50', PAGE_DOMAIN + '##+js(nosiif, , 50)'],
     ];
     const networkingFilters = [
+      ['url', '/gen/url.js^'],
+      ['regex', '/gen\\/regex.js\\?t=[a-z0-9]{6}/'],
       ['modscript', '/gen/modscript.js^$script'],
       ['modxhr', '/gen/modxhr.js^$xhr'],
-      // $match-case (see Firefox)
+      ['modmatchcase', '/gen\\/modmatchcase-UPPERCASE.js/$match-case'],
       ['redirnoopjs', '/gen/redirnoop.js^$redirect=noopjs'],
       [
         'rediradsbygoogle',
@@ -191,33 +193,6 @@ describe('Adblocker Capabilities', function () {
       }
     });
   });
-
-  if (browser.isChromium) {
-    describe('Chromium', function () {
-      const networkingFilters = [
-        // Firefox requires https://github.com/ghostery/adblocker/pull/5296 for proper URL handling
-        ['url', '/gen/url.js^'],
-        ['regex', '/gen\\/regex.js\\?t=[a-z0-9]{6}/'],
-        // modmatchcase is not supported by adblocker library yet
-        // refs https://github.com/ghostery/adblocker/pull/5296
-        ['modmatchcase', '/gen\\/modmatchcase-UPPERCASE.js/$match-case'],
-      ];
-
-      let reports;
-
-      before(async function () {
-        reports = await test(networkingFilters);
-      });
-
-      describe('Networking', function () {
-        for (const [id, filter] of networkingFilters) {
-          it(filter, async function () {
-            expect(reports.networking[0].results[id]).toBe(true);
-          });
-        }
-      });
-    });
-  }
 
   if (browser.isFirefox) {
     describe('Firefox', function () {


### PR DESCRIPTION
This pull request re-enables disabled tests on Firefox due to the missing adblocker capabilities. Now we support all networking tests on Firefox as well, I'm enabling corresponding tests.