### PR TITLE
perf(build): disable gzip size reporting

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -194,6 +194,7 @@ const config = {
     assetsDir: '',
     emptyOutDir: false,
     minify: false,
+    reportCompressedSize: false,
     modulePreload: {
       polyfill: false,
     },


### PR DESCRIPTION
## Summary

- Disables Vite's `reportCompressedSize` since the extension ships uncompressed files (we skip minification for transparency and debugging).
- Removes per-chunk in-memory gzip work from every build.

## Test plan

- [ ] Run a full Firefox and Chromium build and confirm the extension loads and functions as before.
- [ ] Confirm the per-file `gzip: ...` column no longer appears in the build output.