### PR TITLE
fix(e2e): poll subdocument scriptlet result to avoid race condition

### DIFF
--- a/tests/e2e/page/adblocker/index.html
+++ b/tests/e2e/page/adblocker/index.html
@@ -137,13 +137,23 @@
           l++;
           const iframe = document.createElement("iframe");
           iframe.addEventListener("load", function () {
-            if (
-              iframe.contentWindow.subdocument === true
-              && window.subdocument !== true
-            ) {
-              results["subdocument"] = true;
+            // On Chromium, scriptlet injection via chrome.scripting.executeScript
+            // is triggered asynchronously from webNavigation.onCommitted in the
+            // background service worker. For a tiny document like subdocument.html,
+            // the load event in the parent can fire before the scriptlet runs.
+            // Poll with retries to account for this race condition.
+            var retries = 10;
+            function check() {
+              if (iframe.contentWindow.subdocument === true && window.subdocument !== true) {
+                results["subdocument"] = true;
+                done();
+              } else if (--retries > 0) {
+                setTimeout(check, 50);
+              } else {
+                done();
+              }
             }
-            done();
+            check();
           }, { once: true });
           iframe.setAttribute("src", "./subdocument.html");
           iframe.style.width = "1px";


### PR DESCRIPTION
On Chromium, scriptlets are injected via `chrome.scripting.executeScript` triggered asynchronously from `webNavigation.onCommitted` in the background service worker. For a tiny document like `subdocument.html`, the parent frame's `load` event can fire before the scriptlet has run, causing a single synchronous check of `iframe.contentWindow.subdocument` to always return `false`.

The fix replaces the one-shot check with a polling loop (up to 10 retries × 50 ms = 500 ms) that waits for the scriptlet to set the property before concluding the test. The parent-frame guard (`window.subdocument !== true`) is preserved to ensure the subframe constraint (`>>`) is still validated correctly.