### PR TITLE
feat(managed): add custom filters option

### DIFF
--- a/src/background/custom-filters.js
+++ b/src/background/custom-filters.js
@@ -27,6 +27,7 @@ import CustomFilters from '/store/custom-filters.js';
 
 import { setup, reloadMainEngine } from './adblocker.js';
 import { updateRedirectProtectionRules } from './redirect-protection.js';
+import ManagedConfig from '/store/managed-config.js';
 
 class TrustedScriptletError extends Error {}
 
@@ -188,6 +189,25 @@ export async function updateCustomFilters(input, options) {
 }
 
 OptionsObserver.addListener('customFilters', async (value, lastValue) => {
+  // Check managed config custom filters. Managed config has to enable it first,
+  // so we proceed only if customFilters are enabled (performance optimization).
+  if (value.enabled) {
+    const managedConfig = await store.resolve(ManagedConfig);
+    if (managedConfig.customFilters.enabled) {
+      const currentText = (await store.resolve(CustomFilters)).text;
+      const text = managedConfig.customFilters.filters.join('\n');
+
+      // Update custom filters only if the text is different
+      if (text !== currentText) {
+        await store.set(CustomFilters, { text });
+        await updateCustomFilters(text, value);
+
+        // Avoid multiple updates and exit early
+        return;
+      }
+    }
+  }
+
   // 1. Background startup
   // 2. Custom filters are enabled
   // 3. We cannot initialize engine (adblocker version mismatch, etc.)

--- a/src/managed_storage.json
+++ b/src/managed_storage.json
@@ -32,6 +32,15 @@
       "items": {
         "type": "string"
       }
+    },
+
+    "customFilters": {
+      "title": "Custom filters",
+      "description": "Defines a list of custom filters to be applied",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/src/pages/settings/components/managed.js
+++ b/src/pages/settings/components/managed.js
@@ -1,0 +1,34 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { html } from 'hybrids';
+
+export default {
+  value: false,
+  render: ({ value }) =>
+    value
+      ? html`
+          <template layout="block">
+            <ui-tooltip position="bottom" autohide="5" delay="0">
+              <div slot="content">
+                <ui-text type="body-s" color="secondary" slot="content">
+                  The feature is managed by your organization
+                </ui-text>
+              </div>
+              <div inert><slot></slot></div>
+            </ui-tooltip>
+          </template>
+        `.css`
+          :host { cursor: not-allowed; }
+          div[inert] { opacity: 0.5; }
+        `
+      : html`<template layout="contents"><slot></slot></template>`,
+};

--- a/src/pages/settings/views/privacy.js
+++ b/src/pages/settings/views/privacy.js
@@ -14,8 +14,9 @@ import { FLAG_REDIRECT_PROTECTION } from '@ghostery/config';
 
 import { longDateFormatter } from '/ui/labels.js';
 
-import Options, { GLOBAL_PAUSE_ID } from '/store/options.js';
 import Config from '/store/config.js';
+import ManagedConfig from '/store/managed-config.js';
+import Options, { GLOBAL_PAUSE_ID } from '/store/options.js';
 
 import { debugMode } from '/utils/debug.js';
 import { BECOME_A_CONTRIBUTOR_PAGE_URL } from '/utils/urls.js';
@@ -63,6 +64,7 @@ export default {
   },
   options: store(Options),
   config: store(Config),
+  managedConfig: store(ManagedConfig),
   devMode: debugMode,
   globalPause: {
     value: false,
@@ -78,6 +80,7 @@ export default {
   render: ({
     options,
     config,
+    managedConfig,
     devMode,
     globalPause,
     globalPauseRevokeAt,
@@ -123,7 +126,6 @@ export default {
             >
               <div layout="column gap:3">
                 <ui-toggle
-                  disabled="${globalPause}"
                   value="${options.blockAds}"
                   onchange="${html.set(options, 'blockAds')}"
                   data-qa="toggle:ad-blocking"
@@ -136,7 +138,6 @@ export default {
                   </settings-option>
                 </ui-toggle>
                 <ui-toggle
-                  disabled="${globalPause}"
                   value="${options.blockTrackers}"
                   onchange="${html.set(options, 'blockTrackers')}"
                   data-qa="toggle:anti-tracking"
@@ -150,7 +151,6 @@ export default {
                   </settings-option>
                 </ui-toggle>
                 <ui-toggle
-                  disabled="${globalPause}"
                   value="${options.blockAnnoyances}"
                   onchange="${toggleNeverConsent}"
                   data-qa="toggle:never-consent"
@@ -184,7 +184,6 @@ export default {
                     ></ui-icon>
                   </settings-link>
                   <ui-toggle
-                    disabled="${globalPause}"
                     value="${options.serpTrackingPrevention}"
                     onchange="${html.set(options, 'serpTrackingPrevention')}"
                   >
@@ -213,43 +212,47 @@ export default {
                     ></ui-icon>
                   </settings-link>
                   <ui-toggle
-                    disabled="${globalPause}"
                     value="${options.regionalFilters.enabled}"
                     onchange="${html.set(options, 'regionalFilters.enabled')}"
                     data-qa="toggle:regional-filters"
                   >
                   </ui-toggle>
                 </div>
-                <div layout="grid:1|max content:center gap">
-                  <settings-link
-                    href="${router.url(CustomFilters)}"
-                    data-qa="button:custom-filters"
-                  >
-                    <ui-icon
-                      name="detailed-view"
-                      color="quaternary"
-                      layout="size:3 margin:right"
-                    ></ui-icon>
-                    <ui-text
-                      type="headline-xs"
-                      layout="row gap:0.5 items:center"
+                <settings-managed
+                  value="${managedConfig.customFilters.enabled}"
+                >
+                  <div layout="grid:1|max content:center gap">
+                    <settings-link
+                      href="${!managedConfig.customFilters.enabled
+                        ? router.url(CustomFilters)
+                        : ''}"
+                      data-qa="button:custom-filters"
                     >
-                      Custom Filters
-                    </ui-text>
-                    <ui-icon
-                      name="chevron-right"
-                      color="primary"
-                      layout="size:2"
-                    ></ui-icon>
-                  </settings-link>
-                  <ui-toggle
-                    disabled="${globalPause}"
-                    value="${options.customFilters.enabled}"
-                    onchange="${html.set(options, 'customFilters.enabled')}"
-                    data-qa="toggle:custom-filters"
-                  >
-                  </ui-toggle>
-                </div>
+                      <ui-icon
+                        name="detailed-view"
+                        color="quaternary"
+                        layout="size:3 margin:right"
+                      ></ui-icon>
+                      <ui-text
+                        type="headline-xs"
+                        layout="row gap:0.5 items:center"
+                      >
+                        Custom Filters
+                      </ui-text>
+                      <ui-icon
+                        name="chevron-right"
+                        color="primary"
+                        layout="size:2"
+                      ></ui-icon>
+                    </settings-link>
+                    <ui-toggle
+                      value="${options.customFilters.enabled}"
+                      onchange="${html.set(options, 'customFilters.enabled')}"
+                      data-qa="toggle:custom-filters"
+                    >
+                    </ui-toggle>
+                  </div>
+                </settings-managed>
                 <div layout="grid:1|max content:center gap">
                   <settings-link href="${router.url(ExperimentalFilters)}">
                     <ui-icon
@@ -270,7 +273,6 @@ export default {
                     ></ui-icon>
                   </settings-link>
                   <ui-toggle
-                    disabled="${globalPause}"
                     value="${options.experimentalFilters}"
                     onchange="${html.set(options, 'experimentalFilters')}"
                     data-qa="toggle:experimental-filters"
@@ -302,7 +304,6 @@ export default {
                       ></ui-icon>
                     </settings-link>
                     <ui-toggle
-                      disabled="${globalPause}"
                       value="${options.redirectProtection.enabled}"
                       onchange="${html.set(
                         options,

--- a/src/pages/settings/views/whotracksme.js
+++ b/src/pages/settings/views/whotracksme.js
@@ -125,42 +125,43 @@ export default {
                 </div>
               </ui-toggle>
             `}
-            <ui-toggle
-              value="${options.wtmSerpReport}"
-              onchange="${html.set(options, 'wtmSerpReport')}"
-              data-qa="toggle:wtmSerpReport"
-              disabled="${managedConfig.disableTrackersPreview}"
-            >
-              <div layout="row items:start gap:2 grow" layout@768px="gap:3">
-                <settings-help-image>
-                  <img
-                    src="${assets.trackers_preview}"
-                    alt="Trackers Preview"
-                  />
-                </settings-help-image>
-                <settings-option>
-                  Trackers Preview
-                  <span slot="description">
-                    Shows the tracker preview beside search results.
-                  </span>
-                  <ui-text
-                    type="label-s"
-                    color="secondary"
-                    underline
-                    slot="footer"
-                    layout="self:start"
-                  >
-                    <a
-                      href="${TRACKERS_PREVIEW_LEARN_MORE_URL}"
-                      target="_blank"
-                      layout="row gap:0.5"
+            <settings-managed value="${managedConfig.disableTrackersPreview}">
+              <ui-toggle
+                value="${options.wtmSerpReport}"
+                onchange="${html.set(options, 'wtmSerpReport')}"
+                data-qa="toggle:wtmSerpReport"
+              >
+                <div layout="row items:start gap:2 grow" layout@768px="gap:3">
+                  <settings-help-image>
+                    <img
+                      src="${assets.trackers_preview}"
+                      alt="Trackers Preview"
+                    />
+                  </settings-help-image>
+                  <settings-option>
+                    Trackers Preview
+                    <span slot="description">
+                      Shows the tracker preview beside search results.
+                    </span>
+                    <ui-text
+                      type="label-s"
+                      color="secondary"
+                      underline
+                      slot="footer"
+                      layout="self:start"
                     >
-                      Learn more <ui-icon name="arrow-right-s"></ui-icon>
-                    </a>
-                  </ui-text>
-                </settings-option>
-              </div>
-            </ui-toggle>
+                      <a
+                        href="${TRACKERS_PREVIEW_LEARN_MORE_URL}"
+                        target="_blank"
+                        layout="row gap:0.5"
+                      >
+                        Learn more <ui-icon name="arrow-right-s"></ui-icon>
+                      </a>
+                    </ui-text>
+                  </settings-option>
+                </div>
+              </ui-toggle>
+            </settings-managed>
             ${__PLATFORM__ === 'firefox' &&
             html`
               <ui-toggle

--- a/src/store/managed-config.js
+++ b/src/store/managed-config.js
@@ -21,7 +21,11 @@ const ManagedConfig = {
   disableUserControl: false,
   disableUserAccount: false,
   disableTrackersPreview: false,
+
+  // TODO: Update the structure of `trustedDomains` as is with `customFilters`
+  // to have `enabled` flag and `domains` array
   trustedDomains: [TRUSTED_DOMAINS_NONE_ID],
+  customFilters: { enabled: false, filters: [String] },
 
   disableNotifications: (config) =>
     config.disableOnboarding || config.disableUserControl,
@@ -29,7 +33,8 @@ const ManagedConfig = {
   disableModes: (config) =>
     config.disableOnboarding ||
     config.disableUserControl ||
-    config.trustedDomains[0] !== TRUSTED_DOMAINS_NONE_ID,
+    config.trustedDomains[0] !== TRUSTED_DOMAINS_NONE_ID ||
+    config.customFilters.enabled,
 
   [store.connect]: async () => {
     if (__PLATFORM__ !== 'firefox' && (isOpera() || isWebkit())) return {};
@@ -59,6 +64,14 @@ const ManagedConfig = {
 
           managedConfig = fallbackConfig;
         }
+      }
+
+      // Translate `customFilters` storage.managed key (an array) to model structure
+      if (managedConfig.customFilters) {
+        managedConfig.customFilters = {
+          enabled: true,
+          filters: managedConfig.customFilters,
+        };
       }
 
       return managedConfig || {};

--- a/src/store/options.js
+++ b/src/store/options.js
@@ -281,6 +281,10 @@ async function manage(options) {
     });
   }
 
+  if (managed.customFilters.enabled) {
+    options.customFilters = { enabled: true, trustedScriptlets: true };
+  }
+
   return options;
 }
 

--- a/src/ui/components/toggle.js
+++ b/src/ui/components/toggle.js
@@ -57,6 +57,7 @@ export default {
     `.css`
       :host([disabled]) {
         pointer-events: none;
+        opacity: 0.5;
       }
 
       button {

--- a/tests/e2e/spec/managed.spec.js
+++ b/tests/e2e/spec/managed.spec.js
@@ -9,7 +9,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import { browser, expect } from '@wdio/globals';
+import { browser, expect, $ } from '@wdio/globals';
 
 import { PAGE_DOMAIN, PAGE_URL } from '../wdio.conf.js';
 import {
@@ -94,5 +94,24 @@ describe('Managed Configuration', function () {
 
     await openPanel();
     await expect(getExtensionElement('button:menu')).not.toBeDisplayed();
+  });
+
+  it('applies custom filters added to `customFilters`', async function () {
+    await browser.url(PAGE_URL);
+    await expect($('#custom-filter')).toBeDisplayed();
+
+    await setManagedConfig({
+      customFilters: [`${PAGE_DOMAIN}###custom-filter`],
+    });
+
+    await browser.url(PAGE_URL);
+    await expect($('#custom-filter')).not.toBeDisplayed();
+
+    await setManagedConfig({
+      customFilters: [],
+    });
+
+    await browser.url(PAGE_URL);
+    await expect($('#custom-filter')).toBeDisplayed();
   });
 });


### PR DESCRIPTION
Fixes #2885

* Added customFilters support to managed_storage.json and ManagedConfig, allowing organizations to define a list of enforced custom filters.
* Implemented background logic to apply managed custom filters, which override user-defined filters and automatically enable the feature.
* Introduced a settings-managed component to visually lock managed options in the settings panel and display an explanatory tooltip.
* Added E2E tests to verify that managed custom filters are correctly applied and that the UI reflects the managed state.

In a rare combination, when `disableUserControl` is not set and an administrator sets custom filters, the feature is disabled on the settings page (as I added for trackers preview):

<img width="821" height="173" alt="Zrzut ekranu 2026-01-30 o 11 34 07" src="https://github.com/user-attachments/assets/5f8fd46b-ee53-4c48-baf0-7753f2a80f12" />
<img width="811" height="195" alt="Zrzut ekranu 2026-01-30 o 11 33 32" src="https://github.com/user-attachments/assets/187289e4-673b-4f18-8eb7-bc9e235f491f" />
