### PR TITLE
fix(adblocker): update filters when engines change & add missing documentId

### DIFF
--- a/src/background/adblocker/index.js
+++ b/src/background/adblocker/index.js
@@ -186,7 +186,7 @@ export const setup = asyncSetup('adblocker', [
     const lastEnabledEngines = lastValue && getEnabledEngines(lastValue);
 
     // Enabled engines changed (they might contain outdated filters)
-    const engingesChanged =
+    const enginesChanged =
       lastEnabledEngines &&
       (enabledEngines.length !== lastEnabledEngines.length ||
         enabledEngines.some((id, i) => id !== lastEnabledEngines[i]));
@@ -194,14 +194,14 @@ export const setup = asyncSetup('adblocker', [
     // Reload main engine:
     // * when engine is not initialized or initialize fails (adblocker version mismatch)
     // * when enabled engines changed
-    if (!(await engines.init(engines.MAIN_ENGINE)) || engingesChanged) {
+    if (!(await engines.init(engines.MAIN_ENGINE)) || enginesChanged) {
       await reloadMainEngine();
     }
 
     // Update engine filters:
     // * when engines changed, so there might be re-enabled engines with outdated filters
     // * when filters are outdated (older than 1 hour)
-    if (engingesChanged || options.filtersUpdatedAt < Date.now() - UPDATE_ENGINES_DELAY) {
+    if (enginesChanged || options.filtersUpdatedAt < Date.now() - UPDATE_ENGINES_DELAY) {
       await updateEngines();
     }
   }),


### PR DESCRIPTION
This PR fixes two minor issues:
* Adds a trigger for updating filters when enabled engines change. It is required, as we only update enabled engines. If the user disables one of them, and then re-enable, those might be out of date until next scheduled update.
* Adds missing `documentId` option calculated in `onMessage` callback from the content scripts