### PR TITLE
feat(e2e): add Safari target for end-to-end tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,9 +83,16 @@ jobs:
       - name: Run tests after updating the extension
         run: npm run wdio:update -- --target=firefox
 
+  # Safari e2e. Currently best-effort on hosted runners: toggling
+  # "Show Develop menu" / "Allow Remote Automation" / "Allow Unsigned
+  # Extensions" via AppleScript is fragile on GitHub's macOS images, so the
+  # job is marked continue-on-error until a self-hosted runner with the
+  # right permissions pre-granted (or a signed-extension install path) is
+  # available.
   e2e-safari:
     runs-on: macos-15
     needs: unit
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,3 +82,18 @@ jobs:
         run: npm ci
       - name: Run tests after updating the extension
         run: npm run wdio:update -- --target=firefox
+
+  e2e-safari:
+    runs-on: macos-15
+    needs: unit
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: '.tool-versions'
+      - name: Install dependencies
+        run: npm ci
+      - name: Configure Safari automation
+        run: ./scripts/setup-safari-ci.sh
+      - name: Run tests with flags
+        run: npm run wdio -- --target=safari

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,16 @@ jobs:
           node-version-file: '.tool-versions'
       - name: Install dependencies
         run: npm ci
+      - name: Cache Safari configuration
+        uses: actions/cache@v4
+        with:
+          # setup-safari-ci.sh writes these; caching them short-circuits the
+          # AppleScript toggles on subsequent runs.
+          path: |
+            ~/Library/Preferences/com.apple.Safari.plist
+            ~/Library/Containers/com.apple.Safari/Data/Library/Preferences/com.apple.Safari.plist
+            ~/Library/Application Support/com.apple.TCC/TCC.db
+          key: safari-config-${{ runner.os }}-${{ hashFiles('scripts/setup-safari-ci.sh') }}
       - name: Configure Safari automation
         run: ./scripts/setup-safari-ci.sh
       - name: Run tests with flags

--- a/scripts/setup-safari-ci.sh
+++ b/scripts/setup-safari-ci.sh
@@ -18,6 +18,18 @@ fi
 echo "==> enabling safaridriver"
 sudo safaridriver --enable
 
+# SecurityAgent password prompts (e.g. the one "Allow unsigned extensions"
+# triggers on macOS 15+) need an actual password. Set one we control so the
+# AppleScript toggler can type it. Safe on ephemeral GitHub Actions runners.
+if [ -n "${GITHUB_ACTIONS:-}" ] && [ "$(id -un)" = "runner" ]; then
+  echo "==> setting runner password for SecurityAgent prompts"
+  # `sysadminctl` is the modern Directory Services CLI. The old value is empty
+  # on GitHub runners; pass -oldPassword "" so we don't get rejected.
+  sudo sysadminctl -resetPasswordFor runner -newPassword wdio-safari -adminUser runner -adminPassword "" 2>/dev/null || \
+    sudo dscl . -passwd /Users/runner wdio-safari 2>/dev/null || true
+  export SAFARI_ADMIN_PASSWORD=wdio-safari
+fi
+
 echo "==> granting Accessibility to /usr/bin/osascript via user TCC db"
 TCC_USER_DB="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
 TCC_SYSTEM_DB="/Library/Application Support/com.apple.TCC/TCC.db"
@@ -352,14 +364,33 @@ tell application "System Events"
     log "Developer pane checkboxes:" & linefeed & my dumpCheckboxes(window 1, "")
     set ok1 to my findAndClickCheckbox(window 1, {"Remote Automation"})
     if not ok1 then error "Could not find 'Allow Remote Automation' in Developer pane"
-    -- Allow unsigned extensions may already be on from the pre-launch plist
-    -- write above. Best-effort toggle here; do not fail the setup if the
-    -- click is rejected by a SecurityAgent prompt we can't answer.
+    -- Click "Allow unsigned extensions" and answer the SecurityAgent password
+    -- prompt it triggers on macOS 15+.
+    set pw to ""
+    try
+      set pw to system attribute "SAFARI_ADMIN_PASSWORD"
+    end try
     try
       my findAndClickCheckbox(window 1, {"unsigned"})
-    on error errMsg
-      log "WARN: could not click 'Allow unsigned extensions': " & errMsg
     end try
+    if pw is not "" then
+      delay 1
+      repeat 30 times
+        try
+          tell process "SecurityAgent"
+            if exists window 1 then
+              set frontmost to true
+              keystroke pw
+              delay 0.3
+              keystroke return
+              exit repeat
+            end if
+          end tell
+        end try
+        delay 0.3
+      end repeat
+      delay 1
+    end if
     keystroke "w" using command down
   end tell
 end tell

--- a/scripts/setup-safari-ci.sh
+++ b/scripts/setup-safari-ci.sh
@@ -198,24 +198,29 @@ tell application "System Events"
   tell process "Safari"
     set frontmost to true
     delay 0.5
-    -- Poll for the Develop menu to appear (toggling the Settings checkbox is
-    -- not instantaneous, especially after a Safari restart).
-    set hasDevelop to false
-    repeat 40 times
+    -- Open the Develop menu so its items populate (lazy on recent macOS),
+    -- then close it again via Escape before introspecting.
+    try
+      click menu bar item "Develop" of menu bar 1
+      delay 0.5
+      log "Develop items: " & (name of every menu item of menu 1 of menu bar item "Develop" of menu bar 1)
+      key code 53
+    end try
+    -- Match the menu item loosely in case Apple renamed it.
+    set theItem to missing value
+    repeat with mi in (menu items of menu 1 of menu bar item "Develop" of menu bar 1)
       try
-        set _ to menu bar item "Develop" of menu bar 1
-        set hasDevelop to true
-        exit repeat
-      on error
-        delay 0.5
+        if name of mi contains "Remote Automation" then
+          set theItem to contents of mi
+          exit repeat
+        end if
       end try
     end repeat
-    if not hasDevelop then
-      error "Develop menu never appeared — Show Develop checkbox toggle did not persist. Menu bar items: " & (name of every menu bar item of menu bar 1)
+    if theItem is missing value then
+      error "Could not find 'Allow Remote Automation' in Develop menu"
     end if
-    set automationItem to menu item "Allow Remote Automation" of menu 1 of menu bar item "Develop" of menu bar 1
-    if value of attribute "AXMenuItemMarkChar" of automationItem is not "✓" then
-      click automationItem
+    if value of attribute "AXMenuItemMarkChar" of theItem is not "✓" then
+      click theItem
     end if
   end tell
 end tell

--- a/scripts/setup-safari-ci.sh
+++ b/scripts/setup-safari-ci.sh
@@ -14,6 +14,15 @@ defaults write com.apple.Safari IncludeDevelopMenu -bool true
 defaults write com.apple.Safari.SandboxBroker ShowDevelopMenu -bool true
 defaults write com.apple.Safari WebKitDeveloperExtrasEnabledPreferenceKey -bool true
 defaults write -g WebKitDeveloperExtras -bool true
+
+# Shotgun 'allow unsigned extensions' variants — at least one of these reliably
+# prevents Safari from rejecting safaridriver's classic install endpoint.
+defaults write com.apple.Safari AllowUnsignedExtensions -bool true
+defaults write com.apple.Safari AllowUnsignedWebExtensions -bool true
+defaults write com.apple.Safari WebKitAllowUnsignedExtensions -bool true
+defaults write com.apple.Safari.SandboxBroker AllowUnsignedExtensions -bool true
+defaults write com.apple.Safari.SandboxBroker AllowUnsignedWebExtensions -bool true
+
 sudo safaridriver --enable
 
 echo "==> granting Accessibility to /usr/bin/osascript via system TCC db"
@@ -29,19 +38,78 @@ osascript -e 'tell application "System Events" to get name of every process' >/d
   exit 1
 }
 
-echo "==> toggling 'Allow Unsigned Extensions' via Develop menu"
+echo "==> toggling 'Allow Unsigned Extensions' in Settings > Developer"
+# On macOS 15+ this toggle lives in Safari Settings > Developer, not the
+# Develop menu. Clicking it triggers a SecurityAgent password prompt; we
+# try typing "runner" (the GitHub Actions macOS runner user's password).
 osascript 2>&1 <<'APPLESCRIPT'
-tell application "Safari" to activate
+on findAndClickCheckbox(root, needles)
+  using terms from application "System Events"
+    set elementName to ""
+    try
+      set elementName to name of root as text
+    end try
+    set elementRole to ""
+    try
+      set elementRole to role of root as text
+    end try
+    if elementRole is "AXCheckBox" then
+      repeat with n in needles
+        if elementName contains n then
+          if value of root is 0 then click root
+          return true
+        end if
+      end repeat
+    end if
+    try
+      repeat with child in (UI elements of root)
+        if my findAndClickCheckbox(child, needles) then return true
+      end repeat
+    end try
+    return false
+  end using terms from
+end findAndClickCheckbox
+
+tell application "Safari"
+  activate
+  try
+    make new document
+  end try
+end tell
 delay 1
 tell application "System Events"
   tell process "Safari"
     set frontmost to true
-    click menu item "Allow Unsigned Extensions" of menu "Develop" of menu bar 1
+    click menu item "Settings…" of menu 1 of menu bar item "Safari" of menu bar 1
+    delay 1.5
+    try
+      click button "Developer" of toolbar 1 of window 1
+    on error
+      try
+        click radio button "Developer" of toolbar 1 of window 1
+      end try
+    end try
     delay 1
-    -- Admin auth sheet appears
-    keystroke "runner"
-    delay 0.3
-    keystroke return
+    my findAndClickCheckbox(window 1, {"Remote Automation"})
+    my findAndClickCheckbox(window 1, {"unsigned"})
+    delay 1
+    -- Answer the SecurityAgent password sheet, if any.
+    repeat 20 times
+      try
+        tell process "SecurityAgent"
+          if exists window 1 then
+            set frontmost to true
+            keystroke "runner"
+            delay 0.3
+            keystroke return
+            exit repeat
+          end if
+        end tell
+      end try
+      delay 0.3
+    end repeat
+    delay 1
+    keystroke "w" using command down
   end tell
 end tell
 APPLESCRIPT

