### PR TITLE
fix(build): filter DNR metadata entries whose preprocessor is always true

### DIFF
--- a/scripts/utils/filter-metadata.js
+++ b/scripts/utils/filter-metadata.js
@@ -26,38 +26,35 @@ function extractSupportedIdentifiers(expression) {
 }
 
 /**
- * Returns true if the preprocessor expression can yield different results
- * depending on the value of supported envs. If the result is constant
- * regardless of the environment (always true or always false), returns false.
+ * Returns true if the preprocessor expression always evaluates to `true`
+ * across every combination of supported envs. Expressions that depend on
+ * supported envs (yielding both true and false) or that are constantly
+ * false return `false`.
  */
-function dependsOnSupportedEnvs(expression) {
+function alwaysTrueForSupportedEnvs(expression) {
   const ids = extractSupportedIdentifiers(expression);
   if (ids.length === 0) {
-    return false;
+    return evaluatePreprocessor(expression, new Map()) === true;
   }
 
   const combinations = 1 << ids.length;
-  let firstResult;
   for (let mask = 0; mask < combinations; mask++) {
     const env = new Map();
     ids.forEach((key, i) => {
       env.set(key, !!(mask & (1 << i)));
     });
-    const result = evaluatePreprocessor(expression, env);
-    if (mask === 0) {
-      firstResult = result;
-    } else if (result !== firstResult) {
-      return true;
+    if (evaluatePreprocessor(expression, env) !== true) {
+      return false;
     }
   }
-  return false;
+  return true;
 }
 
 /**
- * Filters out metadata entries whose preprocessor references unsupported
- * envs in a way that makes the result constant. Such entries cannot be
- * meaningfully evaluated at runtime, so the rules they describe will always
- * either apply or never apply regardless of the environment.
+ * Filters out metadata entries whose preprocessor always resolves to `true`
+ * regardless of the value of supported envs. Such preprocessors are
+ * redundant because the rules they describe will always apply, so the
+ * metadata entry carries no useful runtime information.
  *
  * @param {Record<string, { preprocessor?: string }>} metadata
  * @returns {Record<string, { preprocessor?: string }>}
@@ -65,7 +62,7 @@ function dependsOnSupportedEnvs(expression) {
 export function filterMetadata(metadata) {
   const filtered = {};
   for (const [id, entry] of Object.entries(metadata)) {
-    if (entry.preprocessor && !dependsOnSupportedEnvs(entry.preprocessor)) {
+    if (entry.preprocessor && alwaysTrueForSupportedEnvs(entry.preprocessor)) {
       continue;
     }
     filtered[id] = entry;

--- a/tests/unit/scripts/download-dnr-rulesets.test.js
+++ b/tests/unit/scripts/download-dnr-rulesets.test.js
@@ -1,0 +1,44 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { filterMetadata } from '../../../scripts/utils/filter-metadata.js';
+
+describe('Download DNR Rulesets', () => {
+  it('filter metadata with always truthy conditions', () => {
+    const metadataFilterOut = {
+      // Always truthy, should be filtered out
+      notAdguard: { preprocessor: '!adguard' },
+      // Always truthy, should be filtered out
+      notAdguardAndNotSafari: { preprocessor: '!adguard&&!ext_abp' },
+      // Contains two unsupported envs, but OR makes it to only yield true
+      notAdguardOrSafari: { preprocessor: '!adguard||ext_abp' },
+    };
+
+    const metadataKeep = {
+      // Not supported - should be kept as results to false
+      adguard: { preprocessor: 'adguard' },
+      // Contains one supported env, but can still yield both true and false
+      notAdguardAndNotEdge: { preprocessor: '!adguard&&!env_edge' },
+      // Contains only supported envs, so it can yield both true and false
+      notEdge: { preprocessor: '!env_edge' },
+    };
+
+    const metadata = {
+      ...metadataFilterOut,
+      ...metadataKeep,
+    };
+
+    assert.deepEqual(filterMetadata(metadata), metadataKeep);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the DNR metadata filtering so it only drops entries whose `preprocessor` always evaluates to `true` across every combination of supported envs. Previously the logic also dropped entries whose result was constantly `false`, and kept entries that varied based on the env — the inverse of what we want.

Entries that are constantly `false` or that depend on supported envs are now preserved, since they still carry meaningful runtime information.

## Changes

- `scripts/utils/filter-metadata.js`: replace `dependsOnSupportedEnvs` with `alwaysTrueForSupportedEnvs`; `filterMetadata` now skips only entries that are unconditionally `true`.
- `tests/unit/scripts/download-dnr-rulesets.js`: add coverage for the new behavior.

## Note on #3302

[#3302](https://github.com/ghostery/ghostery-extension/pull/3302) attempts to fix the same issue, but it does so by hardcoding the list of supported envs inside the build script. That breaks the single source of truth in [src/utils/preprocessors.js](src/utils/preprocessors.js), where the `ENV` map is defined:

> This map is the source of truth for all supported preprocessor envs.

This PR keeps that invariant — `scripts/utils/filter-metadata.js` continues to derive `SUPPORTED_ENVS` from `ENV.keys()`:

```js
const { ENV } = await import('../../src/utils/preprocessors.js');
const SUPPORTED_ENVS = [...ENV.keys()];
```

so any future change to the supported env list only needs to happen in one place.