### PR TITLE
fix(lottie): use light build to drop eval-based expression engine

### DIFF
--- a/src/ui/components/lottie.js
+++ b/src/ui/components/lottie.js
@@ -10,7 +10,7 @@
  */
 
 import { html } from 'hybrids';
-import lottie from 'lottie-web';
+import lottie from 'lottie-web/build/player/esm/lottie_light.min.js';
 
 export default {
   src: '',


### PR DESCRIPTION
## Summary

- Switches `lottie-web` import to the `lottie_light` ESM build, which omits the expression engine that relies on direct `eval`.
- Silences the rolldown `[EVAL]` warning during build and reduces bundle size.
- Both animation JSONs (`lottie-mode-zap.json`, `lottie-mode-default.json`) use only standard SVG rendering with no expression fields, so behavior is unchanged.

## Test plan

- [ ] Open the onboarding flow and verify the mode animations play correctly on hover and autoplay.
- [ ] Open the settings "My Ghostery" view and verify its animations render.
- [ ] Confirm the build output no longer emits the `[EVAL]` warning.