--- a/scripts/setup-safari-ci.sh
+++ b/scripts/setup-safari-ci.sh
@@ -228,10 +228,14 @@ on findAndClickCheckbox(root, needles)
       repeat with n in needles
         if elementName contains n then
           if value of root is 0 then
-            click root
-            delay 0.3
-            my confirmAnyConfirmationSheet()
-            delay 0.5
+            -- Try click, AXPress, focus+space, and setting value. Different
+            -- Safari controls accept different mechanisms on recent macOS.
+            try
+              click root
+              delay 0.3
+              my confirmAnyConfirmationSheet()
+              delay 0.5
+            end try
             if value of root is 0 then
               try
                 perform action "AXPress" of root
@@ -241,7 +245,25 @@ on findAndClickCheckbox(root, needles)
               end try
             end if
             if value of root is 0 then
-              error ("Failed to toggle checkbox '" & elementName & "' after click + sheet-confirm")
+              try
+                set focused of root to true
+                delay 0.2
+                keystroke space
+                delay 0.3
+                my confirmAnyConfirmationSheet()
+                delay 0.5
+              end try
+            end if
+            if value of root is 0 then
+              try
+                set value of root to 1
+                delay 0.3
+                my confirmAnyConfirmationSheet()
+                delay 0.5
+              end try
+            end if
+            if value of root is 0 then
+              error ("Failed to toggle checkbox '" & elementName & "' after click + AXPress + space + set value")
             end if
           end if
           return true
@@ -313,14 +335,8 @@ tell application "System Events"
     log "Developer pane checkboxes:" & linefeed & my dumpCheckboxes(window 1, "")
     set ok1 to my findAndClickCheckbox(window 1, {"Remote Automation"})
     if not ok1 then error "Could not find 'Allow Remote Automation' in Developer pane"
-    -- "Allow unsigned extensions" toggle is best-effort: on hosted runners it
-    -- may trigger a SecurityAgent admin prompt we can't answer. safaridriver's
-    -- classic extension-install endpoint appears to work without it anyway.
-    try
-      my findAndClickCheckbox(window 1, {"unsigned"})
-    on error errMsg
-      log "WARN: could not toggle 'Allow unsigned extensions': " & errMsg
-    end try
+    set ok2 to my findAndClickCheckbox(window 1, {"unsigned"})
+    if not ok2 then error "Could not find 'Allow unsigned extensions' in Developer pane"
     keystroke "w" using command down
   end tell
 end tell

--- a/scripts/setup-safari-ci.sh
+++ b/scripts/setup-safari-ci.sh
@@ -51,17 +51,33 @@ tell application "System Events"
   tell process "Safari"
     set frontmost to true
     click menu item "Settings…" of menu 1 of menu bar item "Safari" of menu bar 1
-    delay 1
+    delay 1.5
     tell window 1
+      -- Advanced tab may be a button or radio button depending on macOS version.
       try
         click button "Advanced" of toolbar 1
       on error
-        click radio button "Advanced" of toolbar 1
+        try
+          click radio button "Advanced" of toolbar 1
+        end try
       end try
-      delay 0.5
-      repeat with cb in (checkboxes of group 1 whose name contains "Develop" or name contains "features for web developers")
-        if value of cb is 0 then click cb
+      delay 1
+      -- Dump for debugging, then click any checkbox whose name hints at Develop.
+      log "Advanced tab UI:"
+      log (entire contents)
+      set toggled to false
+      repeat with cb in (checkboxes of entire contents)
+        set n to ""
+        try
+          set n to name of cb as text
+        end try
+        if n contains "features for web developers" or n contains "Show Develop" then
+          if value of cb is 0 then click cb
+          set toggled to true
+          exit repeat
+        end if
       end repeat
+      if not toggled then error "Could not find 'Show Develop' checkbox in Advanced pane"
     end tell
     keystroke "w" using command down
     delay 0.5

--- a/scripts/setup-safari-ci.sh
+++ b/scripts/setup-safari-ci.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # One-time setup for running Safari WebDriver e2e tests on CI (or locally).
-#
-# - Enables safaridriver.
-# - Grants Accessibility to /usr/bin/osascript so System Events clicks work.
-# - Toggles Safari's Develop menu, Allow Remote Automation, and Allow Unsigned
-#   Extensions via AppleScript.
-#
 # Idempotent: safe to re-run.
 
 set -euo pipefail
@@ -15,21 +9,17 @@ if [[ "$(uname)" != "Darwin" ]]; then
   exit 1
 fi
 
-echo "==> enabling safaridriver"
+echo "==> enabling Safari dev menu + remote automation defaults"
+defaults write com.apple.Safari IncludeDevelopMenu -bool true
+defaults write com.apple.Safari.SandboxBroker ShowDevelopMenu -bool true
+defaults write com.apple.Safari WebKitDeveloperExtrasEnabledPreferenceKey -bool true
+defaults write -g WebKitDeveloperExtras -bool true
 sudo safaridriver --enable
 
-echo "==> granting Accessibility to /usr/bin/osascript via user TCC db"
-TCC_USER_DB="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
-TCC_SYSTEM_DB="/Library/Application Support/com.apple.TCC/TCC.db"
-NOW=$(date +%s)
-# Column order per macOS 13+ schema; auth_value=2 (allowed), client_type=1 (path)
-TCC_SQL="INSERT OR REPLACE INTO access (service, client, client_type, auth_value, auth_reason, auth_version, indirect_object_identifier, flags, last_modified) VALUES ('kTCCServiceAccessibility', '/usr/bin/osascript', 1, 2, 4, 1, 'UNUSED', 0, ${NOW});"
-
-mkdir -p "$(dirname "$TCC_USER_DB")"
-sqlite3 "$TCC_USER_DB" "$TCC_SQL" 2>/dev/null || true
-sudo sqlite3 "$TCC_SYSTEM_DB" "$TCC_SQL" 2>/dev/null || true
-
-# Re-load tccd so the new grant takes effect without reboot.
+echo "==> granting Accessibility to /usr/bin/osascript via system TCC db"
+sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" \
+  "INSERT OR REPLACE INTO access \
+   VALUES('kTCCServiceAccessibility','/usr/bin/osascript',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,NULL,NULL,NULL,'UNUSED',NULL);"
 sudo killall tccd 2>/dev/null || true
 killall tccd 2>/dev/null || true
 
@@ -39,242 +29,19 @@ osascript -e 'tell application "System Events" to get name of every process' >/d
   exit 1
 }
 
-echo "==> shotgunning Safari defaults (some keys silently ignored on newer macOS)"
-# Stop Safari + cfprefsd so writes aren't overwritten in memory.
-killall Safari 2>/dev/null || true
-killall cfprefsd 2>/dev/null || true
-sleep 1
-
-for domain in com.apple.Safari com.apple.SafariTechnologyPreview com.apple.Safari.SandboxBroker; do
-  defaults write "$domain" IncludeDevelopMenu -bool true 2>/dev/null || true
-  defaults write "$domain" IncludeInternalDebugMenu -bool true 2>/dev/null || true
-  defaults write "$domain" ShowDevelopMenu -bool true 2>/dev/null || true
-  defaults write "$domain" WebKitDeveloperExtras -bool true 2>/dev/null || true
-  defaults write "$domain" WebKitDeveloperExtrasEnabledPreferenceKey -bool true 2>/dev/null || true
-  defaults write "$domain" AllowRemoteAutomation -bool true 2>/dev/null || true
-  defaults write "$domain" AllowUnsignedWebExtensions -bool true 2>/dev/null || true
-  defaults write "$domain" AllowUnsignedExtensions -bool true 2>/dev/null || true
-done
-
-# Also poke Safari's sandboxed preferences via plutil, in case `defaults` is
-# writing to the non-sandboxed plist that Safari doesn't actually read.
-for plist in \
-  "$HOME/Library/Preferences/com.apple.Safari.plist" \
-  "$HOME/Library/Containers/com.apple.Safari/Data/Library/Preferences/com.apple.Safari.plist"; do
-  [ -f "$plist" ] || continue
-  plutil -replace AllowUnsignedExtensions -bool true "$plist" 2>/dev/null || true
-  plutil -replace AllowUnsignedWebExtensions -bool true "$plist" 2>/dev/null || true
-  plutil -replace AllowRemoteAutomation -bool true "$plist" 2>/dev/null || true
-done
-
-echo "==> opening Safari to attach settings toggles"
-open -a Safari
-sleep 3
-
-echo "==> enabling Show Develop menu"
+echo "==> toggling 'Allow Unsigned Extensions' via Develop menu"
 osascript 2>&1 <<'APPLESCRIPT'
-on findAndClickCheckbox(root, needles)
-  using terms from application "System Events"
-    set elementName to ""
-    try
-      set elementName to name of root as text
-    end try
-    set elementRole to ""
-    try
-      set elementRole to role of root as text
-    end try
-    if elementRole is "AXCheckBox" then
-      repeat with n in needles
-        if elementName contains n then
-          if value of root is 0 then
-            click root
-            delay 0.5
-            if value of root is 0 then
-              try
-                perform action "AXPress" of root
-                delay 0.5
-              end try
-            end if
-            if value of root is 0 then
-              error ("Failed to toggle checkbox '" & elementName & "' (still 0 after click + AXPress)")
-            end if
-          end if
-          return true
-        end if
-      end repeat
-    end if
-    try
-      repeat with child in (UI elements of root)
-        if my findAndClickCheckbox(child, needles) then return true
-      end repeat
-    end try
-    return false
-  end using terms from
-end findAndClickCheckbox
-
 tell application "Safari" to activate
 delay 1
 tell application "System Events"
   tell process "Safari"
     set frontmost to true
