### PR TITLE
fix(e2e): correct regional filters test selector

### DIFF
--- a/tests/e2e/spec/main.spec.js
+++ b/tests/e2e/spec/main.spec.js
@@ -169,7 +169,7 @@ describe('Main Features', function () {
 
   describe('Regional Filters', function () {
     const WEBSITE_URL = 'https://www.cowwilanowie.pl/';
-    const SELECTOR = '.a-slider';
+    const SELECTOR = '.a-re';
 
     it('shows the ads on the page', async function () {
       await setPrivacyToggle('regional-filters', false);


### PR DESCRIPTION
The regional filters are tested on a real website. The cosmetic filters has changed, so we must update selecter.