### PR TITLE
fix(ui): protect `theme` from failing when accessing `localStorage`

### DIFF
--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -10,8 +10,9 @@
  */
 
 import * as OptionsObserver from '/utils/options-observer.js';
+import { getLocalStorageItem, setLocalStorageItem } from '/utils/storage.js';
 
-let mode = localStorage.getItem('theme') || '';
+let mode = getLocalStorageItem('theme') || '';
 const styleSheets = new Set(Array.from(document.styleSheets));
 
 function updateStylesheet(styleSheet) {
@@ -59,7 +60,7 @@ if (document.documentElement.dataset.theme) {
 } else {
   OptionsObserver.addListener('theme', (theme, lastTheme) => {
     if (theme || lastTheme) {
-      localStorage.setItem('theme', theme);
+      setLocalStorageItem('theme', theme);
       mode = theme;
 
       reloadTheme();

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -23,3 +23,26 @@ export async function checkStorage() {
     throw e;
   }
 }
+
+export function getLocalStorageItem(key) {
+  try {
+    return globalThis.localStorage.getItem(key);
+  } catch (e) {
+    console.error(
+      `[storage] Failed to get localStorage item for key "${key}":`,
+      e,
+    );
+    return null;
+  }
+}
+
+export function setLocalStorageItem(key, value) {
+  try {
+    globalThis.localStorage.setItem(key, value);
+  } catch (e) {
+    console.error(
+      `[storage] Failed to set localStorage item for key "${key}":`,
+      e,
+    );
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/ghostery/ghostery-extension/issues/3036

When `Disable all cookies` option in Safari is turned on, all storages are blocked - IndexedDB, localStorage and cookies. We have to protect access to those APIs, so it does not fail.

I've checked other places accessing IndexedDB and cookies, but those errors are handled correctly.