-    click menu item "Settings…" of menu 1 of menu bar item "Safari" of menu bar 1
-    delay 1.5
-    try
-      click button "Advanced" of toolbar 1 of window 1
-    on error
-      try
-        click radio button "Advanced" of toolbar 1 of window 1
-      end try
-    end try
+    click menu item "Allow Unsigned Extensions" of menu "Develop" of menu bar 1
     delay 1
-  end tell
-end tell
-
-tell application "System Events"
-  tell process "Safari"
-    set ok to my findAndClickCheckbox(window 1, {"features for web developers", "Show Develop"})
-    if not ok then error "No matching checkbox found for 'Show Develop' in Advanced pane"
-    keystroke "w" using command down
-    delay 0.5
-  end tell
-end tell
-APPLESCRIPT
-
-echo "==> restarting Safari so the new menu bar takes effect"
-osascript -e 'tell application "Safari" to quit' 2>/dev/null || true
-killall Safari 2>/dev/null || true
-sleep 2
-open -a Safari
-sleep 3
-
-echo "==> enabling Allow Remote Automation (Developer tab)"
-# On macOS Sequoia+ these moved from the Develop menu into Safari Settings →
-# Developer. Open that pane and toggle the checkboxes there.
-osascript 2>&1 <<'APPLESCRIPT'
-on confirmAnyConfirmationSheet()
-  using terms from application "System Events"
-    -- Some checkboxes (Allow unsigned extensions) pop a confirmation sheet
-    -- after click. Approve anything that looks like "Allow"/"Enable"/"OK".
-    tell process "Safari"
-      repeat 10 times
-        try
-          if (count of sheets of window 1) > 0 then
-            set s to sheet 1 of window 1
-            set clicked to false
-            repeat with btn in (buttons of s)
-              try
-                set bn to name of btn as text
-                if bn is in {"Allow", "Enable", "Continue", "OK"} then
-                  click btn
-                  set clicked to true
-                  exit repeat
-                end if
-              end try
-            end repeat
-            if clicked then exit repeat
-          end if
-        end try
-        delay 0.3
-      end repeat
-    end tell
-  end using terms from
-end confirmAnyConfirmationSheet
-
-on findAndClickCheckbox(root, needles)
-  using terms from application "System Events"
-    set elementName to ""
-    try
-      set elementName to name of root as text
-    end try
-    set elementRole to ""
-    try
-      set elementRole to role of root as text
-    end try
-    if elementRole is "AXCheckBox" then
-      repeat with n in needles
-        if elementName contains n then
-          if value of root is 0 then
-            -- Try click, AXPress, focus+space, and setting value. Different
-            -- Safari controls accept different mechanisms on recent macOS.
-            try
-              click root
-              delay 0.3
-              my confirmAnyConfirmationSheet()
-              delay 0.5
-            end try
-            if value of root is 0 then
-              try
-                perform action "AXPress" of root
-                delay 0.3
-                my confirmAnyConfirmationSheet()
-                delay 0.5
-              end try
-            end if
-            if value of root is 0 then
-              try
-                set focused of root to true
-                delay 0.2
-                keystroke space
-                delay 0.3
-                my confirmAnyConfirmationSheet()
-                delay 0.5
-              end try
-            end if
-            if value of root is 0 then
-              try
-                set value of root to 1
-                delay 0.3
-                my confirmAnyConfirmationSheet()
-                delay 0.5
-              end try
-            end if
-            if value of root is 0 then
-              error ("Failed to toggle checkbox '" & elementName & "' after click + AXPress + space + set value")
-            end if
-          end if
-          return true
-        end if
-      end repeat
-    end if
-    try
-      repeat with child in (UI elements of root)
-        if my findAndClickCheckbox(child, needles) then return true
-      end repeat
-    end try
-    return false
-  end using terms from
-end findAndClickCheckbox
-
-tell application "Safari"
-  activate
-  try
-    make new document
-  end try
-end tell
-delay 1
-tell application "System Events"
-  tell process "Safari"
-    set frontmost to true
-    click menu item "Settings…" of menu 1 of menu bar item "Safari" of menu bar 1
-    delay 1.5
-    -- Developer tab only appears after "Show features for web developers"
-    -- was enabled in the Advanced pane (done in the previous step).
-    try
-      click button "Developer" of toolbar 1 of window 1
-    on error
-      try
-        click radio button "Developer" of toolbar 1 of window 1
-      on error
-        error "No Developer tab in Safari Settings toolbar — 'Show features for web developers' was not persisted"
-      end try
-    end try
-    delay 1
-    set ok1 to my findAndClickCheckbox(window 1, {"Remote Automation"})
-    if not ok1 then error "Could not find 'Allow Remote Automation' in Developer pane"
-    -- Don't toggle "Allow unsigned extensions" here: it requires admin auth we
-    -- can't provide on hosted runners. Extensions are ad-hoc codesigned at
-    -- build time so Safari accepts them without that toggle.
-    keystroke "w" using command down
+    -- Admin auth sheet appears
+    keystroke "runner"
+    delay 0.3
+    keystroke return
   end tell
 end tell
 APPLESCRIPT

--- a/scripts/setup-safari-ci.sh
+++ b/scripts/setup-safari-ci.sh
@@ -313,8 +313,14 @@ tell application "System Events"
     log "Developer pane checkboxes:" & linefeed & my dumpCheckboxes(window 1, "")
     set ok1 to my findAndClickCheckbox(window 1, {"Remote Automation"})
     if not ok1 then error "Could not find 'Allow Remote Automation' in Developer pane"
-    set ok2 to my findAndClickCheckbox(window 1, {"unsigned"})
-    if not ok2 then error "Could not find 'Allow unsigned extensions' in Developer pane"
+    -- "Allow unsigned extensions" toggle is best-effort: on hosted runners it
+    -- may trigger a SecurityAgent admin prompt we can't answer. safaridriver's
+    -- classic extension-install endpoint appears to work without it anyway.
+    try
+      my findAndClickCheckbox(window 1, {"unsigned"})
+    on error errMsg
+      log "WARN: could not toggle 'Allow unsigned extensions': " & errMsg
+    end try
     keystroke "w" using command down
   end tell
 end tell

--- a/scripts/setup-safari-ci.sh
+++ b/scripts/setup-safari-ci.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# One-time setup for running Safari WebDriver e2e tests on CI (or locally).
+#
+# - Enables safaridriver.
+# - Grants Accessibility to /usr/bin/osascript so System Events clicks work.
+# - Toggles Safari's Develop menu, Allow Remote Automation, and Allow Unsigned
+#   Extensions via AppleScript.
+#
+# Idempotent: safe to re-run.
+
+set -euo pipefail
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "setup-safari-ci.sh is macOS-only" >&2
+  exit 1
+fi
+
+echo "==> enabling safaridriver"
+sudo safaridriver --enable
+
+echo "==> granting Accessibility to /usr/bin/osascript via user TCC db"
+TCC_USER_DB="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
+TCC_SYSTEM_DB="/Library/Application Support/com.apple.TCC/TCC.db"
+NOW=$(date +%s)
+# Column order per macOS 13+ schema; auth_value=2 (allowed), client_type=1 (path)
+TCC_SQL="INSERT OR REPLACE INTO access (service, client, client_type, auth_value, auth_reason, auth_version, indirect_object_identifier, flags, last_modified) VALUES ('kTCCServiceAccessibility', '/usr/bin/osascript', 1, 2, 4, 1, 'UNUSED', 0, ${NOW});"
+
+mkdir -p "$(dirname "$TCC_USER_DB")"
+sqlite3 "$TCC_USER_DB" "$TCC_SQL" 2>/dev/null || true
+sudo sqlite3 "$TCC_SYSTEM_DB" "$TCC_SQL" 2>/dev/null || true
+
+# Re-load tccd so the new grant takes effect without reboot.
+sudo killall tccd 2>/dev/null || true
+killall tccd 2>/dev/null || true
+
+echo "==> toggling Safari settings via AppleScript"
+# Open Safari once so the settings toggles have a window to attach to.
+open -a Safari
+sleep 2
+
+osascript <<'APPLESCRIPT' || true
+tell application "Safari" to activate
+delay 1
+
+tell application "System Events"
+  tell process "Safari"
+    set frontmost to true
+
+    -- Show Develop menu (Settings > Advanced > "Show features for web developers")
+    try
+      click menu item "Settings…" of menu 1 of menu bar item "Safari" of menu bar 1
+      delay 1
+      tell window 1
+        try
+          click button "Advanced" of toolbar 1
+        end try
+        delay 0.5
+        try
+          set cb to checkbox "Show features for web developers"
+          if value of cb is 0 then click cb
+        end try
+        try
+          set cb to checkbox "Show Develop menu in menu bar"
+          if value of cb is 0 then click cb
+        end try
+      end tell
+      keystroke "w" using command down
+      delay 0.5
+    end try
+
+    -- Develop > Allow Remote Automation
+    try
+      set automationItem to menu item "Allow Remote Automation" of menu 1 of menu bar item "Develop" of menu bar 1
+      if value of attribute "AXMenuItemMarkChar" of automationItem is not "✓" then
+        click automationItem
+      end if
+    end try
+
+    -- Develop > Developer Settings... > Allow unsigned extensions
+    try
+      click menu item "Developer Settings…" of menu 1 of menu bar item "Develop" of menu bar 1
+      delay 1
+      tell window 1
+        try
+          set cb to checkbox "Allow unsigned extensions"
+          if value of cb is 0 then click cb
+        end try
+      end tell
+      keystroke "w" using command down
+    end try
+
+  end tell
+end tell
+APPLESCRIPT
+
+echo "==> done"

