### PR TITLE
Build: shorten long file paths to avoid windows limits

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -352,6 +352,7 @@ function mapPaths(paths) {
   }, {});
 }
 
+const shortenedPaths = new Map();
 const buildPromise = build({
   ...config,
   build: {
@@ -380,10 +381,50 @@ const buildPromise = build({
             .replace('node_modules', 'npm')
             .replace('_virtual', 'virtual');
 
-          const path = name.replace(pwd, '');
-          if (path.length > 110 && !argv['no-filename-limit']) {
+          const PATH_LIMIT = 110;
+          const hasPwd = name.startsWith(pwd);
+          let relPath = hasPwd ? name.slice(pwd.length) : name;
+
+          if (relPath.length > PATH_LIMIT) {
+            const segments = relPath.split('/');
+
+            while (segments.join('/').length > PATH_LIMIT) {
+              let maxLen = 0;
+              let maxIdx = -1;
+
+              for (let i = 0; i < segments.length; i++) {
+                const dotIdx = segments[i].lastIndexOf('.');
+                const base = dotIdx > 0 ? segments[i].slice(0, dotIdx) : segments[i];
+                if (base.length > maxLen) {
+                  maxLen = base.length;
+                  maxIdx = i;
+                }
+              }
+
+              if (maxLen <= 6) break;
+
+              const seg = segments[maxIdx];
+              const dotIdx = seg.lastIndexOf('.');
+              const ext = dotIdx > 0 ? seg.slice(dotIdx) : '';
+              const base = dotIdx > 0 ? seg.slice(0, dotIdx) : seg;
+
+              let hash = 5381;
+              for (let i = 0; i < base.length; i++) {
+                hash = ((hash << 5) + hash + base.charCodeAt(i)) >>> 0;
+              }
+
+              segments[maxIdx] = base[0] + hash.toString(36).slice(0, 4) + ext;
+            }
+
+            const shortened = segments.join('/');
+            shortenedPaths.set(shortened, relPath);
+            relPath = shortened;
+            name = hasPwd ? pwd + relPath : relPath;
+          }
+
+          if (relPath.length > PATH_LIMIT && !argv['no-filename-limit']) {
             throw new Error(
-              `Filename too long: ${path} (${path.length}) (pass --no-filename-limit to disable; for instance, "npm run build -- --no-filename-limit")`,
+              `Filename too long: ${relPath} (${relPath.length}) (pass --no-filename-limit to disable; for instance, "npm run build -- --no-filename-limit")`,
             );
           }
 
@@ -393,6 +434,18 @@ const buildPromise = build({
     },
   },
   plugins: [
+    {
+      name: 'shortened-path-banner',
+      generateBundle(_, bundle) {
+        for (const [fileName, chunk] of Object.entries(bundle)) {
+          if (chunk.type !== 'chunk') continue;
+          const original = shortenedPaths.get('/' + fileName);
+          if (original) {
+            chunk.code = `/* original: ${original} */\n` + chunk.code;
+          }
+        }
+      },
+    },
     // Keep offscreen documents from @whotracksme/reporting
     {
       name: 'copy-reporting-assets',

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -353,7 +353,7 @@ function mapPaths(paths) {
 }
 
 const PATH_LIMIT = 110;
-const SHORTENED_BASE_LENGTH = 5;
+const MIN_SHORTEN_BASE = 6;
 
 function splitSegment(segment) {
   const dotIdx = segment.lastIndexOf('.');
@@ -361,21 +361,17 @@ function splitSegment(segment) {
   return { base: segment.slice(0, dotIdx), ext: segment.slice(dotIdx) };
 }
 
-function hashDJBX33A(str) {
-  let hash = 5381;
-  for (let i = 0; i < str.length; i++) {
-    hash = ((hash << 5) + hash + str.charCodeAt(i)) >>> 0;
-  }
-  return hash;
-}
+let shortNameCounter = 0;
+const shortNameBySegment = new Map();
+const originalByOutput = new Map();
 
-// Replaces the longest segment bases with `firstChar + base36(hash(base))` until the path fits the limit
+// Rename the longest segments to short counter values: "0", "1", ..., "z", "10", ...
 function shortenPath(path, limit) {
   const segments = path.split('/');
 
   while (segments.join('/').length > limit) {
     let longestIdx = -1;
-    let longestLength = SHORTENED_BASE_LENGTH + 1;
+    let longestLength = MIN_SHORTEN_BASE;
 
     for (let i = 0; i < segments.length; i++) {
       const { base } = splitSegment(segments[i]);
@@ -387,17 +383,38 @@ function shortenPath(path, limit) {
 
     if (longestIdx === -1) break;
 
-    const { base, ext } = splitSegment(segments[longestIdx]);
-    const hash = hashDJBX33A(base)
-      .toString(36)
-      .slice(0, SHORTENED_BASE_LENGTH - 1);
-    segments[longestIdx] = base[0] + hash + ext;
+    const segment = segments[longestIdx];
+    let short = shortNameBySegment.get(segment);
+    if (short === undefined) {
+      short = (shortNameCounter++).toString(36) + splitSegment(segment).ext;
+      shortNameBySegment.set(segment, short);
+    }
+    segments[longestIdx] = short;
   }
 
   return segments.join('/');
 }
 
-const shortenedPaths = new Map();
+// If a short name collides with a real file, append "-1", "-2", ... until unique.
+function makeUnique(path, original) {
+  const taken = (candidate) =>
+    originalByOutput.has(candidate) && originalByOutput.get(candidate) !== original;
+
+  if (!taken(path)) return path;
+
+  const slash = path.lastIndexOf('/');
+  const dir = path.slice(0, slash + 1);
+  const { base, ext } = splitSegment(path.slice(slash + 1));
+
+  let suffix = 1;
+  let candidate = `${dir}${base}-${suffix}${ext}`;
+  while (taken(candidate)) {
+    suffix += 1;
+    candidate = `${dir}${base}-${suffix}${ext}`;
+  }
+  return candidate;
+}
+
 const buildPromise = build({
   ...config,
   build: {
@@ -427,24 +444,21 @@ const buildPromise = build({
             .replace('_virtual', 'virtual');
 
           const hasPwd = name.startsWith(pwd);
-          let relPath = hasPwd ? name.slice(pwd.length) : name;
+          const original = hasPwd ? name.slice(pwd.length) : name;
+          let relPath = original;
 
           if (relPath.length > PATH_LIMIT) {
-            const shortened = shortenPath(relPath, PATH_LIMIT);
-
-            if (shortened !== relPath) {
-              const existing = shortenedPaths.get(shortened);
-              if (existing !== undefined && existing !== relPath) {
-                throw new Error(
-                  `Path shortening collision: "${relPath}" and "${existing}" both shorten to "${shortened}"`,
-                );
-              }
-
-              shortenedPaths.set(shortened, relPath);
-              relPath = shortened;
-              name = hasPwd ? pwd + relPath : relPath;
-            }
+            relPath = makeUnique(shortenPath(relPath, PATH_LIMIT), original);
+            name = hasPwd ? pwd + relPath : relPath;
           }
+
+          const claimed = originalByOutput.get(relPath);
+          if (claimed !== undefined && claimed !== original) {
+            throw new Error(
+              `Path collision: "${original}" and "${claimed}" both map to "${relPath}"`,
+            );
+          }
+          originalByOutput.set(relPath, original);
 
           if (relPath.length > PATH_LIMIT && !argv['no-filename-limit']) {
             throw new Error(
@@ -461,13 +475,16 @@ const buildPromise = build({
     {
       name: 'shortened-path-banner',
       buildStart() {
-        shortenedPaths.clear();
+        shortNameCounter = 0;
+        shortNameBySegment.clear();
+        originalByOutput.clear();
       },
       generateBundle(_, bundle) {
         for (const [fileName, chunk] of Object.entries(bundle)) {
           if (chunk.type !== 'chunk') continue;
-          const original = shortenedPaths.get('/' + fileName);
-          if (original) {
+          const outputPath = '/' + fileName;
+          const original = originalByOutput.get(outputPath);
+          if (original && original !== outputPath) {
             chunk.code = `/* original: ${original} */\n` + chunk.code;
           }
         }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -352,6 +352,51 @@ function mapPaths(paths) {
   }, {});
 }
 
+const PATH_LIMIT = 110;
+const SHORTENED_BASE_LENGTH = 5;
+
+function splitSegment(segment) {
+  const dotIdx = segment.lastIndexOf('.');
+  if (dotIdx <= 0) return { base: segment, ext: '' };
+  return { base: segment.slice(0, dotIdx), ext: segment.slice(dotIdx) };
+}
+
+function hashDJBX33A(str) {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}
+
+// Replaces the longest segment bases with `firstChar + base36(hash(base))` until the path fits the limit
+function shortenPath(path, limit) {
+  const segments = path.split('/');
+
+  while (segments.join('/').length > limit) {
+    let longestIdx = -1;
+    let longestLength = SHORTENED_BASE_LENGTH + 1;
+
+    for (let i = 0; i < segments.length; i++) {
+      const { base } = splitSegment(segments[i]);
+      if (base.length > longestLength) {
+        longestLength = base.length;
+        longestIdx = i;
+      }
+    }
+
+    if (longestIdx === -1) break;
+
+    const { base, ext } = splitSegment(segments[longestIdx]);
+    const hash = hashDJBX33A(base)
+      .toString(36)
+      .slice(0, SHORTENED_BASE_LENGTH - 1);
+    segments[longestIdx] = base[0] + hash + ext;
+  }
+
+  return segments.join('/');
+}
+
 const shortenedPaths = new Map();
 const buildPromise = build({
   ...config,
@@ -381,45 +426,24 @@ const buildPromise = build({
             .replace('node_modules', 'npm')
             .replace('_virtual', 'virtual');
 
-          const PATH_LIMIT = 110;
           const hasPwd = name.startsWith(pwd);
           let relPath = hasPwd ? name.slice(pwd.length) : name;
 
           if (relPath.length > PATH_LIMIT) {
-            const segments = relPath.split('/');
+            const shortened = shortenPath(relPath, PATH_LIMIT);
 
-            while (segments.join('/').length > PATH_LIMIT) {
-              let maxLen = 0;
-              let maxIdx = -1;
-
-              for (let i = 0; i < segments.length; i++) {
-                const dotIdx = segments[i].lastIndexOf('.');
-                const base = dotIdx > 0 ? segments[i].slice(0, dotIdx) : segments[i];
-                if (base.length > maxLen) {
-                  maxLen = base.length;
-                  maxIdx = i;
-                }
+            if (shortened !== relPath) {
+              const existing = shortenedPaths.get(shortened);
+              if (existing !== undefined && existing !== relPath) {
+                throw new Error(
+                  `Path shortening collision: "${relPath}" and "${existing}" both shorten to "${shortened}"`,
+                );
               }
 
-              if (maxLen <= 6) break;
-
-              const seg = segments[maxIdx];
-              const dotIdx = seg.lastIndexOf('.');
-              const ext = dotIdx > 0 ? seg.slice(dotIdx) : '';
-              const base = dotIdx > 0 ? seg.slice(0, dotIdx) : seg;
-
-              let hash = 5381;
-              for (let i = 0; i < base.length; i++) {
-                hash = ((hash << 5) + hash + base.charCodeAt(i)) >>> 0;
-              }
-
-              segments[maxIdx] = base[0] + hash.toString(36).slice(0, 4) + ext;
+              shortenedPaths.set(shortened, relPath);
+              relPath = shortened;
+              name = hasPwd ? pwd + relPath : relPath;
             }
-
-            const shortened = segments.join('/');
-            shortenedPaths.set(shortened, relPath);
-            relPath = shortened;
-            name = hasPwd ? pwd + relPath : relPath;
           }
 
           if (relPath.length > PATH_LIMIT && !argv['no-filename-limit']) {
@@ -436,6 +460,9 @@ const buildPromise = build({
   plugins: [
     {
       name: 'shortened-path-banner',
+      buildStart() {
+        shortenedPaths.clear();
+      },
       generateBundle(_, bundle) {
         for (const [fileName, chunk] of Object.entries(bundle)) {
           if (chunk.type !== 'chunk') continue;


### PR DESCRIPTION
Shorten long file paths in build output to avoid Windows path length limits

With preserveModules: true, some dependencies (e.g. `@adguard/agtree`) produce output paths that can exceed Windows' MAX_PATH limit. The build already renames node_modules to npm, but deeply nested packages with long filenames still cause issues.

This adds a generic path shortening mechanism in `sanitizeFileName`: when a relative path exceeds 110 characters, the longest segments are iteratively replaced with a deterministic short hash (e.g. `ubo-scriptlet-injection-body-deserializer.js` → `u18p9.js`). Shortened files get a `/* original: ... */` banner comment for traceability.

If two different paths ever shorten to the same name, the build fails with an explicit error naming both, so hash collisions cannot silently produce misleading output. The shortened-path map is reset at the start of each rebuild so watch mode stays consistent.