### PR TITLE
fix(store): replace observer pattern for options with sync access

### DIFF
--- a/src/background/adblocker/index.js
+++ b/src/background/adblocker/index.js
@@ -35,8 +35,6 @@ import { getRedirectProtectionUrl } from '../redirect-protection.js';
 
 import { FramesHierarchy } from './ancestors.js';
 
-let options = Options;
-
 const contentScripts = (() => {
   const map = new Map();
   return {
@@ -112,7 +110,9 @@ export async function reloadMainEngine() {
   // Delay the reload to avoid UI freezes in Firefox and Safari
   if (__FIREFOX__ || isWebkit()) await pause(1000);
 
+  const options = await store.resolve(Options);
   const enabledEngines = getEnabledEngines(options);
+
   const resolvedEngines = (
     await Promise.all(
       enabledEngines.map((id) =>
@@ -152,6 +152,8 @@ export async function updateEngines({ cache = true } = {}) {
 
   try {
     updating = true;
+
+    const options = await store.resolve(Options);
     const enabledEngines = getEnabledEngines(options);
 
     if (enabledEngines.length) {
@@ -187,11 +189,9 @@ export async function updateEngines({ cache = true } = {}) {
 
 export const UPDATE_ENGINES_DELAY = 60 * 60 * 1000; // 1 hour
 export const setup = asyncSetup('adblocker', [
-  OptionsObserver.addListener(async function adblockerEngines(value, lastValue) {
-    options = value;
-
-    const enabledEngines = getEnabledEngines(value);
-    const lastEnabledEngines = lastValue && getEnabledEngines(lastValue);
+  OptionsObserver.addListener(async function adblockerEngines(options, lastOptions) {
+    const enabledEngines = getEnabledEngines(options);
+    const lastEnabledEngines = lastOptions && getEnabledEngines(lastOptions);
 
     // Enabled engines changed (they might contain outdated filters)
     const enginesChanged =
@@ -337,6 +337,7 @@ async function injectCosmetics(details, config) {
     return;
   }
 
+  const options = store.get(Options);
   // Checking the request url hostname
   if (getPausedDetails(options, hostname)) {
     return false;
@@ -524,25 +525,27 @@ if (__FIREFOX__) {
  * Network requests blocking - Firefox only
  */
 
-function isTrusted(request, type) {
-  // The request is from a tab that is paused
-  if (getPausedDetails(options, request.sourceHostname)) {
-    return true;
-  }
-
-  if (type === 'main_frame') {
-    return false;
-  }
-
-  return exceptions.getStatus(
-    options,
-    // Get exception for known tracker (metadata id) or by the request hostname (unidentified tracker)
-    trackerdb.getMetadata(request)?.id || request.hostname,
-    request.sourceHostname,
-  ).trusted;
-}
-
 if (__FIREFOX__) {
+  function isTrusted(request, type) {
+    const options = store.get(Options);
+
+    // The request is from a tab that is paused
+    if (getPausedDetails(options, request.sourceHostname)) {
+      return true;
+    }
+
+    if (type === 'main_frame') {
+      return false;
+    }
+
+    return exceptions.getStatus(
+      options,
+      // Get exception for known tracker (metadata id) or by the request hostname (unidentified tracker)
+      trackerdb.getMetadata(request)?.id || request.hostname,
+      request.sourceHostname,
+    ).trusted;
+  }
+
   function isMatchableRequest(details, request) {
     // Extension context request
     if (
@@ -577,7 +580,9 @@ if (__FIREFOX__) {
         const { redirect, match } = engine.match(request);
 
         if (match === true && details.type === 'main_frame') {
+          const options = store.get(Options);
           const redirectUrl = getRedirectProtectionUrl(details.url, request.hostname, options);
+
           return { redirectUrl };
         } else if (redirect !== undefined) {
           request.blocked = true;

--- a/src/background/reporting/url-reporter.js
+++ b/src/background/reporting/url-reporter.js
@@ -9,19 +9,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
+import { store } from 'hybrids';
 import { UrlReporter } from '@whotracksme/reporting/reporting';
 
-import config from './config.js';
-import { getPausedDetails } from '/store/options.js';
-import * as OptionsObserver from '/utils/options-observer.js';
-import communication from './communication.js';
-import prefixedIndexedDBKeyValueStore from './storage-indexeddb.js';
-import StorageLocal from './storage-chrome-local.js';
+import Options, { getPausedDetails } from '/store/options.js';
 
-let options = {};
-OptionsObserver.addListener(function urlReporting(value) {
-  options = value;
-});
+import communication from './communication.js';
+import config from './config.js';
+import StorageLocal from './storage-chrome-local.js';
+import prefixedIndexedDBKeyValueStore from './storage-indexeddb.js';
 
 export default new UrlReporter({
   config: config.url,
@@ -30,8 +26,8 @@ export default new UrlReporter({
   communication,
 
   pauseState: {
-    getFilteringMode: () => options.mode,
-    isHostnamePaused: (hostname) => !!getPausedDetails(options, hostname),
+    getFilteringMode: () => store.get(Options).mode,
+    isHostnamePaused: (hostname) => !!getPausedDetails(store.get(Options), hostname),
     connectHostnamePausingEvents: (notify) => {
       chrome.runtime.onMessage.addListener((msg) => {
         if (msg.action === 'reporting:updateHostnamePause') {

--- a/src/background/reporting/webrequest-reporter.js
+++ b/src/background/reporting/webrequest-reporter.js
@@ -9,15 +9,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import { RequestReporter } from '@whotracksme/reporting/reporting';
 import { store } from 'hybrids';
+import { RequestReporter } from '@whotracksme/reporting/reporting';
 import { ACTION_DISABLE_ANTITRACKING_MODIFICATION } from '@ghostery/config';
 
-import { getPausedDetails } from '/store/options.js';
+import Options, { getPausedDetails } from '/store/options.js';
 import Config from '/store/config.js';
 
 import Request from '/utils/request.js';
-import * as OptionsObserver from '/utils/options-observer.js';
 
 import { updateTabStats } from '../stats.js';
 
@@ -28,11 +27,6 @@ import urlReporter from './url-reporter.js';
 let webRequestReporter = null;
 
 if (chrome.webRequest) {
-  let options = {};
-  OptionsObserver.addListener(function webRequestReporting(value) {
-    options = value;
-  });
-
   let remoteConfig;
   store.resolve(Config).then((remote) => {
     remoteConfig = remote;
@@ -44,7 +38,9 @@ if (chrome.webRequest) {
       countryProvider: urlReporter.countryProvider,
       trustedClock: communication.trustedClock,
       isRequestAllowed: (state) => {
+        const options = store.get(Options);
         const hostname = state.tabUrlParts.hostname;
+
         return (
           !options.blockTrackers ||
           !!getPausedDetails(options, hostname) ||


### PR DESCRIPTION
The `setupAsyc`, which contains `OptionsObserver`, is a sufficient requirement for sync access to the options. The store keeps the current value of the options in memory cache, so once the options are resolved (and using options observer guarantees that), we can access options by `store.get()`. If this function does not result in a proper options object, using the current pattern would also fail. 

Moving from a scope variable to a local one is essential for upcoming features in adblocker background code (GPC needs a new feature, and I want to clean up the adblocker code by splitting it into modules from one huge index file).