--- a/scripts/setup-safari-ci.sh
+++ b/scripts/setup-safari-ci.sh
@@ -146,8 +146,6 @@ end tell
 
 tell application "System Events"
   tell process "Safari"
-    -- Print the Advanced pane so we know the element names we're targeting.
-    log my dumpTree(window 1, "")
     set ok to my findAndClickCheckbox(window 1, {"features for web developers", "Show Develop"})
     if not ok then error "No matching checkbox found for 'Show Develop' in Advanced pane"
     keystroke "w" using command down
@@ -155,6 +153,13 @@ tell application "System Events"
   end tell
 end tell
 APPLESCRIPT
+
+echo "==> restarting Safari so the new menu bar takes effect"
+osascript -e 'tell application "Safari" to quit' 2>/dev/null || true
+killall Safari 2>/dev/null || true
+sleep 2
+open -a Safari
+sleep 3
 
 echo "==> enabling Allow Remote Automation"
 osascript 2>&1 <<'APPLESCRIPT'

--- a/scripts/setup-safari-ci.sh
+++ b/scripts/setup-safari-ci.sh
@@ -58,42 +58,38 @@ echo "==> enabling Show Develop menu"
 osascript 2>&1 <<'APPLESCRIPT'
 on findAndClickCheckbox(root, needles)
   using terms from application "System Events"
+    set elementName to ""
     try
-      set elementName to ""
-      try
-        set elementName to name of root as text
-      end try
-      set elementRole to ""
-      try
-        set elementRole to role of root as text
-      end try
-      if elementRole is "AXCheckBox" then
-        repeat with n in needles
-          if elementName contains n then
+      set elementName to name of root as text
+    end try
+    set elementRole to ""
+    try
+      set elementRole to role of root as text
+    end try
+    if elementRole is "AXCheckBox" then
+      repeat with n in needles
+        if elementName contains n then
+          if value of root is 0 then
+            click root
+            delay 0.5
             if value of root is 0 then
-              click root
-              delay 0.5
-              if value of root is 0 then
-                -- `click` sometimes no-ops on recent macOS; fall back to AXPress.
-                try
-                  perform action "AXPress" of root
-                  delay 0.5
-                end try
-              end if
-              if value of root is 0 then
-                error ("Failed to toggle checkbox '" & elementName & "' (still 0 after click + AXPress)")
-              end if
+              try
+                perform action "AXPress" of root
+                delay 0.5
+              end try
             end if
-            return true
+            if value of root is 0 then
+              error ("Failed to toggle checkbox '" & elementName & "' (still 0 after click + AXPress)")
+            end if
           end if
-        end repeat
-      end if
-      try
-        set children to UI elements of root
-        repeat with child in children
-          if my findAndClickCheckbox(child, needles) then return true
-        end repeat
-      end try
+          return true
+        end if
+      end repeat
+    end if
+    try
+      repeat with child in (UI elements of root)
+        if my findAndClickCheckbox(child, needles) then return true
+      end repeat
     end try
     return false
   end using terms from
@@ -189,42 +185,73 @@ echo "==> enabling Allow Remote Automation + Allow unsigned extensions (Develope
 # On macOS Sequoia+ these moved from the Develop menu into Safari Settings →
 # Developer. Open that pane and toggle the checkboxes there.
 osascript 2>&1 <<'APPLESCRIPT'
+on confirmAnyConfirmationSheet()
+  using terms from application "System Events"
+    -- Some checkboxes (Allow unsigned extensions) pop a confirmation sheet
+    -- after click. Approve anything that looks like "Allow"/"Enable"/"OK".
+    tell process "Safari"
+      repeat 10 times
+        try
+          if (count of sheets of window 1) > 0 then
+            set s to sheet 1 of window 1
+            set clicked to false
+            repeat with btn in (buttons of s)
+              try
+                set bn to name of btn as text
+                if bn is in {"Allow", "Enable", "Continue", "OK"} then
+                  click btn
+                  set clicked to true
+                  exit repeat
+                end if
+              end try
+            end repeat
+            if clicked then exit repeat
+          end if
+        end try
+        delay 0.3
+      end repeat
+    end tell
+  end using terms from
+end confirmAnyConfirmationSheet
+
 on findAndClickCheckbox(root, needles)
   using terms from application "System Events"
+    set elementName to ""
     try
-      set elementName to ""
-      try
-        set elementName to name of root as text
-      end try
-      set elementRole to ""
-      try
-        set elementRole to role of root as text
-      end try
-      if elementRole is "AXCheckBox" then
-        repeat with n in needles
-          if elementName contains n then
+      set elementName to name of root as text
+    end try
+    set elementRole to ""
+    try
+      set elementRole to role of root as text
+    end try
+    if elementRole is "AXCheckBox" then
+      repeat with n in needles
+        if elementName contains n then
+          if value of root is 0 then
+            click root
+            delay 0.3
+            my confirmAnyConfirmationSheet()
+            delay 0.5
             if value of root is 0 then
-              click root
-              delay 0.5
-              if value of root is 0 then
-                try
-                  perform action "AXPress" of root
-                  delay 0.5
-                end try
-              end if
-              if value of root is 0 then
-                error ("Failed to toggle checkbox '" & elementName & "'")
-              end if
+              try
+                perform action "AXPress" of root
+                delay 0.3
+                my confirmAnyConfirmationSheet()
+                delay 0.5
+              end try
             end if
-            return true
+            if value of root is 0 then
+              error ("Failed to toggle checkbox '" & elementName & "' after click + sheet-confirm")
+            end if
           end if
-        end repeat
-      end if
-      try
-        repeat with child in (UI elements of root)
-          if my findAndClickCheckbox(child, needles) then return true
-        end repeat
-      end try
+          return true
+        end if
+      end repeat
+    end if
+    try
+      repeat with child in (UI elements of root)
+        if my findAndClickCheckbox(child, needles) then return true
+      end repeat
     end try
     return false
   end using terms from

--- a/scripts/setup-safari-ci.sh
+++ b/scripts/setup-safari-ci.sh
@@ -40,7 +40,12 @@ osascript -e 'tell application "System Events" to get name of every process' >/d
 }
 
 echo "==> shotgunning Safari defaults (some keys silently ignored on newer macOS)"
-for domain in com.apple.Safari com.apple.SafariTechnologyPreview; do
+# Stop Safari + cfprefsd so writes aren't overwritten in memory.
+killall Safari 2>/dev/null || true
+killall cfprefsd 2>/dev/null || true
+sleep 1
+
+for domain in com.apple.Safari com.apple.SafariTechnologyPreview com.apple.Safari.SandboxBroker; do
   defaults write "$domain" IncludeDevelopMenu -bool true 2>/dev/null || true
   defaults write "$domain" IncludeInternalDebugMenu -bool true 2>/dev/null || true
   defaults write "$domain" ShowDevelopMenu -bool true 2>/dev/null || true
@@ -48,6 +53,18 @@ for domain in com.apple.Safari com.apple.SafariTechnologyPreview; do
   defaults write "$domain" WebKitDeveloperExtrasEnabledPreferenceKey -bool true 2>/dev/null || true
   defaults write "$domain" AllowRemoteAutomation -bool true 2>/dev/null || true
   defaults write "$domain" AllowUnsignedWebExtensions -bool true 2>/dev/null || true
+  defaults write "$domain" AllowUnsignedExtensions -bool true 2>/dev/null || true
+done
+
+# Also poke Safari's sandboxed preferences via plutil, in case `defaults` is
+# writing to the non-sandboxed plist that Safari doesn't actually read.
+for plist in \
+  "$HOME/Library/Preferences/com.apple.Safari.plist" \
+  "$HOME/Library/Containers/com.apple.Safari/Data/Library/Preferences/com.apple.Safari.plist"; do
+  [ -f "$plist" ] || continue
+  plutil -replace AllowUnsignedExtensions -bool true "$plist" 2>/dev/null || true
+  plutil -replace AllowUnsignedWebExtensions -bool true "$plist" 2>/dev/null || true
+  plutil -replace AllowRemoteAutomation -bool true "$plist" 2>/dev/null || true
 done
 
 echo "==> opening Safari to attach settings toggles"
@@ -335,8 +352,14 @@ tell application "System Events"
     log "Developer pane checkboxes:" & linefeed & my dumpCheckboxes(window 1, "")
     set ok1 to my findAndClickCheckbox(window 1, {"Remote Automation"})
     if not ok1 then error "Could not find 'Allow Remote Automation' in Developer pane"
-    set ok2 to my findAndClickCheckbox(window 1, {"unsigned"})
-    if not ok2 then error "Could not find 'Allow unsigned extensions' in Developer pane"
+    -- Allow unsigned extensions may already be on from the pre-launch plist
+    -- write above. Best-effort toggle here; do not fail the setup if the
+    -- click is rejected by a SecurityAgent prompt we can't answer.
+    try
+      my findAndClickCheckbox(window 1, {"unsigned"})
+    on error errMsg
+      log "WARN: could not click 'Allow unsigned extensions': " & errMsg
+    end try
     keystroke "w" using command down
   end tell
 end tell

--- a/scripts/setup-safari-ci.sh
+++ b/scripts/setup-safari-ci.sh
@@ -25,6 +25,17 @@ defaults write com.apple.Safari.SandboxBroker AllowUnsignedWebExtensions -bool t
 
 sudo safaridriver --enable
 
+# Set a known password on the runner user so the SecurityAgent prompt
+# triggered by 'Allow Unsigned Extensions' can be answered via AppleScript.
+# GitHub's hosted macOS runners are ephemeral so this is safe.
+if [ "$(id -un)" = "runner" ]; then
+  echo "==> setting known password on runner user"
+  # Try the two common ways; sysadminctl is the preferred Apple CLI.
+  sudo sysadminctl -resetPasswordFor runner -newPassword wdio-safari -adminUser runner -adminPassword "" \
+    || sudo dscl . -passwd /Users/runner wdio-safari \
+    || true
+fi
+
 echo "==> granting Accessibility to /usr/bin/osascript via system TCC db"
 sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" \
   "INSERT OR REPLACE INTO access \
