### PR TITLE
fix(paused): unify DNR rules for paused and zapped mode

### DIFF
--- a/src/background/paused.js
+++ b/src/background/paused.js
@@ -19,7 +19,6 @@ import {
   getDynamicRulesIds,
   PAUSED_ID_RANGE,
   PAUSED_RULE_PRIORITY,
-  ALL_RESOURCE_TYPES,
 } from '/utils/dnr.js';
 
 // Pause / unpause hostnames
@@ -92,27 +91,9 @@ OptionsObserver.addListener(async function pausedSites(options, lastOptions) {
           {
             id: 1,
             priority: PAUSED_RULE_PRIORITY,
-            action: { type: 'allow' },
-            condition: {
-              initiatorDomains: globalPause ? undefined : hostnames,
-              resourceTypes: ALL_RESOURCE_TYPES,
-            },
-          },
-          {
-            id: 2,
-            priority: PAUSED_RULE_PRIORITY,
-            action: { type: 'allow' },
-            condition: {
-              requestDomains: globalPause ? undefined : hostnames,
-              resourceTypes: ALL_RESOURCE_TYPES,
-            },
-          },
-          {
-            id: 3,
-            priority: PAUSED_RULE_PRIORITY,
             action: { type: 'allowAllRequests' },
             condition: {
-              initiatorDomains: globalPause ? undefined : hostnames,
+              requestDomains: globalPause ? undefined : hostnames,
               resourceTypes: ['main_frame'],
             },
           },

--- a/src/background/zapped.js
+++ b/src/background/zapped.js
@@ -64,7 +64,7 @@ if (__PLATFORM__ !== 'firefox') {
     await chrome.declarativeNetRequest.updateDynamicRules({
       addRules: [
         isWebkit()
-          ? // Safari/WebKit has a bug with setting excludedRequestDomains,
+          ? // TODO: Safari/WebKit has a bug with setting excludedRequestDomains,
             // it simply doesn't work and still allow on excluded domains
             // the only way is to use `allow` action with excludedInitiatorDomains
             {


### PR DESCRIPTION
Fixes #3034. 

Tested on Safari 26.2 (macOS, iPadOS).