### PR TITLE
fix(e2e): use cookie name in clear cookies test

### DIFF
--- a/tests/e2e/spec/clear-cookies.spec.js
+++ b/tests/e2e/spec/clear-cookies.spec.js
@@ -19,18 +19,22 @@ import {
 import { PAGE_DOMAIN, PAGE_URL } from '../wdio.conf.js';
 
 describe('Clear Cookies', () => {
+  const COOKIE_NAME = 'test-cookie';
+
   before(enableExtension);
 
   beforeEach(async () => {
+    await browser.url(PAGE_URL, { waitUntil: 'load' });
     await browser.setCookies({
-      name: 'test-cookie',
+      name: COOKIE_NAME,
       value: 'test-value',
       domain: PAGE_DOMAIN,
     });
   });
 
   afterEach(async () => {
-    await browser.deleteCookies({ domain: PAGE_DOMAIN });
+    await browser.url(PAGE_URL, { waitUntil: 'load' });
+    await browser.deleteCookies({ name: COOKIE_NAME, domain: PAGE_DOMAIN });
   });
 
   it('clears cookies when action is triggered in the panel', async () => {


### PR DESCRIPTION
Required by #3041

> In WebDriver Classic you can only filter for cookie names
Error: In WebDriver Classic you can only filter for cookie names
    at Array.map (<anonymous>)
    at async Context.<anonymous> (file:///Users/dominik/Workspace/ghostery-extension/tests/e2e/spec/clear-cookies.spec.js:35:5)