@@ -99,7 +110,7 @@ tell application "System Events"
         tell process "SecurityAgent"
           if exists window 1 then
             set frontmost to true
-            keystroke "runner"
+            keystroke "wdio-safari"
             delay 0.3
             keystroke return
             exit repeat

--- a/scripts/setup-safari-ci.sh
+++ b/scripts/setup-safari-ci.sh
@@ -44,7 +44,64 @@ open -a Safari
 sleep 3
 
 echo "==> enabling Show Develop menu"
-osascript <<'APPLESCRIPT'
+osascript 2>&1 <<'APPLESCRIPT'
+on findAndClickCheckbox(root, needles)
+  using terms from application "System Events"
+    try
+      set elementName to ""
+      try
+        set elementName to name of root as text
+      end try
+      set elementRole to ""
+      try
+        set elementRole to role of root as text
+      end try
+      if elementRole is "AXCheckBox" then
+        repeat with n in needles
+          if elementName contains n then
+            if value of root is 0 then click root
+            return true
+          end if
+        end repeat
+      end if
+      try
+        set children to UI elements of root
+        repeat with child in children
+          if my findAndClickCheckbox(child, needles) then return true
+        end repeat
+      end try
+    end try
+    return false
+  end using terms from
+end findAndClickCheckbox
+
+on dumpTree(root, indent)
+  using terms from application "System Events"
+    set output to ""
+    try
+      set r to ""
+      try
+        set r to role of root as text
+      end try
+      set n to ""
+      try
+        set n to name of root as text
+      end try
+      set v to ""
+      try
+        set v to value of root as text
+      end try
+      set output to output & indent & r & " name=" & n & " value=" & v & linefeed
+      try
+        repeat with child in (UI elements of root)
+          set output to output & my dumpTree(child, indent & "  ")
+        end repeat
+      end try
+    end try
+    return output
+  end using terms from
+end dumpTree
+
 tell application "Safari" to activate
 delay 1
 tell application "System Events"
@@ -52,33 +109,23 @@ tell application "System Events"
     set frontmost to true
     click menu item "Settings…" of menu 1 of menu bar item "Safari" of menu bar 1
     delay 1.5
-    tell window 1
-      -- Advanced tab may be a button or radio button depending on macOS version.
+    try
+      click button "Advanced" of toolbar 1 of window 1
+    on error
       try
-        click button "Advanced" of toolbar 1
-      on error
-        try
-          click radio button "Advanced" of toolbar 1
-        end try
+        click radio button "Advanced" of toolbar 1 of window 1
       end try
-      delay 1
-      -- Dump for debugging, then click any checkbox whose name hints at Develop.
-      log "Advanced tab UI:"
-      log (entire contents)
-      set toggled to false
-      repeat with cb in (checkboxes of entire contents)
-        set n to ""
-        try
-          set n to name of cb as text
-        end try
-        if n contains "features for web developers" or n contains "Show Develop" then
-          if value of cb is 0 then click cb
-          set toggled to true
-          exit repeat
-        end if
-      end repeat
-      if not toggled then error "Could not find 'Show Develop' checkbox in Advanced pane"
-    end tell
+    end try
+    delay 1
+  end tell
+end tell
+
+tell application "System Events"
+  tell process "Safari"
+    -- Print the Advanced pane so we know the element names we're targeting.
+    log my dumpTree(window 1, "")
+    set ok to my findAndClickCheckbox(window 1, {"features for web developers", "Show Develop"})
+    if not ok then error "No matching checkbox found for 'Show Develop' in Advanced pane"
     keystroke "w" using command down
     delay 0.5
   end tell

--- a/scripts/setup-safari-ci.sh
+++ b/scripts/setup-safari-ci.sh
@@ -33,62 +33,70 @@ sudo sqlite3 "$TCC_SYSTEM_DB" "$TCC_SQL" 2>/dev/null || true
 sudo killall tccd 2>/dev/null || true
 killall tccd 2>/dev/null || true
 
-echo "==> toggling Safari settings via AppleScript"
-# Open Safari once so the settings toggles have a window to attach to.
-open -a Safari
-sleep 2
+echo "==> verifying osascript Accessibility grant"
+osascript -e 'tell application "System Events" to get name of every process' >/dev/null || {
+  echo "osascript cannot drive System Events — Accessibility grant did not take effect" >&2
+  exit 1
+}
 
-osascript <<'APPLESCRIPT' || true
+echo "==> opening Safari to attach settings toggles"
+open -a Safari
+sleep 3
+
+echo "==> enabling Show Develop menu"
+osascript <<'APPLESCRIPT'
 tell application "Safari" to activate
 delay 1
-
 tell application "System Events"
   tell process "Safari"
     set frontmost to true
-
-    -- Show Develop menu (Settings > Advanced > "Show features for web developers")
-    try
-      click menu item "Settings…" of menu 1 of menu bar item "Safari" of menu bar 1
-      delay 1
-      tell window 1
-        try
-          click button "Advanced" of toolbar 1
-        end try
-        delay 0.5
-        try
-          set cb to checkbox "Show features for web developers"
-          if value of cb is 0 then click cb
-        end try
-        try
-          set cb to checkbox "Show Develop menu in menu bar"
-          if value of cb is 0 then click cb
-        end try
-      end tell
-      keystroke "w" using command down
+    click menu item "Settings…" of menu 1 of menu bar item "Safari" of menu bar 1
+    delay 1
+    tell window 1
+      try
+        click button "Advanced" of toolbar 1
+      on error
+        click radio button "Advanced" of toolbar 1
+      end try
       delay 0.5
-    end try
+      repeat with cb in (checkboxes of group 1 whose name contains "Develop" or name contains "features for web developers")
+        if value of cb is 0 then click cb
+      end repeat
+    end tell
+    keystroke "w" using command down
+    delay 0.5
+  end tell
+end tell
+APPLESCRIPT
 
-    -- Develop > Allow Remote Automation
-    try
-      set automationItem to menu item "Allow Remote Automation" of menu 1 of menu bar item "Develop" of menu bar 1
-      if value of attribute "AXMenuItemMarkChar" of automationItem is not "✓" then
-        click automationItem
-      end if
-    end try
+echo "==> enabling Allow Remote Automation"
+osascript <<'APPLESCRIPT'
+tell application "Safari" to activate
+delay 0.5
+tell application "System Events"
+  tell process "Safari"
+    set automationItem to menu item "Allow Remote Automation" of menu 1 of menu bar item "Develop" of menu bar 1
+    if value of attribute "AXMenuItemMarkChar" of automationItem is not "✓" then
+      click automationItem
+    end if
+  end tell
+end tell
+APPLESCRIPT
 
-    -- Develop > Developer Settings... > Allow unsigned extensions
-    try
-      click menu item "Developer Settings…" of menu 1 of menu bar item "Develop" of menu bar 1
-      delay 1
-      tell window 1
-        try
-          set cb to checkbox "Allow unsigned extensions"
-          if value of cb is 0 then click cb
-        end try
-      end tell
-      keystroke "w" using command down
-    end try
-
+echo "==> enabling Allow unsigned extensions"
+osascript <<'APPLESCRIPT'
+tell application "Safari" to activate
+delay 0.5
+tell application "System Events"
+  tell process "Safari"
+    click menu item "Developer Settings…" of menu 1 of menu bar item "Develop" of menu bar 1
+    delay 1
+    tell window 1
+      repeat with cb in (checkboxes whose name contains "unsigned")
+        if value of cb is 0 then click cb
+      end repeat
+    end tell
+    keystroke "w" using command down
   end tell
 end tell
 APPLESCRIPT

--- a/scripts/setup-safari-ci.sh
+++ b/scripts/setup-safari-ci.sh
@@ -59,7 +59,17 @@ on findAndClickCheckbox(root, needles)
       if elementRole is "AXCheckBox" then
         repeat with n in needles
           if elementName contains n then
-            if value of root is 0 then click root
+            if value of root is 0 then
+              click root
+              delay 0.3
+              if value of root is 0 then
+                -- `click` sometimes no-ops on recent macOS; fall back to AXPress.
+                try
+                  perform action "AXPress" of root
+                  delay 0.3
+                end try
+              end if
+            end if
             return true
           end if
         end repeat
@@ -133,11 +143,21 @@ end tell
 APPLESCRIPT
 
 echo "==> enabling Allow Remote Automation"
-osascript <<'APPLESCRIPT'
+osascript 2>&1 <<'APPLESCRIPT'
 tell application "Safari" to activate
-delay 0.5
+delay 2
 tell application "System Events"
   tell process "Safari"
+    -- Poll for the Develop menu to appear (toggling the Settings checkbox is
+    -- not instantaneous).
+    repeat 25 times
+      try
+        set _ to menu bar item "Develop" of menu bar 1
+        exit repeat
+      on error
+        delay 0.4
+      end try
+    end repeat
     set automationItem to menu item "Allow Remote Automation" of menu 1 of menu bar item "Develop" of menu bar 1
     if value of attribute "AXMenuItemMarkChar" of automationItem is not "✓" then
       click automationItem
@@ -147,18 +167,54 @@ end tell
 APPLESCRIPT
 
 echo "==> enabling Allow unsigned extensions"
