### PR TITLE
fix(redirect-protection): align Firefox main_frame matching with DNR

### DIFF
--- a/src/background/adblocker/network.js
+++ b/src/background/adblocker/network.js
@@ -90,11 +90,7 @@ if (__FIREFOX__) {
           // a resource type — we mirror that here.
           if (match === true && !filter?.fromAny()) {
             const options = store.get(Options);
-            const redirectUrl = getRedirectProtectionUrl(
-              details.url,
-              request.hostname,
-              options,
-            );
+            const redirectUrl = getRedirectProtectionUrl(details.url, request.hostname, options);
 
             return { redirectUrl };
           }

--- a/src/background/adblocker/network.js
+++ b/src/background/adblocker/network.js
@@ -80,13 +80,24 @@ if (__FIREFOX__) {
 
       if (isMatchableRequest(details, request)) {
         const engine = engines.get(engines.MAIN_ENGINE);
-        const { redirect, match } = engine.match(request);
+        const { redirect, match, filter } = engine.match(request);
 
-        if (match === true && details.type === 'main_frame') {
-          const options = store.get(Options);
-          const redirectUrl = getRedirectProtectionUrl(details.url, request.hostname, options);
+        if (details.type === 'main_frame') {
+          // For main_frame, only consider matches from filters with an
+          // explicit $document modifier. Type-less filters match main_frame
+          // via @ghostery/adblocker's FROM_ANY mask, but Chrome MV3 DNR's
+          // safety default excludes main_frame for filters that don't specify
+          // a resource type — we mirror that here.
+          if (match === true && !filter?.fromAny()) {
+            const options = store.get(Options);
+            const redirectUrl = getRedirectProtectionUrl(
+              details.url,
+              request.hostname,
+              options,
+            );
 
-          return { redirectUrl };
+            return { redirectUrl };
+          }
         } else if (redirect !== undefined) {
           request.blocked = true;
           // There's a possibility that redirecting to file URL can expose

--- a/src/background/adblocker/network.js
+++ b/src/background/adblocker/network.js
@@ -83,12 +83,10 @@ if (__FIREFOX__) {
         const { redirect, match, filter } = engine.match(request);
 
         if (details.type === 'main_frame') {
-          // For main_frame, only consider matches from filters with an
-          // explicit $document modifier. Type-less filters match main_frame
-          // via @ghostery/adblocker's FROM_ANY mask, but Chrome MV3 DNR's
-          // safety default excludes main_frame for filters that don't specify
-          // a resource type — we mirror that here.
-          if (match === true && !filter?.fromAny()) {
+          // Skip type-less filters whose mask is FROM_ANY: Chrome MV3 DNR's
+          // safety default excludes main_frame for filters without an
+          // explicit resource type, and we mirror that here.
+          if (match === true && filter?.fromDocument() && !filter.fromAny()) {
             const options = store.get(Options);
             const redirectUrl = getRedirectProtectionUrl(details.url, request.hostname, options);
 

--- a/tests/e2e/spec/redirect-protection.spec.js
+++ b/tests/e2e/spec/redirect-protection.spec.js
@@ -190,3 +190,38 @@ describe('Redirect Protection', function () {
     });
   });
 });
+
+// Type-less filters (no $document modifier) must NOT redirect main_frame on
+// either platform. Chrome MV3 DNR enforces this by default (omitting
+// resourceTypes excludes main_frame). Firefox previously matched main_frame
+// for type-less filters via @ghostery/adblocker's FROM_ANY mask; we now skip
+// those matches in src/background/adblocker/network.js.
+describe('Type-less filter does not affect main_frame', function () {
+  before(enableExtension);
+  before(() => setCustomFilters([`||${PAGE_DOMAIN}^`]));
+  after(() => disableCustomFilters());
+
+  it('does not redirect when redirect protection is enabled', async function () {
+    await browser.url('ghostery:settings');
+    await getExtensionElement('button:redirect-protection').click();
+    await setToggle('redirect-protection', true);
+
+    await browser.url(PAGE_URL);
+    expect((await browser.getUrl()).includes('pages/redirect-protection')).toBe(false);
+    expect(await browser.getTitle()).toBe('E2E Test Page');
+  });
+
+  it('does not block when redirect protection is disabled', async function () {
+    await browser.url('ghostery:settings');
+    await getExtensionElement('button:redirect-protection').click();
+    await setToggle('redirect-protection', false);
+
+    await browser.url(PAGE_URL);
+    expect((await browser.getUrl()).includes('pages/redirect-protection')).toBe(false);
+    expect(await browser.getTitle()).toBe('E2E Test Page');
+
+    await browser.url('ghostery:settings');
+    await getExtensionElement('button:redirect-protection').click();
+    await setToggle('redirect-protection', true);
+  });
+});


### PR DESCRIPTION
## Summary

On Firefox, type-less filters (e.g. `||tracker.com^` with no `$document` modifier) were triggering the redirect-protection warning page on top-level navigations. This diverges from Chrome MV3, where DNR's safety default excludes `main_frame` for rules that don't specify `resourceTypes`.

The behavior originated in `@ghostery/adblocker`, whose `FROM_ANY` mask matches `main_frame` for type-less filters. The Firefox webRequest handler in `src/background/adblocker/network.js` then engaged the redirect-protection branch on every such match.

We now restrict the main_frame branch to filters with an explicit `$document` modifier (`!filter.fromAny()`), matching DNR's behavior and the filter authors' intent. As a side effect, the silent pass-through caused by returning `{ redirectUrl: undefined }` is gone — main_frame handling lives entirely inside the document-only branch.

The `Type-less filter does not affect main_frame` e2e suite covers both toggle states.

## Test plan

- [ ] On Firefox, navigate to a page that matches a custom filter without `$document` (e.g. add `||example.com^` to custom filters and visit `https://example.com`). Expect: page loads normally, no warning page.
- [ ] On Firefox, with a `$document` custom filter (`||example.com^$document`) and redirect protection on, visit the URL. Expect: warning page appears (existing behavior).
- [ ] On Firefox, with a `$document` custom filter and redirect protection off, visit the URL. Expect: page loads normally (existing behavior).
- [ ] On Chromium, repeat all three scenarios. Expect: identical behavior — DNR was already correct here.