### PR TITLE
fix(dnr): group rules

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -276,6 +276,11 @@ if (manifest.declarative_net_request?.rule_resources) {
   });
 }
 
+// optimise declarative net request lists
+execSync('node scripts/group-dnr-rulesets.js', {
+  stdio: silent ? '' : 'inherit',
+});
+
 // copy whotracksme configuration files
 mkdirSync(resolve(options.outDir, 'rule_resources'), { recursive: true });
 cpSync(

--- a/scripts/group-dnr-rulesets.js
+++ b/scripts/group-dnr-rulesets.js
@@ -56,7 +56,9 @@ function groupRuleset(ruleset, metadata) {
       rule.action.type === 'block' &&
       // Pick the simplest condition only with urlFilter satisfying PATTERN
       Object.keys(rule.condition).length === 1 &&
-      rule.condition?.urlFilter?.match(DOMAIN_BLOCKING_PATTERN)
+      rule.condition?.urlFilter?.match(DOMAIN_BLOCKING_PATTERN) &&
+      // Pick the rule with priority of 1
+      rule.priority === 1
     ) {
       // Extract host from ||example.com^ pattern
       hostnames.add(rule.condition.urlFilter.slice(2, -1));
@@ -70,6 +72,7 @@ function groupRuleset(ruleset, metadata) {
     result.push({
       // The rule id starts with 1, we top up 2
       id: ruleset.length + 2,
+      priority: 1,
       action: {
         type: 'block',
       },

--- a/scripts/group-dnr-rulesets.js
+++ b/scripts/group-dnr-rulesets.js
@@ -18,10 +18,7 @@ const dist = join(import.meta.dirname, '../dist/rule_resources');
 const source = join(import.meta.dirname, '../src/rule_resources');
 
 function cutPuncBy100(n) {
-  n *= 100;
-  n |= 0;
-  n /= 100;
-  return n;
+  return Math.trunc(n * 100) / 100;
 }
 
 function getRulesetIds() {

--- a/scripts/group-dnr-rulesets.js
+++ b/scripts/group-dnr-rulesets.js
@@ -1,0 +1,110 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const PATTERN = /^\|\|(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}\^$/;
+
+const dist = join(import.meta.dirname, '../dist/rule_resources');
+const source = join(import.meta.dirname, '../src/rule_resources');
+
+function cutPuncBy100(n) {
+  n *= 100;
+  n |= 0;
+  n /= 100;
+  return n;
+}
+
+function getRulesetIds() {
+  if (existsSync(dist) === false) {
+    console.warn(
+      'The destination directory is not available! Please try again after building the extension.',
+    );
+    process.exit(0);
+  }
+
+  return readdirSync(dist, { withFileTypes: true }).reduce(function (ids, descriptor) {
+    if (
+      descriptor.isFile() &&
+      // Is a JSON file
+      descriptor.name.endsWith('.json') &&
+      // Not a metadata file
+      descriptor.name.endsWith('.metadata.json') === false &&
+      // Not a redirect-protection (this won't have any rules targeted by "groupRuleset" but for safety)
+      descriptor.name.includes('redirect-protection') === false
+    ) {
+      ids.push(descriptor.name);
+    }
+    return ids;
+  }, []);
+}
+
+function groupRuleset(ruleset, metadata) {
+  const hostnames = [];
+  const result = [];
+  for (const rule of ruleset) {
+    if (
+      // Skip a rule in the metadata
+      !(rule.id in metadata) &&
+      // Pick 'block' type of rule with simple network hostname pattern
+      rule.action.type === 'block' &&
+      // Pick the simplest condition only with urlFilter satisfying PATTERN
+      Object.keys(rule.condition).length === 1 &&
+      rule.condition?.urlFilter?.match(PATTERN)
+    ) {
+      // Exact from ||acme.com^ pattern
+      hostnames.push(rule.condition.urlFilter.slice(2, -1));
+    } else {
+      result.push(rule);
+    }
+  }
+
+  result.push({
+    // The rule id starts with 1, we top up 2
+    id: ruleset.length + 2,
+    action: {
+      type: 'block',
+    },
+    requestDomains: hostnames,
+  });
+
+  return result;
+}
+
+const grandTotal = {
+  ruleset: 0,
+  newRuleset: 0,
+};
+
+for (const id of getRulesetIds()) {
+  const rulesetPath = join(source, id);
+  const metadataPath = join(source, id.replace('.json', '.metadata.json'));
+  const distPath = join(dist, id);
+
+  const ruleset = JSON.parse(readFileSync(rulesetPath, 'utf8'));
+  const metadata = existsSync(metadataPath) ? JSON.parse(readFileSync(metadataPath, 'utf8')) : {};
+
+  const newRuleset = groupRuleset(ruleset, metadata);
+
+  grandTotal.ruleset += ruleset.length;
+  grandTotal.newRuleset += newRuleset.length;
+  const ratio = cutPuncBy100(newRuleset.length / ruleset.length);
+
+  console.log(`id="${id}" before=${ruleset.length} after=${newRuleset.length} ratio=${ratio}`);
+
+  writeFileSync(distPath, JSON.stringify(newRuleset), 'utf8');
+}
+
+const grandTotalRatio = cutPuncBy100(grandTotal.newRuleset / grandTotal.ruleset);
+console.log(
+  `Reduced ${grandTotal.ruleset} rules into ${grandTotal.newRuleset} rules with ratio of ${grandTotalRatio}`,
+);

--- a/scripts/group-dnr-rulesets.js
+++ b/scripts/group-dnr-rulesets.js
@@ -58,7 +58,7 @@ function groupRuleset(ruleset, metadata) {
       Object.keys(rule.condition).length === 1 &&
       rule.condition?.urlFilter?.match(PATTERN)
     ) {
-      // Exact from ||acme.com^ pattern
+      // Extract host from ||example.com^ pattern
       hostnames.push(rule.condition.urlFilter.slice(2, -1));
     } else {
       result.push(rule);

--- a/scripts/group-dnr-rulesets.js
+++ b/scripts/group-dnr-rulesets.js
@@ -65,14 +65,19 @@ function groupRuleset(ruleset, metadata) {
     }
   }
 
-  result.push({
-    // The rule id starts with 1, we top up 2
-    id: ruleset.length + 2,
-    action: {
-      type: 'block',
-    },
-    requestDomains: Array.from(hostnames),
-  });
+  // Empty `requestDomains` is not allowed by the format.
+  if (hostnames.size > 0) {
+    result.push({
+      // The rule id starts with 1, we top up 2
+      id: ruleset.length + 2,
+      action: {
+        type: 'block',
+      },
+      condition: {
+        requestDomains: Array.from(hostnames),
+      },
+    });
+  }
 
   return result;
 }

--- a/scripts/group-dnr-rulesets.js
+++ b/scripts/group-dnr-rulesets.js
@@ -12,7 +12,7 @@
 import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-const PATTERN = /^\|\|(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}\^$/;
+const DOMAIN_BLOCKING_PATTERN = /^\|\|(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}\^$/;
 
 const dist = join(import.meta.dirname, '../dist/rule_resources');
 const source = join(import.meta.dirname, '../src/rule_resources');
@@ -49,7 +49,7 @@ function getRulesetIds() {
 }
 
 function groupRuleset(ruleset, metadata) {
-  const hostnames = [];
+  const hostnames = new Set();
   const result = [];
   for (const rule of ruleset) {
     if (
@@ -59,10 +59,10 @@ function groupRuleset(ruleset, metadata) {
       rule.action.type === 'block' &&
       // Pick the simplest condition only with urlFilter satisfying PATTERN
       Object.keys(rule.condition).length === 1 &&
-      rule.condition?.urlFilter?.match(PATTERN)
+      rule.condition?.urlFilter?.match(DOMAIN_BLOCKING_PATTERN)
     ) {
       // Exact from ||acme.com^ pattern
-      hostnames.push(rule.condition.urlFilter.slice(2, -1));
+      hostnames.add(rule.condition.urlFilter.slice(2, -1));
     } else {
       result.push(rule);
     }
@@ -74,7 +74,7 @@ function groupRuleset(ruleset, metadata) {
     action: {
       type: 'block',
     },
-    requestDomains: hostnames,
+    requestDomains: Array.from(hostnames),
   });
 
   return result;


### PR DESCRIPTION
This PR reduces the size of the DNR API ruleset by merging multiple simple rules into a more compact representation using requestDomains.
Instead of emitting many separate rules for equivalent behavior across different request domains, we group them into a single rule where possible. This lowers the total rule count and reduces ruleset size while preserving the same matching behavior.

**Notes**

- Main goal is to make the generated DNR ruleset smaller and more efficient to store/process.
- This should not have a direct effect on Safari: Safari expands rules that use requestDomains back into multiple rules internally, so the optimization mainly benefits platforms that keep the grouped form.