### PR TITLE
fix(errors): disable error capturing for unsupported browsers

### DIFF
--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -37,6 +37,8 @@ const config = {
   // Sampling is handled in beforeSend to allow per-event control
   sampleRate: 1.0,
   beforeSend(event) {
+    if (!event.tags?.ua) return null;
+
     if (event.tags?.[TAG_CRITICAL]) {
       return event;
     }


### PR DESCRIPTION
When `getBrowserInfo` resolves with an empty `ua` token, the browser is unsupported. In that case Sentry would set an empty string as the `ua` tag.

The `beforeSend` hook now checks `event.tags?.ua` — if it is falsy (empty string or not set), the event is dropped, effectively disabling error capturing for unsupported browsers.