### PR TITLE
fix: replace `__PLATFORM__` environment variable

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,7 +12,8 @@ export default [
         ...globals.browser,
         ...globals.serviceworker,
         ...globals.webextensions,
-        __PLATFORM__: 'readonly',
+        __CHROMIUM__: 'readonly',
+        __FIREFOX__: 'readonly',
       },
 
       ecmaVersion: 'latest',

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -179,7 +179,10 @@ const config = {
   resolve: {
     preserveSymlinks: true,
   },
-  define: { __PLATFORM__: JSON.stringify(argv.target) },
+  define: {
+    __CHROMIUM__: JSON.stringify(argv.target === 'chromium'),
+    __FIREFOX__: JSON.stringify(argv.target === 'firefox'),
+  },
   build: {
     outDir: options.outDir,
     assetsDir: '',

--- a/src/background/autoconsent.js
+++ b/src/background/autoconsent.js
@@ -69,8 +69,7 @@ async function evalCode(snippetId, id, tabId, frameId) {
       tabId,
       frameIds: [frameId],
     },
-    world:
-      chrome.scripting.ExecutionWorld?.MAIN ?? (__PLATFORM__ === 'firefox' ? undefined : 'MAIN'),
+    world: chrome.scripting.ExecutionWorld?.MAIN ?? (__FIREFOX__ ? undefined : 'MAIN'),
     func: evalSnippets[snippetId],
   });
 

