### PR TITLE
Handle request reporter initialization errors gracefully

### DIFF
--- a/src/background/reporting/webrequest-reporter.js
+++ b/src/background/reporting/webrequest-reporter.js
@@ -38,41 +38,54 @@ if (chrome.webRequest) {
     remoteConfig = remote;
   });
 
-  webRequestReporter = new RequestReporter(config.request, {
-    onMessageReady: urlReporter.forwardRequestReporterMessage.bind(urlReporter),
-    countryProvider: urlReporter.countryProvider,
-    trustedClock: communication.trustedClock,
-    isRequestAllowed: (state) => {
-      const hostname = state.tabUrlParts.hostname;
-      return (
-        !options.blockTrackers ||
-        !!getPausedDetails(options, hostname) ||
-        remoteConfig?.hasAction(
-          hostname,
-          ACTION_DISABLE_ANTITRACKING_MODIFICATION,
-        )
-      );
-    },
-    onTrackerInteraction: (event, state) => {
-      if (event === 'observed') {
-        return;
+  try {
+    webRequestReporter = new RequestReporter(config.request, {
+      onMessageReady:
+        urlReporter.forwardRequestReporterMessage.bind(urlReporter),
+      countryProvider: urlReporter.countryProvider,
+      trustedClock: communication.trustedClock,
+      isRequestAllowed: (state) => {
+        const hostname = state.tabUrlParts.hostname;
+        return (
+          !options.blockTrackers ||
+          !!getPausedDetails(options, hostname) ||
+          remoteConfig?.hasAction(
+            hostname,
+            ACTION_DISABLE_ANTITRACKING_MODIFICATION,
+          )
+        );
+      },
+      onTrackerInteraction: (event, state) => {
+        if (event === 'observed') {
+          return;
+        }
+
+        const request = Request.fromRequestDetails({
+          url: state.url,
+          originUrl: state.tabUrl,
+        });
+        request.modified = true;
+
+        updateTabStats(state.tabId, [request]);
+      },
+    });
+
+    chrome.runtime.onMessage.addListener((msg, sender) => {
+      if (msg.action === 'mousedown') {
+        webRequestReporter.recordClick(
+          msg.event,
+          msg.context,
+          msg.href,
+          sender,
+        );
       }
-
-      const request = Request.fromRequestDetails({
-        url: state.url,
-        originUrl: state.tabUrl,
-      });
-      request.modified = true;
-
-      updateTabStats(state.tabId, [request]);
-    },
-  });
-
-  chrome.runtime.onMessage.addListener((msg, sender) => {
-    if (msg.action === 'mousedown') {
-      webRequestReporter.recordClick(msg.event, msg.context, msg.href, sender);
-    }
-  });
+    });
+  } catch (e) {
+    console.warn(
+      'Failed to create webRequestReporter. Leaving it disabled.',
+      e,
+    );
+  }
 }
 
 export default webRequestReporter;


### PR DESCRIPTION
It should not happen that the request reporter fails during construction. However, given that it is an optional library, failing gracefully and disabling it without crashing looks safer.

If it crashes, it also prevents the url reporter from starting up. By disabling it, this cascading effort is mitigated.