### PR TITLE
fix(e2e): visit ghostery.com before setting attribution cookie

### DIFF
--- a/tests/e2e/wdio.conf.js
+++ b/tests/e2e/wdio.conf.js
@@ -193,6 +193,7 @@ export const config = {
       }
 
       /* attribution.spec */
+      await browser.url('https://www.ghostery.com/', { waitUntil: 'load' });
       await browser.setCookies({
         name: 'attribution',
         value: `s=source&c=campaign`,


### PR DESCRIPTION
Required by #3041. The WebDriver has started failing when we try to set cookie on the domain we have not visited before.

> Error while setting up test environment invalid cookie domain: WebDriverError: invalid cookie domain
[0-0]   (Session info: chrome=145.0.7632.46) when running "cookie" with method "POST"
