### PR TITLE
fix(safari): "loadExtendedSelectors" missing from Safari base config

### DIFF
--- a/src/background/custom-filters.js
+++ b/src/background/custom-filters.js
@@ -82,6 +82,8 @@ async function collectFilters(text, { isTrustedScriptInjectAllowed }) {
     text,
     {
       ...baseConfig,
+      // Safari doesn't support "loadExtendedSelectors" with the baseConfig.
+      loadExtendedSelectors: true,
       debug: true,
     },
   );


### PR DESCRIPTION
<details>

<summary>A screenshot from Safari</summary>

<img width="2439" height="1392" alt="image" src="https://github.com/user-attachments/assets/e1b82f69-adf5-45b8-9587-e47d49160dec" />

</details>

<details>

<summary>A screenshot from Chrome</summary>

<img width="2524" height="1459" alt="image" src="https://github.com/user-attachments/assets/68605a85-9939-4ea7-881d-325abac7c415" />

</details>

```
blick.ch##.tp-modal:has([allow="payment"])
blick.ch##body.tp-modal-open:has(.tp-modal [allow"payment"]) > .tp-backdrop
blick.ch##body.tp-modal-open:has(.tp-modal [allow"payment"]):style(overflow: initial !important)
```

Safari v10.5.38 on macOS 26.4.1 (25E253)