### PR TITLE
fix(notifications): make close handler robust against edge cases

### DIFF
--- a/src/content_scripts/notifications.js
+++ b/src/content_scripts/notifications.js
@@ -125,17 +125,25 @@ function mount(url, position = 'right', debug = false) {
 
     if (type === notifications.CLOSE_WINDOW_EVENT) {
       if (e.data.clear) {
-        // Send clearIframe message to other pages
-        chrome.runtime.sendMessage({
-          action: notifications.CLEAR_ACTION,
-          id: new URL(url).pathname.split('/').pop(),
-        });
+        // Notify sibling iframes. Guarded because an invalidated extension
+        // context throws synchronously and would abort the close routine.
+        try {
+          chrome.runtime.sendMessage({
+            action: notifications.CLEAR_ACTION,
+            id: new URL(url).pathname.split('/').pop(),
+          });
+        } catch (err) {
+          console.warn('[notifications] Failed to broadcast CLEAR_ACTION:', err);
+        }
       }
 
-      wrapper.addEventListener('transitionend', () => {
+      // Wait slightly longer than the 0.2s CSS transition before removing the
+      // wrapper. Using a timer instead of transitionend ensures cleanup also
+      // happens when the transition is skipped (reduced motion, hidden tab).
+      setTimeout(() => {
         wrapper.remove();
         if (e.data.reload) window.location.reload();
-      });
+      }, 500);
 
       wrapper.classList.remove('active');
     }

--- a/src/pages/notifications/youtube.js
+++ b/src/pages/notifications/youtube.js
@@ -16,8 +16,8 @@ import * as notifications from '/utils/notifications.js';
 
 const close = notifications.setupNotificationPage(420);
 
-function dontAsk() {
-  chrome.storage.local.set({ youtubeDontAsk: true });
+async function dontAsk() {
+  await chrome.storage.local.set({ youtubeDontAsk: true });
   close();
 }
 


### PR DESCRIPTION
Hardens the notification iframe close path so the popup (most visibly the 30-day review notification) cannot get stuck on screen. Two edge cases could leave the wrapper in the DOM after the user clicked close: (1) after an extension update/reload, the first call in the close handler — `chrome.runtime.sendMessage(CLEAR_ACTION)` — throws synchronously with `Extension context invalidated`, aborting the rest of the cleanup; (2) the wrapper was only removed inside a `transitionend` listener, which never fires under `prefers-reduced-motion`, hidden tabs, or accessibility tooling that disables CSS transitions.

This PR wraps the `CLEAR_ACTION` broadcast in `try/catch` and replaces the `transitionend` listener with a `setTimeout` slightly longer than the 0.2s CSS transition, so cleanup always runs. Drive-by: `await` `chrome.storage.local.set` in the YouTube notification's `dontAsk` handler so the value is persisted before the page closes.