### PR TITLE
fix(e2e): only production tags for `wdio:update` tests

### DIFF
--- a/tests/e2e/wdio.update.conf.js
+++ b/tests/e2e/wdio.update.conf.js
@@ -59,7 +59,7 @@ export const config = {
       if (!version) {
         execSync('git fetch --tags --quiet');
         version = execSync(
-          'git describe --tags $(git rev-list --tags --max-count=1)',
+          'git tag --sort=-creatordate | grep -E "^v[0-9]+\\.[0-9]+\\.[0-9]+$" | head -n 1',
         )
           .toString()
           .trim()


### PR DESCRIPTION
This change ensures the update tests always target the latest stable release by filtering out auxiliary tags like `v10.5.27-user-tests`. The version resolution logic was updated to use a regex filter on git tag output, strictly selecting only valid semantic version tags (e.g., `v10.5.27`).