### PR TITLE
feat(adblocker): use `handlePseudoDirective` for pseudo directives

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.69.0",
         "@ghostery/adblocker": "^2.14.1",
-        "@ghostery/adblocker-content": "^2.13.3",
-        "@ghostery/adblocker-extended-selectors": "^2.13.3",
+        "@ghostery/adblocker-content": "^2.14.1",
+        "@ghostery/adblocker-extended-selectors": "^2.14.1",
         "@ghostery/adblocker-webextension": "^2.14.1",
         "@ghostery/config": "^0.0.10",
         "@ghostery/scriptlets": "github:ghostery/scriptlets",
@@ -15203,9 +15203,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
-      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15843,9 +15843,9 @@
       }
     },
     "node_modules/webdriver/node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.69.0",
     "@ghostery/adblocker": "^2.14.1",
-    "@ghostery/adblocker-content": "^2.13.3",
-    "@ghostery/adblocker-extended-selectors": "^2.13.3",
+    "@ghostery/adblocker-content": "^2.14.1",
+    "@ghostery/adblocker-extended-selectors": "^2.14.1",
     "@ghostery/adblocker-webextension": "^2.14.1",
     "@ghostery/config": "^0.0.10",
     "@ghostery/scriptlets": "github:ghostery/scriptlets",

--- a/src/content_scripts/adblocker/extended-selectors.js
+++ b/src/content_scripts/adblocker/extended-selectors.js
@@ -9,7 +9,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import { querySelectorAll } from '@ghostery/adblocker-extended-selectors';
+import { handlePseudoDirective, querySelectorAll } from '@ghostery/adblocker-extended-selectors';
 
 let UPDATE_EXTENDED_TIMEOUT = null;
 const PENDING = new Set();
@@ -56,9 +56,8 @@ function updateExtended() {
   for (const root of roots) {
     for (const selector of EXTENDED.values()) {
       for (const element of cachedQuerySelector(root, selector, cache)) {
-        if (selector.remove === true) {
-          element.textContent = '';
-          element.remove();
+        if (selector.directive !== undefined) {
+          handlePseudoDirective(element, selector.directive);
         } else if (selector.attribute !== undefined && HIDDEN.has(element) === false) {
           elementsToHide.set(element, { selector, root });
         }


### PR DESCRIPTION
After Adblocker combines pseudo-directives to integrate `:remove` and more, it now support one unified method: `handlePseudoDirective`.

refs https://github.com/ghostery/adblocker/pull/5397