--- a/src/background/custom-filters.js
+++ b/src/background/custom-filters.js
@@ -144,7 +144,7 @@ export async function updateCustomFilters(input, options) {
   const { networkFilters, cosmeticFilters, errors } = normalizeFilters(input, options);
 
   const result = await updateEngine(
-    [...(__PLATFORM__ === 'firefox' ? networkFilters : []), ...cosmeticFilters].join('\n'),
+    [...(__FIREFOX__ ? networkFilters : []), ...cosmeticFilters].join('\n'),
   );
 
   result.errors = errors;
@@ -153,7 +153,7 @@ export async function updateCustomFilters(input, options) {
   await reloadMainEngine();
 
   // Update DNR rules for Chromium and Safari
-  if (__PLATFORM__ !== 'firefox') {
+  if (__CHROMIUM__) {
     const { rules, errors } = await convert([...networkFilters].map((f) => f.toString()));
 
     if (errors?.length) {
@@ -197,7 +197,7 @@ OptionsObserver.addListener('customFilters', async (value, lastValue) => {
     const { text } = await store.resolve(CustomFilters);
     await updateCustomFilters(text, value);
   } else if (
-    __PLATFORM__ !== 'firefox' &&
+    __CHROMIUM__ &&
     lastValue &&
     // Omit if `trustedScriptlets` is changed, as user then must click "save" button
     value.trustedScriptlets === lastValue.trustedScriptlets

--- a/src/background/dnr.js
+++ b/src/background/dnr.js
@@ -21,7 +21,7 @@ import { ENGINE_CONFIGS_ROOT_URL } from '/utils/urls.js';
 import { UPDATE_ENGINES_DELAY } from './adblocker/index.js';
 import { updateRedirectProtectionRules } from './redirect-protection.js';
 
-if (__PLATFORM__ !== 'firefox') {
+if (__CHROMIUM__) {
   const DNR_RESOURCES = chrome.runtime
     .getManifest()
     .declarative_net_request.rule_resources.filter(({ enabled }) => !enabled)

--- a/src/background/exceptions.js
+++ b/src/background/exceptions.js
@@ -70,7 +70,7 @@ async function updateFilters() {
   }
 }
 
-if (__PLATFORM__ !== 'firefox') {
+if (__CHROMIUM__) {
   // Update exceptions filters every time TrackerDB updates
   // It happens when all engines are updated
   OptionsObserver.addListener(

--- a/src/background/notifications.js
+++ b/src/background/notifications.js
@@ -111,7 +111,7 @@ chrome.runtime.onMessage.addListener((msg, sender) => {
 */
 
 if (
-  __PLATFORM__ !== 'firefox' &&
+  __CHROMIUM__ &&
   !isWebkit() && // Safari
   getOS() !== 'android' // Edge on Android (and possibly other browsers)
 ) {
@@ -161,7 +161,7 @@ chrome.webNavigation.onCompleted.addListener(async (details) => {
    Opera SERP notification if the protection is not enabled
 */
 
-if (__PLATFORM__ !== 'firefox' && isOpera()) {
+if (__CHROMIUM__ && isOpera()) {
   const NOTIFICATION_DELAY = 7 * 24 * 60 * 60 * 1000; // 7 days in milliseconds
   const NOTIFICATION_SHOW_LIMIT = 4;
 

--- a/src/background/paused.js
+++ b/src/background/paused.js
@@ -58,7 +58,7 @@ OptionsObserver.addListener(async function pausedSites(options, lastOptions) {
   }
 
   if (
-    __PLATFORM__ !== 'firefox' &&
+    __CHROMIUM__ &&
     // Paused state has changed by the user interaction
     ((lastOptions && !OptionsObserver.isOptionEqual(options.paused, lastOptions.paused)) ||
       // Filtering mode has changed

--- a/src/background/redirect-protection.js
+++ b/src/background/redirect-protection.js
@@ -113,7 +113,7 @@ export function getRedirectProtectionUrl(url, hostname, options) {
   return REDIRECT_PROTECTION_PAGE_URL + '?url=' + btoa(url);
 }
 
-if (__PLATFORM__ !== 'firefox') {
+if (__CHROMIUM__) {
   chrome.webNavigation.onBeforeNavigate.addListener(
     (details) => {
       if (
@@ -164,7 +164,7 @@ if (__PLATFORM__ !== 'firefox') {
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  if (__PLATFORM__ !== 'firefox' && message.action === 'getRedirectUrl') {
+  if (__CHROMIUM__ && message.action === 'getRedirectUrl') {
     const url = sender.tab && sender.tab.id ? redirectUrlMap.get(sender.tab.id) || null : null;
     sendResponse({ url });
     return false;
@@ -176,7 +176,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       return false;
     }
 
-    if (__PLATFORM__ === 'firefox') {
+    if (__FIREFOX__) {
       allowedRedirectUrls.add(message.url);
       sendResponse({ success: true });
       return false;

--- a/src/background/stats.js
+++ b/src/background/stats.js
@@ -34,7 +34,7 @@ const chromeAction = chrome.action || chrome.browserAction;
 const { icons } = chrome.runtime.getManifest();
 
 // We need to add a leading slash to the icon paths
-if (__PLATFORM__ !== 'firefox') {
+if (__CHROMIUM__) {
   Object.keys(icons).forEach((key) => {
     icons[key] = `/${icons[key]}`;
   });
@@ -71,7 +71,7 @@ async function hasAccessToPage(tabId) {
 async function refreshIcon(tabId) {
   const options = await store.resolve(Options);
 
-  if (__PLATFORM__ !== 'firefox' && isOpera() && options.terms) {
+  if (__CHROMIUM__ && isOpera() && options.terms) {
     isSerpSupported().then(async (supported) => {
       if (!supported) {
         setBadgeColor((await hasAccessToPage(tabId)) ? undefined : '#f13436' /* danger-500 */);
@@ -138,7 +138,7 @@ function updateIcon(tabId, force) {
         refreshIcon(tabId);
       },
       // Firefox flickers when updating the icon, so we should expand the debounce delay
-      __PLATFORM__ === 'firefox' ? 1000 : 250,
+      __FIREFOX__ ? 1000 : 250,
     ),
   );
 
@@ -343,7 +343,7 @@ chrome.webNavigation.onCommitted.addListener((details) => {
   }
 });
 
-if (__PLATFORM__ !== 'firefox') {
+if (__CHROMIUM__) {
   // On Safari we have content script to sends back the list of urls
   chrome.runtime.onMessage.addListener((msg, sender) => {
     if (sender.url && sender.frameId !== undefined && sender.tab?.id > -1) {
@@ -368,7 +368,7 @@ if (__PLATFORM__ !== 'firefox') {
   });
 }
 
-if (__PLATFORM__ !== 'firefox' && chrome.webRequest) {
+if (__CHROMIUM__ && chrome.webRequest) {
   // Gather stats for requests that are not main_frame
   chrome.webRequest.onBeforeRequest.addListener(
     (details) => {

--- a/src/background/sync.js
+++ b/src/background/sync.js
@@ -88,7 +88,7 @@ const syncOptions = debounce(
 
 // Opera provides chrome.storage.sync API, but it does not sync data between browsers
 // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/sync#browser_compatibility
-if (__PLATFORM__ === 'firefox' || (!isOpera() && !isWebkit())) {
+if (__FIREFOX__ || (!isOpera() && !isWebkit())) {
   // Sync options on startup and when options change
   OptionsObserver.addListener(function sync(options, lastOptions) {
     syncOptions(options, lastOptions);

--- a/src/background/zapped.js
+++ b/src/background/zapped.js
@@ -38,7 +38,7 @@ store.observe(Config, async (_, config, lastConfig) => {
   }
 });
 
-if (__PLATFORM__ !== 'firefox') {
+if (__CHROMIUM__) {
   OptionsObserver.addListener(async function zapped(options, lastOptions) {
     if (
       // No changes in options

--- a/src/pages/onboarding/views/main.js
+++ b/src/pages/onboarding/views/main.js
@@ -66,7 +66,7 @@ export default {
           </div>
         </div>
         <div layout="column gap:2">
-          ${__PLATFORM__ === 'firefox' &&
+          ${__FIREFOX__ &&
           html`
             <div layout="row gap items:start">
               <ui-input>
@@ -87,7 +87,7 @@ export default {
               </ui-text>
             </div>
           `}
-          ${__PLATFORM__ !== 'firefox' &&
+          ${__CHROMIUM__ &&
           html`
             <ui-text type="body-s" underline data-qa="text:description">
               ${msg.html`

--- a/src/pages/onboarding/views/success.js
+++ b/src/pages/onboarding/views/success.js
@@ -27,7 +27,7 @@ import pinExtensionOpera from '../assets/pin-extension-opera.jpg';
 let screenshotURL = '';
 let type = '';
 
-if (__PLATFORM__ !== 'firefox') {
+if (__CHROMIUM__) {
   const { name } = getBrowser();
 
   if (name === 'chrome' || name === 'yandex' || name === 'oculus') {
@@ -112,7 +112,7 @@ export default {
             `}
           </section>
         </ui-card>
-        ${__PLATFORM__ !== 'firefox' &&
+        ${__CHROMIUM__ &&
         screenshotURL &&
         html`
           <ui-card>

--- a/src/pages/panel/store/notification.js
+++ b/src/pages/panel/store/notification.js
@@ -28,7 +28,7 @@ const NOTIFICATIONS = {
     type: 'danger',
     text: msg`Due to browser restrictions and additional permissions missing, Ghostery is not able to protect you.`,
     url:
-      __PLATFORM__ !== 'firefox' && isSafari()
+      __CHROMIUM__ && isSafari()
         ? 'https://www.ghostery.com/blog/how-to-install-extensions-in-safari?utm_source=gbe&utm_campaign=safaripermissions'
         : 'https://www.ghostery.com/support?utm_source=gbe&utm_campaign=permissions',
     action: msg`Get help`,
@@ -79,7 +79,7 @@ const Notification = {
     if (!terms) return NOTIFICATIONS.terms;
 
     // Opera SERP support notification
-    if (__PLATFORM__ !== 'firefox' && isOpera() && !(await isSerpSupported())) {
+    if (__CHROMIUM__ && isOpera() && !(await isSerpSupported())) {
       return NOTIFICATIONS.opera;
     }
 
@@ -87,7 +87,7 @@ const Notification = {
     if (!panel.notifications) return null;
 
     // Edge mobile notification for Edge desktop users
-    if (__PLATFORM__ !== 'firefox' && isEdge() && !isMobile()) {
+    if (__CHROMIUM__ && isEdge() && !isMobile()) {
       return NOTIFICATIONS.edgeMobile;
     }
 

--- a/src/pages/panel/views/menu.js
+++ b/src/pages/panel/views/menu.js
@@ -126,7 +126,7 @@ export default {
             </panel-menu-item>
 
             <panel-menu-item
-              href="${__PLATFORM__ === 'firefox'
+              href="${__FIREFOX__
                 ? 'https://addons.mozilla.org/firefox/addon/ghostery/privacy/'
                 : 'https://www.ghostery.com/privacy-policy?utm_source=gbe&utm_campaign=menu-privacypolicy'}"
               icon="privacy-m"

--- a/src/pages/panel/views/trackers-report.js
+++ b/src/pages/panel/views/trackers-report.js
@@ -50,7 +50,7 @@ async function downloadReport(host, event) {
     type: 'text/csv;charset=utf-8;',
     // Safari does not support downloading files from the popup window,
     // so we need to open the download helper page in a new tab
-    forceNewTab: __PLATFORM__ !== 'firefox' && isWebkit(),
+    forceNewTab: __CHROMIUM__ && isWebkit(),
   });
 
   button.disabled = false;

--- a/src/pages/redirect-protection/store/target.js
+++ b/src/pages/redirect-protection/store/target.js
@@ -22,7 +22,7 @@ const Target = {
   [store.connect]: async () => {
     let url = '';
 
-    if (__PLATFORM__ === 'firefox') {
+    if (__FIREFOX__) {
       const params = new URLSearchParams(window.location.search);
       const encodedUrl = params.get('url');
 

--- a/src/pages/settings/components/devtools.js
+++ b/src/pages/settings/components/devtools.js
@@ -242,7 +242,7 @@ export default {
               `,
             ),
           )}
-          ${__PLATFORM__ !== 'firefox' &&
+          ${__CHROMIUM__ &&
           html`
             <div layout="column gap items:start" translate="no">
               <ui-text type="headline-s">Enabled DNR rulesets</ui-text>

--- a/src/pages/settings/views/custom-filters.js
+++ b/src/pages/settings/views/custom-filters.js
@@ -122,7 +122,7 @@ export default {
                         Custom filters have been updated
                       </ui-text>
                       <ui-text type="body-s" color="secondary">
-                        ${__PLATFORM__ === 'firefox'
+                        ${__FIREFOX__
                           ? html`Network filters: ${result.networkFilters || 0} `
                           : html`
                               <details>

--- a/src/pages/settings/views/my-ghostery.js
+++ b/src/pages/settings/views/my-ghostery.js
@@ -132,7 +132,7 @@ export default {
             `}
             ${!managedConfig.disableUserAccount &&
             html`
-              ${(__PLATFORM__ === 'firefox' || (!isOpera() && !isWebkit())) &&
+              ${(__FIREFOX__ || (!isOpera() && !isWebkit())) &&
               html`
                 <ui-toggle value="${options.sync}" onchange="${html.set(options, 'sync')}">
                   <settings-option>

--- a/src/pages/settings/views/whotracksme.js
+++ b/src/pages/settings/views/whotracksme.js
@@ -149,7 +149,7 @@ export default {
                 </div>
               </ui-toggle>
             </settings-managed>
-            ${__PLATFORM__ === 'firefox' &&
+            ${__FIREFOX__ &&
             html`
               <ui-toggle value="${options.feedback}" onchange="${html.set(options, 'feedback')}">
                 <div layout="row items:start gap:2 grow" layout@768px="gap:3">

--- a/src/store/config.js
+++ b/src/store/config.js
@@ -80,7 +80,7 @@ const Config = {
       values ||= {};
 
       await chrome.storage.local.set({
-        config: __PLATFORM__ === 'firefox' ? JSON.parse(JSON.stringify(values)) : values,
+        config: __FIREFOX__ ? JSON.parse(JSON.stringify(values)) : values,
       });
       return values;
     },

--- a/src/store/element-picker-selectors.js
+++ b/src/store/element-picker-selectors.js
@@ -22,8 +22,7 @@ const ElementPickerSelectors = {
     },
     set: async (id, values) => {
       await chrome.storage.local.set({
-        elementPickerSelectors:
-          __PLATFORM__ === 'firefox' ? JSON.parse(JSON.stringify(values)) : values,
+        elementPickerSelectors: __FIREFOX__ ? JSON.parse(JSON.stringify(values)) : values,
       });
 
       return values;

--- a/src/store/managed-config.js
+++ b/src/store/managed-config.js
@@ -36,7 +36,7 @@ const ManagedConfig = {
     config.customFilters.enabled,
 
   [store.connect]: async () => {
-    if (__PLATFORM__ !== 'firefox' && (isOpera() || isWebkit())) return {};
+    if (__CHROMIUM__ && (isOpera() || isWebkit())) return {};
 
     try {
       // Firefox uses filesystem configuration on every platform
@@ -51,7 +51,7 @@ const ManagedConfig = {
       // Chromium-based browsers just return an empty object,
       // and it might be available later (especially on the browser restart),
       // so we try to read it with fallback from local storage
-      if (__PLATFORM__ !== 'firefox' || debugMode) {
+      if (__CHROMIUM__ || debugMode) {
         if (Object.keys(managedConfig).length) {
           // Save local version for fallback usage
           // Don't await - we don't need to block on this

--- a/src/store/options.js
+++ b/src/store/options.js
@@ -85,7 +85,7 @@ const Options = {
   // WhoTracks.Me
   wtmSerpReport: true,
   trackerWheel: false,
-  ...(__PLATFORM__ === 'firefox' || !isSafari() ? { trackerCount: true } : {}),
+  ...(__FIREFOX__ || !isSafari() ? { trackerCount: true } : {}),
   pauseAssistant: true,
 
   // Onboarding
@@ -132,7 +132,7 @@ const Options = {
       }
 
       // Apply managed options for supported platforms
-      if (__PLATFORM__ === 'firefox' || (!isSafari() && !isOpera())) {
+      if (__FIREFOX__ || (!isSafari() && !isOpera())) {
         return manage(options);
       }
 
@@ -144,7 +144,7 @@ const Options = {
       await chrome.storage.local.set({
         options:
           // Firefox does not serialize correctly objects with getters
-          __PLATFORM__ === 'firefox' ? JSON.parse(JSON.stringify(options)) : options,
+          __FIREFOX__ ? JSON.parse(JSON.stringify(options)) : options,
       });
 
       // Send update message to another contexts (background page / panel / options)

--- a/src/store/resources.js
+++ b/src/store/resources.js
@@ -19,7 +19,7 @@ const Resources = {
     get: async () => chrome.storage.local.get('resources').then(({ resources = {} }) => resources),
     set: async (_, values) => {
       await chrome.storage.local.set({
-        resources: __PLATFORM__ === 'firefox' ? JSON.parse(JSON.stringify(values)) : values,
+        resources: __FIREFOX__ ? JSON.parse(JSON.stringify(values)) : values,
       });
 
       return values;

--- a/src/utils/browser-info.js
+++ b/src/utils/browser-info.js
@@ -21,11 +21,11 @@ function getUA() {
 }
 
 export function getBrowser() {
-  if (__PLATFORM__ === 'firefox') {
+  if (__FIREFOX__) {
     return { name: 'firefox', token: 'ff' };
   }
 
-  if (__PLATFORM__ !== 'firefox') {
+  if (__CHROMIUM__) {
     // Brave's user agent detects as `Chrome`,
     // so we need to check for Brave specifically
     if (navigator.brave?.isBrave) {
@@ -92,7 +92,7 @@ export function isOculus() {
 }
 
 export function isWebkit() {
-  if (__PLATFORM__ === 'firefox') return false;
+  if (__FIREFOX__) return false;
 
   // Edge on iPadOS has OS detected as `ios`
   if (isSafari() || getOS() === 'ios') return true;
@@ -144,7 +144,7 @@ export default async function getBrowserInfo() {
   };
 
   if (
-    __PLATFORM__ !== 'firefox' &&
+    __CHROMIUM__ &&
     browserInfo.os === 'mac' &&
     chrome.runtime.getPlatformInfo &&
     (await chrome.runtime.getPlatformInfo()).os === 'ios'

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -28,9 +28,14 @@ export function filter(item) {
     // Platform check
     // Possible values: 'chromium', 'firefox', 'webkit'
     if (check && Array.isArray(item.filter.platform)) {
-      check = item.filter.platform.includes(
-        __PLATFORM__ !== 'firefox' && isWebkit() ? 'webkit' : __PLATFORM__,
-      );
+      let platform;
+      if (__CHROMIUM__) {
+        platform = isWebkit() ? 'webkit' : 'chromium';
+      } else if (__FIREFOX__) {
+        platform = 'firefox';
+      }
+
+      check = item.filter.platform.includes(platform);
     }
 
     // Browser check

--- a/src/utils/engines.js
+++ b/src/utils/engines.js
@@ -111,7 +111,7 @@ async function loadFromStorage(name) {
         });
       })
       .catch((e) => {
-        if (__PLATFORM__ === 'firefox') {
+        if (__FIREFOX__) {
           const key = `engines:${name}`;
           return chrome.storage.local.get([key]).then((data) => data[key]);
         } else {
@@ -160,14 +160,14 @@ async function saveToStorage(name, checksum) {
       await table.delete(name);
     }
 
-    if (__PLATFORM__ === 'firefox') {
+    if (__FIREFOX__) {
       // Clear out the fallback local storage if the engine is saved to the IDB
       chrome.storage.local.remove([`engines:${name}`]);
     }
 
     await tx.done;
   } catch (e) {
-    if (__PLATFORM__ === 'firefox') {
+    if (__FIREFOX__) {
       const key = `engines:${name}`;
       if (engine) {
         return chrome.storage.local.set({ [key]: serialized });

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -48,7 +48,7 @@ getBrowserInfo().then(
 export async function captureException(error) {
   const { terms, feedback } = await store.resolve(Options);
 
-  if (__PLATFORM__ === 'tests' || !terms || !feedback || !(error instanceof Error)) {
+  if (!terms || !feedback || !(error instanceof Error)) {
     return;
   }
 

--- a/src/utils/files.js
+++ b/src/utils/files.js
@@ -21,7 +21,7 @@ export function saveAs(url, filename) {
 }
 
 function saveOrOpenTab(url, filename, forceNewTab = false) {
-  if (__PLATFORM__ !== 'firefox' && forceNewTab) {
+  if (__CHROMIUM__ && forceNewTab) {
     return chrome.tabs.create({
       url: url.startsWith('data:')
         ? url
@@ -47,7 +47,7 @@ export async function download({
 
   // Safari on iOS does not support downloading blobs,
   // but it can handle data URLs, so we convert the blob to a data URL in that case.
-  if (__PLATFORM__ !== 'firefox') {
+  if (__CHROMIUM__) {
     const { os } = await getBrowserInfo();
 
     if (os === 'ios' || os === 'ipados') {

--- a/src/utils/tabs.js
+++ b/src/utils/tabs.js
@@ -14,7 +14,7 @@ import { getOS } from './browser-info.js';
 export async function openTabWithUrl(host, event) {
   // Firefox does not support Tabs API in iframes (Trackers Preview)
   // Firefox Android does not allow using `window.close()` in async event listeners
-  if (__PLATFORM__ === 'firefox' && (!chrome.tabs || getOS() === 'android')) {
+  if (__FIREFOX__ && (!chrome.tabs || getOS() === 'android')) {
     event.currentTarget.target = '_blank';
     // Timeout is required to prevent from closing the window before the anchor is opened
     setTimeout(() => window.close(), 50);

--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -25,7 +25,7 @@ export const PANEL_STORE_PAGE_URL = `${HOME_PAGE_URL}downloads/review?utm_source
 export const REVIEW_STORE_PAGE_URL = `${HOME_PAGE_URL}downloads/review?utm_source=gbe&utm_campaign=review`;
 
 export const BECOME_A_CONTRIBUTOR_PAGE_URL =
-  __PLATFORM__ !== 'firefox' && isSafari()
+  __CHROMIUM__ && isSafari()
     ? 'ghosteryapp://www.ghostery.com'
     : 'https://www.ghostery.com/become-a-contributor';
 

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -9,13 +9,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import { describe, it } from 'node:test';
+import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { filter } from '../../src/utils/config.js';
 
 describe('Remote config', () => {
   describe('filter()', () => {
+    beforeEach(() => {
+      global.__CHROMIUM__ = true;
+      global.__FIREFOX__ = false;
+    });
+
     it('should return false for unsupported filters', () => {
       const originalWarn = console.warn;
       let warnCalled = false;
@@ -38,33 +43,33 @@ describe('Remote config', () => {
     });
 
     it('should return true if platform matches', () => {
-      global.__PLATFORM__ = 'chromium';
       assert.deepEqual(filter({ filter: { platform: ['chromium'] } }), true);
     });
 
     it('should return false if platform does not match', () => {
-      global.__PLATFORM__ = 'chromium';
       assert.deepEqual(filter({ filter: { platform: ['firefox'] } }), false);
     });
 
     it('should return true for firefox platform when set', () => {
-      global.__PLATFORM__ = 'firefox';
+      global.__CHROMIUM__ = false;
+      global.__FIREFOX__ = true;
+
       assert.deepEqual(filter({ filter: { platform: ['firefox'] } }), true);
       assert.deepEqual(filter({ filter: { platform: ['chromium'] } }), false);
     });
 
     it('should return true if browser matches', () => {
-      global.__PLATFORM__ = 'chromium';
       assert.deepEqual(filter({ filter: { browser: 'chrome' } }), true);
     });
 
     it('should return false if browser does not match', () => {
-      global.__PLATFORM__ = 'chromium';
       assert.deepEqual(filter({ filter: { browser: 'firefox' } }), false);
     });
 
     it('should return true for firefox browser when set', () => {
-      global.__PLATFORM__ = 'firefox';
+      global.__CHROMIUM__ = false;
+      global.__FIREFOX__ = true;
+
       assert.deepEqual(filter({ filter: { browser: 'firefox' } }), true);
       assert.deepEqual(filter({ filter: { browser: 'chrome' } }), false);
     });
@@ -91,7 +96,6 @@ describe('Remote config', () => {
     });
 
     it('should combine version and platform checks', () => {
-      global.__PLATFORM__ = 'chromium';
       global.chrome.runtime.getManifest = () => ({ version: '2.0.0' });
 
       // Both match
@@ -105,7 +109,6 @@ describe('Remote config', () => {
     });
 
     it('should combine version and browser checks', () => {
-      global.__PLATFORM__ = 'chromium';
       global.chrome.runtime.getManifest = () => ({ version: '2.0.0' });
 
       // Both match

--- a/tests/unit/setup/init-chrome.js
+++ b/tests/unit/setup/init-chrome.js
@@ -27,6 +27,5 @@ Object.defineProperty(global, 'navigator', {
   configurable: true,
 });
 
-if (typeof globalThis.__PLATFORM__ === 'undefined') {
-  global.__PLATFORM__ = 'chrome';
-}
+global.__CHROMIUM__ = true;
+global.__FIREFOX__ = false;


### PR DESCRIPTION
This PR replaces `__PLATFORM__` environment variable with `__FIREFOX__` and `__CHROMIUM__`. The readability of conditions has been improved.

This PR does not remove any condition. It only replaces variables. We can check whether there are places where using env for conditional code makes sense, but it's usually used when code must run only on a selected platform.