### PR TITLE
fix(exceptions): add e2e tests

### DIFF
--- a/src/pages/panel/views/main.js
+++ b/src/pages/panel/views/main.js
@@ -442,6 +442,7 @@ export default {
                                         trackerId: tracker.id,
                                       })}"
                                       layout="row center relative"
+                                      data-qa="button:tracker:protection-status:${tracker.id}"
                                     >
                                       <panel-protection-status-icon
                                         options="${options}"

--- a/src/pages/panel/views/protection-status.js
+++ b/src/pages/panel/views/protection-status.js
@@ -69,6 +69,7 @@ export default {
               disabled="${exceptionStatus.trusted && exceptionStatus.global}"
               onchange="${toggleDomain}"
               no-label
+              data-qa="button:protection-status:trust:website"
             >
               <div layout="grow">
                 <ui-text type="label-m">Trust on this website</ui-text>
@@ -85,6 +86,7 @@ export default {
               value="${exceptionStatus.trusted && exceptionStatus.global}"
               onchange="${toggleGlobal}"
               no-label
+              data-qa="button:protection-status:trust:global"
             >
               <div layout="grow">
                 <ui-text type="label-m">Trust on all websites</ui-text>

--- a/src/pages/settings/components/exception-toggle.js
+++ b/src/pages/settings/components/exception-toggle.js
@@ -31,13 +31,21 @@ export default {
         layout.responsive@768px="row"
       >
         <ui-action-button grouped active="${!value}">
-          <button layout="row relative gap:0.5 padding:0.5" onclick="${updateValue(false)}">
+          <button
+            layout="row relative gap:0.5 padding:0.5"
+            onclick="${updateValue(false)}"
+            data-qa="component:exception-toggle:block"
+          >
             <ui-icon name="block-s"></ui-icon>
             <ui-text type="label-xs" color="inherit">Blocked</ui-text>
           </button>
         </ui-action-button>
         <ui-action-button class="trusted" grouped active="${value}">
-          <button layout="row gap:0.5 padding:0.5" onclick="${updateValue(true)}">
+          <button
+            layout="row gap:0.5 padding:0.5"
+            onclick="${updateValue(true)}"
+            data-qa="component:exception-toggle:trust"
+          >
             <ui-icon name="trust-s"></ui-icon>
             <ui-text type="label-xs" color="inherit">Trusted</ui-text>
           </button>

--- a/src/pages/settings/settings.js
+++ b/src/pages/settings/settings.js
@@ -57,6 +57,7 @@ export default {
               active: router.active(Trackers, { stack: true }),
             }}"
             slot="nav"
+            data-qa="button:trackers"
           >
             <ui-icon name="block-m" color="nav" layout="size:3"></ui-icon>
             Trackers

--- a/src/pages/settings/views/trackers.js
+++ b/src/pages/settings/views/trackers.js
@@ -112,11 +112,16 @@ export default {
                 layout="width::12 grow"
                 layout@768px="grow:0"
                 onclick="${html.set('category', category !== '_all' ? '_all' : '')}"
+                data-qa="button:trackers:expand"
               >
                 <button>${category !== '_all' ? msg`Expand` : msg`Collapse`}</button>
               </ui-button>
               <ui-input layout="grow" layout@768px="grow:0">
-                <select value="${filter}" onchange="${html.set('filter')}">
+                <select
+                  value="${filter}"
+                  onchange="${html.set('filter')}"
+                  data-qa="select:trackers:filter"
+                >
                   <option selected value="">Show all</option>
                   <option value="adjusted">
                     <!-- Plural form - list of adjusted trackers | tracker-list -->Adjusted
@@ -135,6 +140,7 @@ export default {
                   defaultValue="${query}"
                   oninput="${setLazyQuery}"
                   placeholder="${msg`Search for a tracker or organization...`}"
+                  data-qa="input:trackers:search"
                 />
               </ui-input>
             </div>
@@ -167,6 +173,7 @@ export default {
                                     })}"
                                     layout="column grow basis:0"
                                     layout@768px="row gap:2"
+                                    data-qa="button:trackers:details:${tracker.id}"
                                   >
                                     <ui-text type="label-m"> ${tracker.name} </ui-text>
                                     ${store.ready(tracker.organization) &&

--- a/src/pages/settings/views/websites.js
+++ b/src/pages/settings/views/websites.js
@@ -176,7 +176,11 @@ export default {
                           ${!item.managed &&
                           html`
                             <ui-action>
-                              <button layout@768px="order:1" onclick="${revokeCallback(item)}">
+                              <button
+                                layout@768px="order:1 row center"
+                                onclick="${revokeCallback(item)}"
+                                data-qa="button:website:trash:${item.id}"
+                              >
                                 <ui-icon name="trash" layout="size:3" color="tertiary"></ui-icon>
                               </button>
                             </ui-action>

--- a/tests/e2e/spec/exceptions.spec.js
+++ b/tests/e2e/spec/exceptions.spec.js
@@ -1,0 +1,120 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+import { browser, expect } from '@wdio/globals';
+
+import { PAGE_DOMAIN, PAGE_URL } from '../wdio.conf.js';
+import {
+  enableExtension,
+  getExtensionElement,
+  getExtensionPageURL,
+  openPanel,
+  TRACKER_IDS,
+  waitForIdleBackgroundTasks,
+} from '../utils.js';
+
+describe('Exceptions', function () {
+  before(enableExtension);
+
+  const TRACKER_ID = TRACKER_IDS[0];
+
+  it('adds global exception to the selected tracker', async function () {
+    await browser.url(PAGE_URL);
+
+    await openPanel();
+    await getExtensionElement('button:detailed-view').click();
+
+    await expect(getExtensionElement(`button:tracker:${TRACKER_ID}`)).toBeDisplayed();
+    await expect(getExtensionElement(`icon:tracker:${TRACKER_ID}:blocked`)).toBeDisplayed();
+
+    await getExtensionElement(`button:tracker:protection-status:${TRACKER_ID}`).click();
+
+    const toggle = await getExtensionElement('button:protection-status:trust:global');
+    await expect(await toggle.getProperty('value')).toBe(false);
+
+    await toggle.click();
+    await waitForIdleBackgroundTasks();
+
+    // Check that the tracker is now marked as trusted in the panel
+
+    await browser.url(PAGE_URL);
+    await openPanel();
+    await expect(getExtensionElement(`button:tracker:${TRACKER_ID}`)).toBeDisplayed();
+    await expect(getExtensionElement(`icon:tracker:${TRACKER_ID}:blocked`)).not.toBeDisplayed();
+
+    // Open list of trackers and go to tracker details
+
+    await browser.url(getExtensionPageURL('settings'));
+    await getExtensionElement('button:trackers').click();
+
+    const filterSelect = await getExtensionElement('select:trackers:filter');
+    await filterSelect.selectByAttribute('value', 'trusted');
+
+    await getExtensionElement(`button:trackers:expand`).click();
+    await getExtensionElement(`button:trackers:details:${TRACKER_ID}`).click();
+
+    // Toggle protection status to blocked
+
+    await getExtensionElement(`component:exception-toggle:block`).click();
+    await waitForIdleBackgroundTasks();
+
+    await browser.url(PAGE_URL);
+
+    await openPanel();
+    await expect(getExtensionElement(`button:tracker:${TRACKER_ID}`)).toBeDisplayed();
+    await expect(getExtensionElement(`icon:tracker:${TRACKER_ID}:blocked`)).toBeDisplayed();
+  });
+
+  it('adds website exception to the selected tracker', async function () {
+    await browser.url(PAGE_URL);
+
+    await openPanel();
+    await getExtensionElement('button:detailed-view').click();
+
+    await expect(getExtensionElement(`button:tracker:${TRACKER_ID}`)).toBeDisplayed();
+    await expect(getExtensionElement(`icon:tracker:${TRACKER_ID}:blocked`)).toBeDisplayed();
+
+    await getExtensionElement(`button:tracker:protection-status:${TRACKER_ID}`).click();
+
+    const toggle = await getExtensionElement('button:protection-status:trust:website');
+    await expect(await toggle.getProperty('value')).toBe(false);
+
+    await toggle.click();
+    await waitForIdleBackgroundTasks();
+
+    // Check that the tracker is now marked as trusted in the panel
+
+    await browser.url(PAGE_URL);
+    await openPanel();
+    await expect(getExtensionElement(`button:tracker:${TRACKER_ID}`)).toBeDisplayed();
+    await expect(getExtensionElement(`icon:tracker:${TRACKER_ID}:blocked`)).not.toBeDisplayed();
+
+    // Go to settings and check that the website is listed in the list of websites
+
+    await browser.url(getExtensionPageURL('settings'));
+    await getExtensionElement('button:websites').click();
+
+    const trashButton = getExtensionElement(`button:website:trash:${PAGE_DOMAIN}`);
+    await expect(trashButton).toBeDisplayed();
+
+    // Remove the website exception
+
+    await trashButton.click();
+    await waitForIdleBackgroundTasks();
+
+    // Check that the tracker is now marked as blocked in the panel
+
+    await browser.url(PAGE_URL);
+
+    await openPanel();
+    await expect(getExtensionElement(`button:tracker:${TRACKER_ID}`)).toBeDisplayed();
+    await expect(getExtensionElement(`icon:tracker:${TRACKER_ID}:blocked`)).toBeDisplayed();
+  });
+});


### PR DESCRIPTION
The PR adds missing e2e tests for the exceptions feature. The tests contain trusting a tracker globally and in website domain scope.