### PR TITLE
chore(deprecate): `filterMaxPriorityRules`

### DIFF
--- a/scripts/download-dnr-rulesets.js
+++ b/scripts/download-dnr-rulesets.js
@@ -13,7 +13,6 @@ import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
 
 import REGIONS from '../src/utils/regions.js';
 import { CDN_HOSTNAME, RESOURCES_PATH } from './utils/urls.js';
-import { filterMaxPriorityRules } from '../src/utils/dnr.js';
 
 if (!existsSync(RESOURCES_PATH)) {
   mkdirSync(RESOURCES_PATH, { recursive: true });
@@ -58,9 +57,7 @@ for (const [name, target] of Object.entries(RULESETS)) {
   /* DNR rules */
 
   if (list.dnr) {
-    const dnr = await fetch(list.dnr.url || list.dnr.network)
-      .then(handleResponse)
-      .then(filterMaxPriorityRules);
+    const dnr = await fetch(list.dnr.url || list.dnr.network).then(handleResponse);
 
     writeFileSync(outputPath, JSON.stringify(dnr, null, 2));
 

--- a/src/background/dnr.js
+++ b/src/background/dnr.js
@@ -14,7 +14,7 @@ import { store } from 'hybrids';
 import { ENGINES, isGloballyPaused } from '/store/options.js';
 import Resources from '/store/resources.js';
 
-import { FIXES_ID_RANGE, getDynamicRulesIds, filterMaxPriorityRules } from '/utils/dnr.js';
+import { FIXES_ID_RANGE, getDynamicRulesIds } from '/utils/dnr.js';
 import * as OptionsObserver from '/utils/options-observer.js';
 import { ENGINE_CONFIGS_ROOT_URL } from '/utils/urls.js';
 import { isFilterConditionAccepted } from '/utils/engines.js';
@@ -143,13 +143,11 @@ if (__CHROMIUM__) {
 
           if (list.dnr.checksum !== resources.checksums[DNR_FIXES_KEY]) {
             const rules = new Set(
-              await fetch(list.dnr.url)
-                .then((res) =>
-                  res.ok
-                    ? res.json()
-                    : Promise.reject(new Error(`Failed to fetch DNR rules: ${res.statusText}`)),
-                )
-                .then(filterMaxPriorityRules),
+              await fetch(list.dnr.url).then((res) =>
+                res.ok
+                  ? res.json()
+                  : Promise.reject(new Error(`Failed to fetch DNR rules: ${res.statusText}`)),
+              ),
             );
             const metadata = await fetch(list.dnr.metadataUrl)
               .then((res) => res.json())

--- a/src/utils/dnr.js
+++ b/src/utils/dnr.js
@@ -47,10 +47,6 @@ export const ALL_RESOURCE_TYPES = [
   'other',
 ];
 
-export function filterMaxPriorityRules(rules) {
-  return rules.filter((rule) => rule.priority !== MAX_RULE_PRIORITY);
-}
-
 export async function getDynamicRules(type) {
   return (await chrome.declarativeNetRequest.getDynamicRules()).filter(
     (rule) => rule.id >= type.start && rule.id < type.end,


### PR DESCRIPTION
Deprecating this method as we no longer handle main frame exception via backend. Please, make sure the backend is shipping rulesets without the exception rule with the max priority.