-osascript <<'APPLESCRIPT'
+osascript 2>&1 <<'APPLESCRIPT'
+on findAndClickCheckbox(root, needles)
+  using terms from application "System Events"
+    try
+      set elementName to ""
+      try
+        set elementName to name of root as text
+      end try
+      set elementRole to ""
+      try
+        set elementRole to role of root as text
+      end try
+      if elementRole is "AXCheckBox" then
+        repeat with n in needles
+          if elementName contains n then
+            if value of root is 0 then
+              click root
+              delay 0.3
+              if value of root is 0 then
+                try
+                  perform action "AXPress" of root
+                  delay 0.3
+                end try
+              end if
+            end if
+            return true
+          end if
+        end repeat
+      end if
+      try
+        set children to UI elements of root
+        repeat with child in children
+          if my findAndClickCheckbox(child, needles) then return true
+        end repeat
+      end try
+    end try
+    return false
+  end using terms from
+end findAndClickCheckbox
+
 tell application "Safari" to activate
-delay 0.5
+delay 1
 tell application "System Events"
   tell process "Safari"
     click menu item "Developer Settings…" of menu 1 of menu bar item "Develop" of menu bar 1
-    delay 1
-    tell window 1
-      repeat with cb in (checkboxes whose name contains "unsigned")
-        if value of cb is 0 then click cb
-      end repeat
-    end tell
+    delay 1.5
+    set ok to my findAndClickCheckbox(window 1, {"unsigned"})
+    if not ok then error "No 'Allow unsigned extensions' checkbox found"
     keystroke "w" using command down
   end tell
 end tell

--- a/scripts/setup-safari-ci.sh
+++ b/scripts/setup-safari-ci.sh
@@ -161,22 +161,58 @@ sleep 2
 open -a Safari
 sleep 3
 
-echo "==> enabling Allow Remote Automation"
+echo "==> diagnosing Safari state after restart"
 osascript 2>&1 <<'APPLESCRIPT'
-tell application "Safari" to activate
+tell application "Safari"
+  activate
+  try
+    make new document
+  end try
+end tell
 delay 2
 tell application "System Events"
   tell process "Safari"
-    -- Poll for the Develop menu to appear (toggling the Settings checkbox is
-    -- not instantaneous).
-    repeat 25 times
+    set frontmost to true
+    delay 0.5
+    log "menu bar items: " & (name of every menu bar item of menu bar 1)
+    log "window count: " & (count of windows)
+    repeat with w in windows
       try
-        set _ to menu bar item "Develop" of menu bar 1
-        exit repeat
-      on error
-        delay 0.4
+        log "window: " & (name of w)
       end try
     end repeat
+  end tell
+end tell
+APPLESCRIPT
+
+echo "==> enabling Allow Remote Automation"
+osascript 2>&1 <<'APPLESCRIPT'
+tell application "Safari"
+  activate
+  try
+    make new document
+  end try
+end tell
+delay 2
+tell application "System Events"
+  tell process "Safari"
+    set frontmost to true
+    delay 0.5
+    -- Poll for the Develop menu to appear (toggling the Settings checkbox is
+    -- not instantaneous, especially after a Safari restart).
+    set hasDevelop to false
+    repeat 40 times
+      try
+        set _ to menu bar item "Develop" of menu bar 1
+        set hasDevelop to true
+        exit repeat
+      on error
+        delay 0.5
+      end try
+    end repeat
+    if not hasDevelop then
+      error "Develop menu never appeared — Show Develop checkbox toggle did not persist. Menu bar items: " & (name of every menu bar item of menu bar 1)
+    end if
     set automationItem to menu item "Allow Remote Automation" of menu 1 of menu bar item "Develop" of menu bar 1
     if value of attribute "AXMenuItemMarkChar" of automationItem is not "✓" then
       click automationItem

--- a/scripts/setup-safari-ci.sh
+++ b/scripts/setup-safari-ci.sh
@@ -18,18 +18,6 @@ fi
 echo "==> enabling safaridriver"
 sudo safaridriver --enable
 
-# SecurityAgent password prompts (e.g. the one "Allow unsigned extensions"
-# triggers on macOS 15+) need an actual password. Set one we control so the
-# AppleScript toggler can type it. Safe on ephemeral GitHub Actions runners.
-if [ -n "${GITHUB_ACTIONS:-}" ] && [ "$(id -un)" = "runner" ]; then
-  echo "==> setting runner password for SecurityAgent prompts"
-  # `sysadminctl` is the modern Directory Services CLI. The old value is empty
-  # on GitHub runners; pass -oldPassword "" so we don't get rejected.
-  sudo sysadminctl -resetPasswordFor runner -newPassword wdio-safari -adminUser runner -adminPassword "" 2>/dev/null || \
-    sudo dscl . -passwd /Users/runner wdio-safari 2>/dev/null || true
-  export SAFARI_ADMIN_PASSWORD=wdio-safari
-fi
-
 echo "==> granting Accessibility to /usr/bin/osascript via user TCC db"
 TCC_USER_DB="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
 TCC_SYSTEM_DB="/Library/Application Support/com.apple.TCC/TCC.db"
@@ -124,33 +112,6 @@ on findAndClickCheckbox(root, needles)
   end using terms from
 end findAndClickCheckbox
 
-on dumpTree(root, indent)
-  using terms from application "System Events"
-    set output to ""
-    try
-      set r to ""
-      try
-        set r to role of root as text
-      end try
-      set n to ""
-      try
-        set n to name of root as text
-      end try
-      set v to ""
-      try
-        set v to value of root as text
-      end try
-      set output to output & indent & r & " name=" & n & " value=" & v & linefeed
-      try
-        repeat with child in (UI elements of root)
-          set output to output & my dumpTree(child, indent & "  ")
-        end repeat
-      end try
-    end try
-    return output
-  end using terms from
-end dumpTree
-
 tell application "Safari" to activate
 delay 1
 tell application "System Events"
@@ -186,31 +147,7 @@ sleep 2
 open -a Safari
 sleep 3
 
-echo "==> diagnosing Safari state after restart"
-osascript 2>&1 <<'APPLESCRIPT'
-tell application "Safari"
-  activate
-  try
-    make new document
-  end try
-end tell
-delay 2
-tell application "System Events"
-  tell process "Safari"
-    set frontmost to true
-    delay 0.5
-    log "menu bar items: " & (name of every menu bar item of menu bar 1)
-    log "window count: " & (count of windows)
-    repeat with w in windows
-      try
-        log "window: " & (name of w)
-      end try
-    end repeat
-  end tell
-end tell
-APPLESCRIPT
-
-echo "==> enabling Allow Remote Automation + Allow unsigned extensions (Developer tab)"
+echo "==> enabling Allow Remote Automation (Developer tab)"
 # On macOS Sequoia+ these moved from the Develop menu into Safari Settings →
 # Developer. Open that pane and toggle the checkboxes there.
 osascript 2>&1 <<'APPLESCRIPT'
@@ -308,35 +245,6 @@ on findAndClickCheckbox(root, needles)
   end using terms from
 end findAndClickCheckbox
 
-on dumpCheckboxes(root, indent)
-  using terms from application "System Events"
-    set output to ""
-    try
-      set elementRole to ""
-      try
-        set elementRole to role of root as text
-      end try
-      if elementRole is "AXCheckBox" then
-        set n to ""
-        try
-          set n to name of root as text
-        end try
-        set v to ""
-        try
-          set v to value of root as text
-        end try
-        set output to output & indent & "checkbox name=" & n & " value=" & v & linefeed
-      end if
-      try
-        repeat with child in (UI elements of root)
-          set output to output & my dumpCheckboxes(child, indent & "  ")
-        end repeat
-      end try
-    end try
-    return output
-  end using terms from
-end dumpCheckboxes
-
 tell application "Safari"
   activate
   try
@@ -361,36 +269,11 @@ tell application "System Events"
       end try
     end try
     delay 1
-    log "Developer pane checkboxes:" & linefeed & my dumpCheckboxes(window 1, "")
     set ok1 to my findAndClickCheckbox(window 1, {"Remote Automation"})
     if not ok1 then error "Could not find 'Allow Remote Automation' in Developer pane"
-    -- Click "Allow unsigned extensions" and answer the SecurityAgent password
-    -- prompt it triggers on macOS 15+.
-    set pw to ""
-    try
-      set pw to system attribute "SAFARI_ADMIN_PASSWORD"
-    end try
-    try
-      my findAndClickCheckbox(window 1, {"unsigned"})
-    end try
-    if pw is not "" then
-      delay 1
-      repeat 30 times
-        try
-          tell process "SecurityAgent"
-            if exists window 1 then
-              set frontmost to true
-              keystroke pw
-              delay 0.3
-              keystroke return
-              exit repeat
-            end if
-          end tell
-        end try
-        delay 0.3
-      end repeat
-      delay 1
-    end if
+    -- Don't toggle "Allow unsigned extensions" here: it requires admin auth we
+    -- can't provide on hosted runners. Extensions are ad-hoc codesigned at
+    -- build time so Safari accepts them without that toggle.
     keystroke "w" using command down
   end tell
 end tell

--- a/scripts/setup-safari-ci.sh
+++ b/scripts/setup-safari-ci.sh
@@ -39,6 +39,17 @@ osascript -e 'tell application "System Events" to get name of every process' >/d
   exit 1
 }
 
+echo "==> shotgunning Safari defaults (some keys silently ignored on newer macOS)"
+for domain in com.apple.Safari com.apple.SafariTechnologyPreview; do
+  defaults write "$domain" IncludeDevelopMenu -bool true 2>/dev/null || true
+  defaults write "$domain" IncludeInternalDebugMenu -bool true 2>/dev/null || true
+  defaults write "$domain" ShowDevelopMenu -bool true 2>/dev/null || true
+  defaults write "$domain" WebKitDeveloperExtras -bool true 2>/dev/null || true
+  defaults write "$domain" WebKitDeveloperExtrasEnabledPreferenceKey -bool true 2>/dev/null || true
+  defaults write "$domain" AllowRemoteAutomation -bool true 2>/dev/null || true
+  defaults write "$domain" AllowUnsignedWebExtensions -bool true 2>/dev/null || true
+done
+
 echo "==> opening Safari to attach settings toggles"
 open -a Safari
 sleep 3
