### PR TITLE
fix(pause-assistant): add e2e tests

### DIFF
--- a/src/background/helpers.js
+++ b/src/background/helpers.js
@@ -99,6 +99,21 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       });
       return true;
 
+    case 'e2e:setConfigDomains':
+      store.resolve(Config).then(async (config) => {
+        const domains = {};
+
+        for (const domain of Object.keys(config.domains)) {
+          domains[domain] = null;
+        }
+
+        Object.assign(domains, msg.domains);
+
+        await store.set(Config, { domains });
+        sendResponse('done');
+      });
+      return true;
+
     case 'e2e:reloadExtension':
       setTimeout(() => chrome.runtime.reload(), 2000);
       sendResponse('done');

--- a/src/pages/notifications/pause-assistant.js
+++ b/src/pages/notifications/pause-assistant.js
@@ -57,6 +57,7 @@ mount(document.body, {
             size="s"
             onclick="${dismiss}"
             layout="width::10"
+            data-qa="button:dismiss"
           >
             <button>OK</button>
           </ui-button>

--- a/src/pages/notifications/pause-resume.js
+++ b/src/pages/notifications/pause-resume.js
@@ -40,7 +40,11 @@ mount(document.body, {
           </ui-text>
         </div>
         <div layout="row gap" layout="width::10">
-          <ui-button type="success" onclick="${resume}">
+          <ui-button
+            type="success"
+            onclick="${resume}"
+            data-qa="button:dismiss"
+          >
             <button>OK</button>
           </ui-button>
         </div>

--- a/tests/e2e/spec/notifications.spec.js
+++ b/tests/e2e/spec/notifications.spec.js
@@ -8,12 +8,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
-import { browser, expect, $ } from '@wdio/globals';
+import { browser, expect } from '@wdio/globals';
 import { FLAG_NOTIFICATION_REVIEW } from '@ghostery/config';
 
-import { argv } from '../wdio.conf.js';
-import { enableExtension } from '../utils.js';
-import { PAGE_URL } from '../wdio.conf.js';
+import { argv, PAGE_URL } from '../wdio.conf.js';
+import { enableExtension, getNotificationIframe } from '../utils.js';
 
 describe('Notifications', function () {
   before(enableExtension);
@@ -23,34 +22,24 @@ describe('Notifications', function () {
     // and it is displayed just after enabling the extension on the first visited page.
     if (browser.isChromium) {
       await browser.url(PAGE_URL);
-
-      const url = 'notifications/pin-it.html';
-      const iframe = $('>>>iframe#ghostery-notification-iframe');
-
-      await expect(iframe).toHaveAttribute('src', expect.stringContaining(url));
-      await expect(iframe).toBeDisplayed();
+      await expect(getNotificationIframe('pin-it')).toBeDisplayed();
     }
 
     // The "review" notification is displayed after 30 days of usage,
     // but in debug mode it is shown immediately. As the code in background
     // runs after the "pin-it" notification, it will be shown after it.
     if (argv.flags.includes(FLAG_NOTIFICATION_REVIEW)) {
-      await browser.url(PAGE_URL);
-
-      const url = 'notifications/review.html';
-      const iframe = $('>>>iframe#ghostery-notification-iframe');
-
-      await expect(iframe).toHaveAttribute('src', expect.stringContaining(url));
-      await expect(iframe).toBeDisplayed();
+      await browser.url(PAGE_URL, { wait: 'complete' });
+      await expect(getNotificationIframe('review')).toBeDisplayed();
     }
 
     // After pin-it and review notifications have been displayed,
     // no further notification should be shown
-    await browser.url(PAGE_URL);
+    await browser.url(PAGE_URL, { wait: 'complete' });
 
-    const iframe = $('>>>iframe#ghostery-notification-iframe');
     try {
-      await expect(iframe).not.toBeDisplayed();
+      await expect(await getNotificationIframe('pin-it')).not.toBeDisplayed();
+      await expect(await getNotificationIframe('review')).not.toBeDisplayed();
     } catch {
       throw new Error(
         `No notification should be displayed after notifications have been shown`,

--- a/tests/e2e/spec/pause-assistant.spec.js
+++ b/tests/e2e/spec/pause-assistant.spec.js
@@ -1,0 +1,107 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { browser, expect, $ } from '@wdio/globals';
+import { FLAG_PAUSE_ASSISTANT } from '@ghostery/config';
+
+import {
+  enableExtension,
+  getExtensionPageURL,
+  getNotificationIframe,
+  sendMessage,
+  setWhoTracksMeToggle,
+  waitForIdleBackgroundTasks,
+  ADBLOCKING_GLOBAL_SELECTOR,
+  dismissNotification,
+} from '../utils.js';
+
+import { argv, PAGE_DOMAIN, PAGE_URL } from '../wdio.conf.js';
+
+// IMPORTANT: The feature relys on the notifications, so the tests must be run always with
+// and after notifications.spec.js (other notifications must not interfere with the tests)
+
+if (argv.flags.includes(FLAG_PAUSE_ASSISTANT)) {
+  describe('Pause Assistant', function () {
+    before(enableExtension);
+
+    before(async () => {
+      await browser.url(getExtensionPageURL('panel'));
+      await sendMessage({
+        action: 'e2e:setConfigDomains',
+        domains: { [PAGE_DOMAIN]: { actions: ['pause-assistant'] } },
+      });
+
+      await waitForIdleBackgroundTasks();
+    });
+
+    after(async () => {
+      await browser.url(getExtensionPageURL('panel'));
+      await sendMessage({ action: 'e2e:setConfigDomains', domains: {} });
+
+      await waitForIdleBackgroundTasks();
+    });
+
+    it('does not pause the domain if the feature is turned off', async function () {
+      await setWhoTracksMeToggle('pauseAssistant', false);
+
+      await browser.url(PAGE_URL, { wait: 'complete' });
+
+      await expect(getNotificationIframe('pause-assistant')).not.toExist();
+      await expect(getNotificationIframe('pause-resume')).not.toExist();
+    });
+
+    it('pauses the domain when the feature is turned on', async function () {
+      await setWhoTracksMeToggle('pauseAssistant', true);
+
+      await browser.url(PAGE_URL, { wait: 'complete' });
+
+      // Ads are showned
+      await expect($(ADBLOCKING_GLOBAL_SELECTOR)).toBeDisplayed();
+
+      // Notification is shown
+      await expect(getNotificationIframe('pause-assistant')).toExist();
+
+      // Notification is shown again after reload (until user interacts with it)
+      await browser.url(PAGE_URL, { wait: 'complete' });
+      const iframe = getNotificationIframe('pause-assistant');
+      await expect(iframe).toExist();
+
+      // Dismiss the notification
+      await dismissNotification('pause-assistant');
+
+      // Ensure iframe is closed after dismissing
+      await expect(getNotificationIframe('pause-assistant')).not.toExist();
+
+      // Notification is not shown after dismissing
+      await browser.url(PAGE_URL, { wait: 'complete' });
+      await expect(getNotificationIframe('pause-assistant')).not.toExist();
+    });
+
+    it('resumes when action is removed from config', async function () {
+      await browser.url(getExtensionPageURL('panel'));
+      await sendMessage({ action: 'e2e:setConfigDomains', domains: {} });
+
+      await waitForIdleBackgroundTasks();
+
+      await browser.url(PAGE_URL, { wait: 'complete' });
+
+      const iframe = getNotificationIframe('pause-resume');
+      await expect(iframe).toExist();
+
+      // Dismiss the notification
+      await dismissNotification('pause-resume');
+
+      // Adblocking is active again
+      await browser.url(PAGE_URL, { wait: 'complete' });
+      await expect($(ADBLOCKING_GLOBAL_SELECTOR)).not.toBeDisplayed();
+    });
+  });
+}


### PR DESCRIPTION
This PR adds missing e2e tests for the "Browsing Assistant" feature. 