### PR TITLE
fix(utils): add fallback to request url for source url

### DIFF
--- a/src/background/adblocker/index.js
+++ b/src/background/adblocker/index.js
@@ -528,7 +528,7 @@ function isTrusted(request, type) {
 }
 
 if (__FIREFOX__) {
-  function resolveRequest(details) {
+  function getMatchableRequest(details) {
     // Extension context request
     if (
       (details.tabId === -1 && details.url.startsWith('moz-extension://')) ||
@@ -556,7 +556,7 @@ if (__FIREFOX__) {
 
   chrome.webRequest.onBeforeRequest.addListener(
     (details) => {
-      const request = resolveRequest(details);
+      const request = getMatchableRequest(details);
       if (!request) return;
 
       const engine = engines.get(engines.MAIN_ENGINE);
@@ -593,7 +593,7 @@ if (__FIREFOX__) {
 
   chrome.webRequest.onHeadersReceived.addListener(
     (details) => {
-      const request = resolveRequest(details);
+      const request = getMatchableRequest(details);
       if (!request) return;
 
       const engine = engines.get(engines.MAIN_ENGINE);


### PR DESCRIPTION
On Firefox, requests to images on YT throw an error:
<img width="758" height="110" alt="Zrzut ekranu 2026-02-20 o 09 44 48" src="https://github.com/user-attachments/assets/63c622a9-a732-40b3-9417-4a49896a73fb" />

The error is related to how we compute the `sourceHostname`. Take a look at the request details:

<img width="472" height="399" alt="Zrzut ekranu 2026-02-20 o 09 44 37" src="https://github.com/user-attachments/assets/a3d17842-a8ed-41ae-9651-7e28a019de5f" />

It must be an XHR unconnected to the main frame, as the `originUrl` and `documentUrl` are `undefined`. As the last resort, we must fallback to `details.url`.

The PR fixes the error message (and this request processing) in the SW logs.