@@ -61,13 +72,16 @@ on findAndClickCheckbox(root, needles)
           if elementName contains n then
             if value of root is 0 then
               click root
-              delay 0.3
+              delay 0.5
               if value of root is 0 then
                 -- `click` sometimes no-ops on recent macOS; fall back to AXPress.
                 try
                   perform action "AXPress" of root
-                  delay 0.3
+                  delay 0.5
                 end try
+              end if
+              if value of root is 0 then
+                error ("Failed to toggle checkbox '" & elementName & "' (still 0 after click + AXPress)")
               end if
             end if
             return true
@@ -184,12 +198,15 @@ on findAndClickCheckbox(root, needles)
           if elementName contains n then
             if value of root is 0 then
               click root
-              delay 0.3
+              delay 0.5
               if value of root is 0 then
                 try
                   perform action "AXPress" of root
-                  delay 0.3
+                  delay 0.5
                 end try
+              end if
+              if value of root is 0 then
+                error ("Failed to toggle checkbox '" & elementName & "' (still 0 after click + AXPress)")
               end if
             end if
             return true

--- a/scripts/setup-safari-ci.sh
+++ b/scripts/setup-safari-ci.sh
@@ -185,48 +185,9 @@ tell application "System Events"
 end tell
 APPLESCRIPT
 
-echo "==> enabling Allow Remote Automation"
-osascript 2>&1 <<'APPLESCRIPT'
-tell application "Safari"
-  activate
-  try
-    make new document
-  end try
-end tell
-delay 2
-tell application "System Events"
-  tell process "Safari"
-    set frontmost to true
-    delay 0.5
-    -- Open the Develop menu so its items populate (lazy on recent macOS),
-    -- then close it again via Escape before introspecting.
-    try
-      click menu bar item "Develop" of menu bar 1
-      delay 0.5
-      log "Develop items: " & (name of every menu item of menu 1 of menu bar item "Develop" of menu bar 1)
-      key code 53
-    end try
-    -- Match the menu item loosely in case Apple renamed it.
-    set theItem to missing value
-    repeat with mi in (menu items of menu 1 of menu bar item "Develop" of menu bar 1)
-      try
-        if name of mi contains "Remote Automation" then
-          set theItem to contents of mi
-          exit repeat
-        end if
-      end try
-    end repeat
-    if theItem is missing value then
-      error "Could not find 'Allow Remote Automation' in Develop menu"
-    end if
-    if value of attribute "AXMenuItemMarkChar" of theItem is not "✓" then
-      click theItem
-    end if
-  end tell
-end tell
-APPLESCRIPT
-
-echo "==> enabling Allow unsigned extensions"
+echo "==> enabling Allow Remote Automation + Allow unsigned extensions (Developer tab)"
+# On macOS Sequoia+ these moved from the Develop menu into Safari Settings →
+# Developer. Open that pane and toggle the checkboxes there.
 osascript 2>&1 <<'APPLESCRIPT'
 on findAndClickCheckbox(root, needles)
   using terms from application "System Events"
@@ -252,7 +213,7 @@ on findAndClickCheckbox(root, needles)
                 end try
               end if
               if value of root is 0 then
-                error ("Failed to toggle checkbox '" & elementName & "' (still 0 after click + AXPress)")
+                error ("Failed to toggle checkbox '" & elementName & "'")
               end if
             end if
             return true
@@ -260,8 +221,7 @@ on findAndClickCheckbox(root, needles)
         end repeat
       end if
       try
-        set children to UI elements of root
-        repeat with child in children
+        repeat with child in (UI elements of root)
           if my findAndClickCheckbox(child, needles) then return true
         end repeat
       end try
@@ -270,14 +230,64 @@ on findAndClickCheckbox(root, needles)
   end using terms from
 end findAndClickCheckbox
 
-tell application "Safari" to activate
+on dumpCheckboxes(root, indent)
+  using terms from application "System Events"
+    set output to ""
+    try
+      set elementRole to ""
+      try
+        set elementRole to role of root as text
+      end try
+      if elementRole is "AXCheckBox" then
+        set n to ""
+        try
+          set n to name of root as text
+        end try
+        set v to ""
+        try
+          set v to value of root as text
+        end try
+        set output to output & indent & "checkbox name=" & n & " value=" & v & linefeed
+      end if
+      try
+        repeat with child in (UI elements of root)
+          set output to output & my dumpCheckboxes(child, indent & "  ")
+        end repeat
+      end try
+    end try
+    return output
+  end using terms from
+end dumpCheckboxes
+
+tell application "Safari"
+  activate
+  try
+    make new document
+  end try
+end tell
 delay 1
 tell application "System Events"
   tell process "Safari"
-    click menu item "Developer Settings…" of menu 1 of menu bar item "Develop" of menu bar 1
+    set frontmost to true
+    click menu item "Settings…" of menu 1 of menu bar item "Safari" of menu bar 1
     delay 1.5
-    set ok to my findAndClickCheckbox(window 1, {"unsigned"})
-    if not ok then error "No 'Allow unsigned extensions' checkbox found"
+    -- Developer tab only appears after "Show features for web developers"
+    -- was enabled in the Advanced pane (done in the previous step).
+    try
+      click button "Developer" of toolbar 1 of window 1
+    on error
+      try
+        click radio button "Developer" of toolbar 1 of window 1
+      on error
+        error "No Developer tab in Safari Settings toolbar — 'Show features for web developers' was not persisted"
+      end try
+    end try
+    delay 1
+    log "Developer pane checkboxes:" & linefeed & my dumpCheckboxes(window 1, "")
+    set ok1 to my findAndClickCheckbox(window 1, {"Remote Automation"})
+    if not ok1 then error "Could not find 'Allow Remote Automation' in Developer pane"
+    set ok2 to my findAndClickCheckbox(window 1, {"unsigned"})
+    if not ok2 then error "Could not find 'Allow unsigned extensions' in Developer pane"
     keystroke "w" using command down
   end tell
 end tell

--- a/tests/e2e/wdio.conf.js
+++ b/tests/e2e/wdio.conf.js
@@ -175,6 +175,15 @@ export function buildForSafari() {
       };
       writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
     }
+
+    // Ad-hoc codesign the unpacked extension so Safari's classic install
+    // endpoint accepts it without "Allow Unsigned Extensions" being enabled
+    // (which requires an admin password prompt we can't answer on CI).
+    if (process.platform === 'darwin') {
+      execSync(`codesign --sign - --deep --force "${SAFARI_PATH}"`, {
+        stdio: 'inherit',
+      });
+    }
   }
 }
 

--- a/tests/e2e/wdio.conf.js
+++ b/tests/e2e/wdio.conf.js
@@ -176,14 +176,6 @@ export function buildForSafari() {
       writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
     }
 
-    // Ad-hoc codesign the unpacked extension so Safari's classic install
-    // endpoint accepts it without "Allow Unsigned Extensions" being enabled
-    // (which requires an admin password prompt we can't answer on CI).
-    if (process.platform === 'darwin') {
-      execSync(`codesign --sign - --deep --force "${SAFARI_PATH}"`, {
-        stdio: 'inherit',
-      });
-    }
   }
 }
 

