### PR TITLE
fix(e2e): use browser context to set cookies

### DIFF
--- a/tests/e2e/spec/clear-cookies.spec.js
+++ b/tests/e2e/spec/clear-cookies.spec.js
@@ -13,6 +13,7 @@ import {
   enableExtension,
   getExtensionElement,
   openPanel,
+  setCookieInBrowserContext,
   waitForIdleBackgroundTasks,
 } from '../utils.js';
 
@@ -24,12 +25,7 @@ describe('Clear Cookies', () => {
   before(enableExtension);
 
   beforeEach(async () => {
-    await browser.url(PAGE_URL, { waitUntil: 'load' });
-    await browser.setCookies({
-      name: COOKIE_NAME,
-      value: 'test-value',
-      domain: PAGE_DOMAIN,
-    });
+    await setCookieInBrowserContext(PAGE_URL, COOKIE_NAME, 'test-value');
   });
 
   afterEach(async () => {

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -210,3 +210,15 @@ export async function switchFrame(frameElement) {
 
   await browser.switchFrame(frameElement);
 }
+
+export async function setCookieInBrowserContext(url, name, value) {
+  await browser.url(url, { waitUntil: 'load' });
+
+  await browser.execute(
+    (name, value) => {
+      document.cookie = `${name}=${value}`;
+    },
+    name,
+    value,
+  );
+}

--- a/tests/e2e/wdio.conf.js
+++ b/tests/e2e/wdio.conf.js
@@ -25,7 +25,11 @@ import { execSync } from 'node:child_process';
 import { $ } from '@wdio/globals';
 import { FLAGS } from '@ghostery/config';
 
-import { setConfigFlags, setExtensionBaseUrl } from './utils.js';
+import {
+  setConfigFlags,
+  setCookieInBrowserContext,
+  setExtensionBaseUrl,
+} from './utils.js';
 import { setupTestPage } from './page/server.js';
 
 export const WEB_EXT_PATH = path.join(process.cwd(), 'web-ext-artifacts');
@@ -193,12 +197,11 @@ export const config = {
       }
 
       /* attribution.spec */
-      await browser.url('https://www.ghostery.com/', { waitUntil: 'load' });
-      await browser.setCookies({
-        name: 'attribution',
-        value: `s=source&c=campaign`,
-        domain: '.ghostery.com',
-      });
+      await setCookieInBrowserContext(
+        'https://www.ghostery.com/',
+        'attribution',
+        's=source&c=campaign',
+      );
       /* attribution.spec */
 
       await setConfigFlags(argv.flags);


### PR DESCRIPTION
Required by #3041

With the above update, Firefox has started setting cookies differently. When using `browser.setCookies()`, the `partitionKey` is set, so the attribution logic returns `null` when getting the cookie for ghostery.com. 