### PR TITLE
chore(node): update nodejs to 25.6.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 24.8.0
+nodejs 25.6.0


### PR DESCRIPTION
Node.js had a security update for all active release lines. We should bump its version. We can use this opportunity to use the latest available version.

https://groups.google.com/g/nodejs-sec/c/MpwMqTK3ZPY/m/b30rYNE5CQAJ