### PR TITLE
fix(storage): clear storage.session when reaching quota limit

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -9,6 +9,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
+import './storage.js';
+
 import './onboarding.js';
 import './config.js';
 

--- a/src/background/storage.js
+++ b/src/background/storage.js
@@ -1,0 +1,45 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { captureException } from '/utils/errors.js';
+
+// By the specification, the storage.session.QUOTA_BYTES is set to 10MB
+// so the threshold should be reached at 9MB.
+const QUOTA_THRESHOLD = 0.9;
+
+// Check session storage quota on startup to prevent issues with quota limits
+(async function checkSessionStorageQuota() {
+  try {
+    const quotaBytes = chrome.storage.session.QUOTA_BYTES;
+    if (!quotaBytes) return;
+
+    const bytesInUse = await chrome.storage.session.getBytesInUse();
+    const usage = bytesInUse / quotaBytes;
+
+    if (usage >= QUOTA_THRESHOLD) {
+      console.warn(
+        `[storage] Session storage usage at ${(usage * 100).toFixed(1)}% (${bytesInUse}/${quotaBytes} bytes). Clearing session storage.`,
+      );
+
+      await chrome.storage.session.clear();
+
+      captureException(
+        new Error(
+          `Session storage quota exceeded for ${quotaBytes} quota bytes. Cleared session storage to prevent issues.`,
+        ),
+        { critical: true, once: true },
+      );
+    }
+  } catch (e) {
+    console.error('[storage] Failed to check session storage quota:', e);
+    captureException(e, { critical: true, once: true });
+  }
+})();

--- a/src/utils/map.js
+++ b/src/utils/map.js
@@ -14,11 +14,9 @@
 // the loss of all stats when the browser terminates the execution
 // context (background script or service worker).
 
-export const storage = chrome.storage.session || chrome.storage.local;
-
 export default class AutoSyncingMap {
   static async get(storageKey, key) {
-    const data = await storage.get([storageKey]);
+    const data = await chrome.storage.session.get([storageKey]);
     return data[storageKey]?.entries[key];
   }
 
@@ -77,7 +75,7 @@ export default class AutoSyncingMap {
     // and log it. A potential improvement could be to treat the
     // in-memory map as the source of truth in that scenario.)
     this._pending = new Promise((resolve, reject) => {
-      storage.get([this.storageKey], (result) => {
+      chrome.storage.session.get([this.storageKey], (result) => {
         if (chrome.runtime.lastError) {
           reject(chrome.runtime.lastError);
         } else {
@@ -142,7 +140,7 @@ export default class AutoSyncingMap {
 
     this._scheduleAction(
       new Promise((resolve, reject) => {
-        storage.remove(this.storageKey, () => {
+        chrome.storage.session.remove(this.storageKey, () => {
           if (chrome.runtime.lastError) {
             reject(chrome.runtime.lastError);
           } else {
@@ -225,7 +223,7 @@ export default class AutoSyncingMap {
           entries: Object.fromEntries(this.inMemoryMap),
           ttl: Object.fromEntries(this._ttlMap),
         };
-        storage.set({ [this.storageKey]: serialized }, () => {
+        chrome.storage.session.set({ [this.storageKey]: serialized }, () => {
           if (chrome.runtime.lastError) {
             reject(chrome.runtime.lastError);
           } else {


### PR DESCRIPTION
This PR adds a check for session storage quota on startup to prevent issues with quota limits.

The WTM reporting package uses `storage.session` directly, so we can't create an abstract layer to protect access to the storage.

Also, the condition to fallback to `storage.local` was added to support Safari 15 (https://github.com/ghostery/ghostery-extension/pull/1340). All currently supported platforms provide `storage.session`.