### PR TITLE
feat(config): add `browser` filter check

### DIFF
--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -8,9 +8,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
-import { isWebkit } from './browser-info.js';
+import { getBrowser, isWebkit } from './browser-info.js';
 
-const SUPPORTED_FILTERS = ['version', 'platform'];
+const SUPPORTED_FILTERS = ['platform', 'browser', 'version'];
 
 export function filter(item) {
   if (item.filter) {
@@ -31,6 +31,12 @@ export function filter(item) {
       check = item.filter.platform.includes(
         __PLATFORM__ !== 'firefox' && isWebkit() ? 'webkit' : __PLATFORM__,
       );
+    }
+
+    // Browser check
+    // Values from getBrowser() method
+    if (check && typeof item.filter.browser === 'string') {
+      check = getBrowser().name === item.filter.browser;
     }
 
     // Version check

--- a/tests/unit/setup/init-chrome.js
+++ b/tests/unit/setup/init-chrome.js
@@ -16,6 +16,17 @@ if (typeof globalThis.chrome === 'undefined') {
   };
 }
 
+// Mock navigator to simulate Chrome
+Object.defineProperty(global, 'navigator', {
+  value: {
+    userAgent:
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36',
+    brave: undefined,
+  },
+  writable: true,
+  configurable: true,
+});
+
 if (typeof globalThis.__PLATFORM__ === 'undefined') {
   global.__PLATFORM__ = 'chrome';
 }


### PR DESCRIPTION
The PR adds a `browser` filter check for remote configuration.