### PR TITLE
fix(ci): properly filter always true conditions

### DIFF
--- a/scripts/utils/filter-metadata.js
+++ b/scripts/utils/filter-metadata.js
@@ -17,40 +17,20 @@ globalThis.__CHROMIUM__ ??= false;
 
 const { ENV } = await import('../../src/utils/preprocessors.js');
 
-const SUPPORTED_ENVS = [...ENV.keys()];
-const IDENTIFIER_RE = /[a-zA-Z0-9_]+/g;
-
-function extractSupportedIdentifiers(expression) {
-  const ids = expression.match(IDENTIFIER_RE) || [];
-  return [...new Set(ids.filter((id) => SUPPORTED_ENVS.includes(id)))];
-}
-
-/**
- * Returns true if the preprocessor expression can yield different results
- * depending on the value of supported envs. If the result is constant
- * regardless of the environment (always true or always false), returns false.
- */
-function dependsOnSupportedEnvs(expression) {
-  const ids = extractSupportedIdentifiers(expression);
-  if (ids.length === 0) {
-    return false;
+function isConditionAlwaysTrue(condition, target) {
+  // If the condition doesn't include target, it means we don't have any
+  // other factors to judge the condition.
+  if (condition.includes(target) === false) {
+    return evaluatePreprocessor(condition, ENV);
   }
 
-  const combinations = 1 << ids.length;
-  let firstResult;
-  for (let mask = 0; mask < combinations; mask++) {
-    const env = new Map();
-    ids.forEach((key, i) => {
-      env.set(key, !!(mask & (1 << i)));
-    });
-    const result = evaluatePreprocessor(expression, env);
-    if (mask === 0) {
-      firstResult = result;
-    } else if (result !== firstResult) {
-      return true;
-    }
-  }
-  return false;
+  // Do negative test against target, so we can know it actually affects
+  // the resulting logical gate.
+  const re = new RegExp(`(env_)?${target}[a-z_]*`, 'gi');
+  return (
+    evaluatePreprocessor(condition.replace(re, 'true'), ENV) === false &&
+    evaluatePreprocessor(condition, ENV) === true
+  );
 }
 
 /**
@@ -63,12 +43,12 @@ function dependsOnSupportedEnvs(expression) {
  * @returns {Record<string, { preprocessor?: string }>}
  */
 export function filterMetadata(metadata) {
-  const filtered = {};
-  for (const [id, entry] of Object.entries(metadata)) {
-    if (entry.preprocessor && !dependsOnSupportedEnvs(entry.preprocessor)) {
-      continue;
-    }
-    filtered[id] = entry;
-  }
-  return filtered;
+  return Object.fromEntries(
+    Object.entries(metadata).filter(function ([, { preprocessor }]) {
+      return (
+        !isConditionAlwaysTrue(preprocessor, 'adguard') &&
+        !isConditionAlwaysTrue(preprocessor, 'firefox')
+      );
+    }),
+  );
 }

--- a/scripts/utils/filter-metadata.js
+++ b/scripts/utils/filter-metadata.js
@@ -11,26 +11,36 @@
 
 import { evaluatePreprocessor } from '@ghostery/adblocker';
 
-// Set globals for `utils/preprocessors.js`
-globalThis.__FIREFOX__ ??= true;
-globalThis.__CHROMIUM__ ??= false;
+const truthyIdentifiers = [
+  'ext_ghostery',
+  'ext_ublock',
+  'env_mv3',
+  'ext_ubol',
+  'cap_user_stylesheet',
+  'env_chromium',
+  'adguard_ext_chromium',
+  'adguard_ext_opera',
+];
+const staleIdentifiers = ['env_edge', 'env_safari', 'env_mobile'];
 
-const { ENV } = await import('../../src/utils/preprocessors.js');
+const env = new Map(
+  truthyIdentifiers.map(function (identifier) {
+    return [identifier, true];
+  }),
+);
 
-function isConditionAlwaysTrue(condition, target) {
-  // If the condition doesn't include target, it means we don't have any
-  // other factors to judge the condition.
-  if (condition.includes(target) === false) {
-    return evaluatePreprocessor(condition, ENV);
+function isConditionAlwaysTrue(condition) {
+  for (let i = 0; i < 1 << staleIdentifiers.length; i++) {
+    for (let k = 0; k < staleIdentifiers.length; k++) {
+      env.set(staleIdentifiers[k], !!(i & (1 << k)));
+    }
+
+    if (evaluatePreprocessor(condition, env) === false) {
+      return false;
+    }
   }
 
-  // Do negative test against target, so we can know it actually affects
-  // the resulting logical gate.
-  const re = new RegExp(`(env_)?${target}[a-z_]*`, 'gi');
-  return (
-    evaluatePreprocessor(condition.replace(re, 'true'), ENV) === false &&
-    evaluatePreprocessor(condition, ENV) === true
-  );
+  return true;
 }
 
 /**
@@ -45,10 +55,7 @@ function isConditionAlwaysTrue(condition, target) {
 export function filterMetadata(metadata) {
   return Object.fromEntries(
     Object.entries(metadata).filter(function ([, { preprocessor }]) {
-      return (
-        !isConditionAlwaysTrue(preprocessor, 'adguard') &&
-        !isConditionAlwaysTrue(preprocessor, 'firefox')
-      );
+      return isConditionAlwaysTrue(preprocessor) === false;
     }),
   );
 }

--- a/tests/unit/preprocessor.test.js
+++ b/tests/unit/preprocessor.test.js
@@ -25,12 +25,16 @@ describe('Preprocessor', () => {
         chromiumAndNotChromium: { preprocessor: 'env_chromium&&!env_chromium' },
         chromiumOrNotChromium: { preprocessor: 'env_chromium||!env_chromium' },
         chromiumAndGhostery: { preprocessor: 'env_chromium&&ext_ghostery' },
+        notEdge: { preprocessor: '!env_edge' },
+        notAdguardAndNotEdge: { preprocessor: '!adguard&&!env_edge' },
       };
 
       assert.deepEqual(filterMetadata(metadata), {
         adguard: { preprocessor: 'adguard' },
         adguardOrSafari: { preprocessor: 'adguard||ext_safari' },
         chromiumAndNotChromium: { preprocessor: 'env_chromium&&!env_chromium' },
+        notEdge: { preprocessor: '!env_edge' },
+        notAdguardAndNotEdge: { preprocessor: '!adguard&&!env_edge' },
       });
     });
   });

--- a/tests/unit/preprocessor.test.js
+++ b/tests/unit/preprocessor.test.js
@@ -1,0 +1,37 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { filterMetadata } from '../../scripts/utils/filter-metadata.js';
+
+describe('Preprocessor', () => {
+  describe('#filterMetadata', () => {
+    it('filterMetadata', () => {
+      const metadata = {
+        adguard: { preprocessor: 'adguard' },
+        notAdguard: { preprocessor: '!adguard' },
+        notAdguardOrSafari: { preprocessor: '!adguard||ext_safari' },
+        adguardOrSafari: { preprocessor: 'adguard||ext_safari' },
+        chromiumAndNotChromium: { preprocessor: 'env_chromium&&!env_chromium' },
+        chromiumOrNotChromium: { preprocessor: 'env_chromium||!env_chromium' },
+        chromiumAndGhostery: { preprocessor: 'env_chromium&&ext_ghostery' },
+      };
+
+      assert.deepEqual(filterMetadata(metadata), {
+        adguard: { preprocessor: 'adguard' },
+        adguardOrSafari: { preprocessor: 'adguard||ext_safari' },
+        chromiumAndNotChromium: { preprocessor: 'env_chromium&&!env_chromium' },
+      });
+    });
+  });
+});


### PR DESCRIPTION
Correction on https://github.com/ghostery/ghostery-extension/pull/3297

Previous pull request was dropped condition without properly looking at operators like "!" and logical gates whenever all identifier tokens are unsupported. This creates invalid drops of conditions from the metadata file even when it's always false. This may lead to duplicated scripting or blocking issue on specific websites when the list or user custom filter has two filters in different adblocker syntax (one in ubo and another in adguard) then both gets accepted in any way (when they're correctly parsed).

We can extended this pull request to drop filter ids when the condition is always false later. But it's more risky step than having a filter turned on.