### PR TITLE
fix(adblocker): suppress CSS injection error when frame is destroyed before injection

### DIFF
--- a/src/background/adblocker/cosmetics.js
+++ b/src/background/adblocker/cosmetics.js
@@ -109,7 +109,27 @@ function injectStyles(styles, details) {
       origin: 'USER',
       target: resolveInjectionTarget(details),
     })
-    .catch((e) => console.warn('[adblocker] failed to inject CSS', e));
+    .catch(async (e) => {
+      // On Firefox, "Missing host permission for the tab or frames" is produced
+      // whenever the target frame is destroyed before the browser completes the
+      // CSS injection, regardless of how the injection was triggered.
+      if (__FIREFOX__ && e?.message?.startsWith('Missing host permission')) return;
+
+      // Only log a warning if the frame still exists, otherwise it means that
+      // the frame is destroyed before the CSS is injected.
+      const frame = await chrome.webNavigation
+        .getFrame({ tabId: details.tabId, frameId: details.frameId })
+        .catch(() => null);
+
+      if (!frame) return;
+
+      // On Chromium, when documentId is used as the injection target, verify the
+      // frame's current document matches. If it differs, the frame navigated to a
+      // new document after onCommitted fired but before insertCSS ran (benign race).
+      if (__CHROMIUM__ && details.documentId && frame.documentId !== details.documentId) return;
+
+      console.warn('[adblocker] failed to inject CSS', e);
+    });
 }
 
 const SUBFRAME_SCRIPTING = resolveFlag(FLAG_SUBFRAME_SCRIPTING);
@@ -239,11 +259,10 @@ async function injectCosmetics(details, config) {
     }
 
     if (extended && extended.length > 0) {
-      chrome.tabs.sendMessage(
-        tabId,
-        { action: 'evaluateExtendedSelectors', extended },
-        { frameId },
-      );
+      chrome.tabs
+        .sendMessage(tabId, { action: 'evaluateExtendedSelectors', extended }, { frameId })
+        // In case the frame is destroyed before the message is delivered, we can get an error
+        .catch(() => {});
     }
   }
 


### PR DESCRIPTION
On Firefox, `webNavigation.onCommitted` can fire for a subframe that gets a new browsing context ID after a server-side redirect. By the time `chrome.scripting.insertCSS` executes, the original frame no longer exists, causing Firefox to throw a false-positive `"Missing host permission for the tab or frames"` error from `queryContent()` in `ext-tabs-base.js`.

The fix checks whether the frame still exists via `chrome.webNavigation.getFrame()` inside the `.catch()` handler, and only emits a `console.warn` if the frame is still alive — confirming the error is a real injection failure rather than a benign race condition. On Firefox, subframes (non-zero `frameId`) are additionally skipped early since Firefox does not support `documentId` for reliable frame identity checks.