### PR TITLE
chore(deps): refresh npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@ghostery/urlfilter2dnr": "^2.0.4",
         "@github/relative-time-element": "^5.0.0",
         "@sentry/browser": "^10.50.0",
-        "@whotracksme/reporting": "^8.0.2",
+        "@whotracksme/reporting": "^9.0.1",
         "apexsankey": "github:ghostery/apexsankey",
         "bowser": "^2.14.1",
         "csv-stringify": "^6.7.0",
@@ -27,7 +27,7 @@
         "idb": "^8.0.3",
         "lottie-web": "^5.13.0",
         "plotly.js-basic-dist": "^3.5.0",
-        "tldts-experimental": "^7.0.28"
+        "tldts-experimental": "^7.0.29"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -5302,9 +5302,9 @@
       }
     },
     "node_modules/@whotracksme/reporting": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@whotracksme/reporting/-/reporting-8.0.2.tgz",
-      "integrity": "sha512-5pOTBSiMq2qfC/PIxbwire0LPikf6j+zXL0n56Ncarc3O3JBjVxxrm/Gw46DpakYtBrjeYrpg/Ay2+jgt5gBtg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@whotracksme/reporting/-/reporting-9.0.1.tgz",
+      "integrity": "sha512-ht4yTrVbBH85Q3W5/bnrqLfSTG+OtHROJqNrgWPbTOt0e9AGcb5F2mEjWJqaAHvu+nJhnzp0KPRmvNr430VL3Q==",
       "license": "MPL-2.0",
       "workspaces": [
         "reporting",
@@ -15082,18 +15082,18 @@
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.28.tgz",
-      "integrity": "sha512-z000DWdcayJ6TctJCb50BtJb89aeXw7WVUp5OREZZrkg56jEwLT18ySbSB28bJvEcNQ4D3JG5SLS/eSViGlRuA==",
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.29.tgz",
+      "integrity": "sha512-7Lbk4nLf30nRLLm+vFtqBN4rPAJ7jjPj9QwvMiaZuSAl5d6Udz5GCuhH7hjquYXbaSlPKmd3SrClLBSHVlZKiQ==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.28"
+        "tldts-core": "^7.0.29"
       }
     },
     "node_modules/tldts-experimental/node_modules/tldts-core": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
-      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
+      "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
       "license": "MIT"
     },
     "node_modules/tmp": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@ghostery/urlfilter2dnr": "^2.0.4",
     "@github/relative-time-element": "^5.0.0",
     "@sentry/browser": "^10.50.0",
-    "@whotracksme/reporting": "^8.0.2",
+    "@whotracksme/reporting": "^9.0.1",
     "apexsankey": "github:ghostery/apexsankey",
     "bowser": "^2.14.1",
     "csv-stringify": "^6.7.0",
@@ -59,7 +59,7 @@
     "idb": "^8.0.3",
     "lottie-web": "^5.13.0",
     "plotly.js-basic-dist": "^3.5.0",
-    "tldts-experimental": "^7.0.28"
+    "tldts-experimental": "^7.0.29"
   },
   "dataDependencies": {
     "redirect-resources": "220b5c885c08c9674c6dbb039194795f8d898544e1e35784ca5c76786050b55e",


### PR DESCRIPTION
## Summary
- rerun dependency refresh to latest available npm versions
- run `npm dedupe`
- run `npm audit fix` without forcing breaking changes

## Updated packages
- @whotracksme/reporting: ^8.0.2 -> ^9.0.1
- tldts-experimental: ^7.0.28 -> ^7.0.29

## Validation
- `npm run lint` passes (existing warnings only)
- `npm audit fix` could not apply remaining advisories without breaking changes

## Remaining audit status
- 15 vulnerabilities remain (9 moderate, 6 high)
- includes advisories in transitive `tar`/`uuid` chains with either no non-breaking fix or no fix available in current dependency graph