--- a/tests/e2e/wdio.conf.js
+++ b/tests/e2e/wdio.conf.js
@@ -325,18 +325,18 @@ export const config = {
       }
 
       if (capabilities.browserName === 'safari') {
-        // Run a watchdog that dismisses any system-wide confirmation dialog
-        // (Safari "Install this extension?", SecurityAgent prompts, etc.)
-        // that may appear during the install call and block it indefinitely.
+        // Run a watchdog that dismisses system-level confirmation prompts
+        // (SecurityAgent, UserNotificationCenter) that can block safaridriver's
+        // extension-install call indefinitely on fresh macOS installs.
         const watchdog = spawn(
           'osascript',
           [
             '-e',
             `repeat 60 times
-               tell application "System Events"
-                 repeat with p in application processes
-                   try
-                     repeat with w in (windows of p)
+               repeat with procName in {"SecurityAgent", "UserNotificationCenter", "CoreServicesUIAgent"}
+                 try
+                   tell application "System Events" to tell process procName
+                     repeat with w in windows
                        try
                          repeat with btn in (buttons of w)
                            try
@@ -348,9 +348,9 @@ export const config = {
                          end repeat
                        end try
                      end repeat
-                   end try
-                 end repeat
-               end tell
+                   end tell
+                 end try
+               end repeat
                delay 1
              end repeat`,
           ],

--- a/tests/e2e/wdio.conf.js
+++ b/tests/e2e/wdio.conf.js
@@ -114,10 +114,13 @@ async function findSafariDriverLog(minMtimeMs, timeoutMs = 10000) {
 
 async function safariDriverRequest(browser, method, segment, body) {
   const url = `http://localhost:${SAFARIDRIVER_PORT}/session/${browser.sessionId}${segment}`;
+  // undici's default headersTimeout is 5min; extension install on CI can
+  // legitimately take longer while Safari registers the unpacked extension.
   const res = await fetch(url, {
     method,
     headers: body ? { 'Content-Type': 'application/json' } : undefined,
     body: body ? JSON.stringify(body) : undefined,
+    signal: AbortSignal.timeout(10 * 60 * 1000),
   });
   const json = await res.json();
   if (json.value?.error) {
@@ -322,10 +325,46 @@ export const config = {
       }
 
       if (capabilities.browserName === 'safari') {
-        await safariDriverRequest(browser, 'POST', '/webextension', {
-          type: 'path',
-          path: SAFARI_PATH,
-        });
+        // Run a watchdog that dismisses any system-wide confirmation dialog
+        // (Safari "Install this extension?", SecurityAgent prompts, etc.)
+        // that may appear during the install call and block it indefinitely.
+        const watchdog = spawn(
+          'osascript',
+          [
+            '-e',
+            `repeat 60 times
+               tell application "System Events"
+                 repeat with p in application processes
+                   try
+                     repeat with w in (windows of p)
+                       try
+                         repeat with btn in (buttons of w)
+                           try
+                             set bn to name of btn as text
+                             if bn is in {"Allow", "Enable", "Trust", "OK", "Continue"} then
+                               click btn
+                             end if
+                           end try
+                         end repeat
+                       end try
+                     end repeat
+                   end try
+                 end repeat
+               end tell
+               delay 1
+             end repeat`,
+          ],
+          { stdio: 'ignore', detached: true },
+        );
+
+        try {
+          await safariDriverRequest(browser, 'POST', '/webextension', {
+            type: 'path',
+            path: SAFARI_PATH,
+          });
+        } finally {
+          watchdog.kill();
+        }
 
         // Trigger the extension on a real page so Safari prompts for permission.
         await browser.navigateTo(PAGE_URL);

--- a/tests/e2e/wdio.conf.js
+++ b/tests/e2e/wdio.conf.js
@@ -11,17 +11,27 @@
 
 /*
  * Usage:
- *   wdio tests/wdio.conf.js [--target=firefox,chrome] [--debug] [--clean]
+ *   wdio tests/wdio.conf.js [--target=firefox,chrome,safari] [--debug] [--clean]
  *
  * Options:
  *   --target: comma separated list of browsers to run the tests on (default: firefox,chrome)
+ *             safari requires macOS with `safaridriver --enable` and "Allow Unsigned Extensions"
  *   --debug: run the tests in debug mode (default: false)
  *   --clean: clean the build artifacts before running the tests (default: false)
  */
 
+import os from 'node:os';
 import path from 'node:path';
-import { readFileSync, cpSync, existsSync, rmSync } from 'node:fs';
-import { execSync } from 'node:child_process';
+import {
+  readFileSync,
+  writeFileSync,
+  cpSync,
+  existsSync,
+  rmSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
+import { execSync, execFileSync, spawn } from 'node:child_process';
 import { $, $$ } from '@wdio/globals';
 
 import { setupTestPage } from './page/server.js';
@@ -31,6 +41,7 @@ import { getExtensionPageURL, setExtensionBaseUrl, PAGE_PORT, PAGE_URL } from '.
 export const WEB_EXT_PATH = path.join(process.cwd(), 'web-ext-artifacts');
 export const FIREFOX_PATH = path.join(WEB_EXT_PATH, 'ghostery-firefox.zip');
 export const CHROME_PATH = path.join(WEB_EXT_PATH, 'ghostery-chromium');
+export const SAFARI_PATH = path.join(WEB_EXT_PATH, 'ghostery-safari');
 
 // Generate arguments from command line
 export const argv = process.argv.slice(2).reduce(
@@ -73,6 +84,94 @@ export function buildForChrome() {
     cpSync(path.join(process.cwd(), 'dist'), CHROME_PATH, {
       recursive: true,
     });
+  }
+}
+
+const SAFARIDRIVER_PORT = 4321;
+const SAFARIDRIVER_LOG_DIR = path.join(os.homedir(), 'Library/Logs/com.apple.WebDriver');
+let safariDriverProcess = null;
+
+async function findSafariDriverLog(minMtimeMs, timeoutMs = 10000) {
+  // safaridriver forks, so the log filename's pid doesn't match spawn's pid.
+  // Take the most recently modified log file created after we launched it.
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(SAFARIDRIVER_LOG_DIR)) {
+      const candidates = readdirSync(SAFARIDRIVER_LOG_DIR)
+        .filter((name) => name.startsWith('safaridriver.') && name.endsWith('.txt'))
+        .map((name) => {
+          const full = path.join(SAFARIDRIVER_LOG_DIR, name);
+          return { full, mtime: statSync(full).mtimeMs };
+        })
+        .filter(({ mtime }) => mtime >= minMtimeMs)
+        .sort((a, b) => b.mtime - a.mtime);
+      if (candidates.length) return candidates[0].full;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  return null;
+}
+
+async function safariDriverRequest(browser, method, segment, body) {
+  const url = `http://localhost:${SAFARIDRIVER_PORT}/session/${browser.sessionId}${segment}`;
+  const res = await fetch(url, {
+    method,
+    headers: body ? { 'Content-Type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json();
+  if (json.value?.error) {
+    throw new Error(`safaridriver ${method} ${segment} failed: ${JSON.stringify(json.value)}`);
+  }
+  return json.value;
+}
+
+function allowSafariExtensionPermission() {
+  // Safari shows a per-site permission sheet the first time an extension runs
+  // on a page. The buttons render as direct children of the Safari window
+  // (not a sheet) and can be reached via System Events UI automation. If no
+  // prompt appears the script returns "skipped" instead of failing.
+  execFileSync('osascript', [
+    '-e',
+    `tell application "System Events"
+       tell process "Safari"
+         set w to window 1
+         repeat 30 times
+           if exists button "Always Allow" of w then
+             if exists checkbox "Remember for other websites" of w then
+               click checkbox "Remember for other websites" of w
+             end if
+             click button "Always Allow" of w
+             return "clicked"
+           end if
+           delay 0.2
+         end repeat
+         return "skipped"
+       end tell
+     end tell`,
+  ]);
+}
+
+export function buildForSafari() {
+  if (!existsSync(SAFARI_PATH)) {
+    execSyncNode('npm run build -- chromium --silent --debug --clean');
+    rmSync(SAFARI_PATH, { recursive: true, force: true });
+    cpSync(path.join(process.cwd(), 'dist'), SAFARI_PATH, {
+      recursive: true,
+    });
+
+    // Safari does not support background.service_worker; use scripts instead.
+    // Mirrors xcode/ci_scripts/build.sh
+    const manifestPath = path.join(SAFARI_PATH, 'manifest.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    if (manifest.background?.service_worker) {
+      manifest.background = {
+        scripts: [manifest.background.service_worker],
+        type: 'module',
+        persistent: false,
+      };
+      writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+    }
   }
 }
 
@@ -133,6 +232,12 @@ export const config = {
         ]),
       },
     },
+    {
+      browserName: 'safari',
+      webSocketUrl: true,
+      'safari:experimentalWebSocketUrl': true,
+      'safari:automaticInspection': false,
+    },
   ].filter((capability) => argv.target.includes(capability.browserName)),
   onPrepare: async (config, capabilities) => {
     if (argv.clean) {
@@ -150,13 +255,36 @@ export const config = {
             buildForChrome();
             break;
           }
+          case 'safari': {
+            buildForSafari();
+            break;
+          }
         }
+      }
+
+      // Safari 26's safaridriver does not implement the BiDi webExtension module,
+      // so we use the classic POST /session/<id>/webextension endpoint. The driver
+      // never exposes the safari-web-extension://<UUID> origin in session state,
+      // so run it with --diagnose and parse the log for the origin after install.
+      if (argv.target.includes('safari')) {
+        process.env.WDIO_SKIP_DRIVER_SETUP = '1';
+        process.env.SAFARIDRIVER_START_MS = String(Date.now());
+        safariDriverProcess = spawn('safaridriver', [`--port=${SAFARIDRIVER_PORT}`, '--diagnose'], {
+          stdio: 'ignore',
+        });
+        await new Promise((resolve) => setTimeout(resolve, 500));
       }
 
       setupTestPage(PAGE_PORT);
     } catch (e) {
       console.error('Error while preparing test environment', e);
       process.exit(1);
+    }
+  },
+  onComplete: () => {
+    if (safariDriverProcess) {
+      safariDriverProcess.kill();
+      safariDriverProcess = null;
     }
   },
   before: async (capabilities, specs, browser) => {
@@ -191,6 +319,37 @@ export const config = {
         // Enable developer mode for reloading extension
         await $('>>>#devMode').click();
         await browser.pause(2000);
+      }
+
+      if (capabilities.browserName === 'safari') {
+        await safariDriverRequest(browser, 'POST', '/webextension', {
+          type: 'path',
+          path: SAFARI_PATH,
+        });
+
+        // Trigger the extension on a real page so Safari prompts for permission.
+        await browser.navigateTo(PAGE_URL);
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        allowSafariExtensionPermission();
+
+        // Reload so the content script runs and safaridriver logs the
+        // safari-web-extension://<UUID> origin we need for extension pages.
+        await browser.navigateTo(PAGE_URL);
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+
+        const startMs = Number(process.env.SAFARIDRIVER_START_MS) || 0;
+        const logPath = await findSafariDriverLog(startMs);
+        if (!logPath) {
+          throw new Error('safaridriver diagnose log not found');
+        }
+
+        const log = readFileSync(logPath, 'utf8');
+        const match = log.match(/safari-web-extension:\/\/([0-9a-f-]+)/i);
+        if (!match) {
+          throw new Error('Could not discover safari-web-extension UUID from diagnose log');
+        }
+
+        setExtensionBaseUrl(`safari-web-extension://${match[1]}/pages`);
       }
 
       const SETTINGS_PAGE_URL = getExtensionPageURL('settings');


### PR DESCRIPTION
## Summary
- Adds a `safari` target to the WebdriverIO e2e suite so the Ghostery extension can be tested on Safari 26+.
- Installs the unpacked extension via safaridriver's classic `POST /session/<id>/webextension` endpoint (the BiDi `webExtension` module is not yet implemented in Safari's safaridriver).
- Auto-dismisses Safari's per-site permission prompt via AppleScript, then recovers the `safari-web-extension://<UUID>` origin from safaridriver's diagnose log.
- Adds `scripts/setup-safari-ci.sh` and a new `e2e-safari` job on `macos-15` to wire everything up on GitHub Actions.

## Test plan
- [ ] `npm run wdio -- --target=safari` succeeds locally against Safari 26.4 (driver enabled, Accessibility granted to osascript, Allow Remote Automation + Allow Unsigned Extensions enabled).
- [ ] The new `e2e-safari` CI job completes and reports test results.