### PR TITLE
fix(options): improve bootstrap and options observers

### DIFF
--- a/src/background/report-issue.js
+++ b/src/background/report-issue.js
@@ -17,7 +17,7 @@ import Resources from '/store/resources.js';
 
 import getBrowserInfo from '/utils/browser-info.js';
 import { SUPPORT_PAGE_URL } from '/utils/urls.js';
-import { isOptionEqual } from '/utils/options-observer.js';
+import * as OptionsObserver from '/utils/options-observer.js';
 import { parseWithCache } from '/utils/request.js';
 
 import { tabStats } from './stats.js';
@@ -32,7 +32,7 @@ async function getMetadata(tab) {
       .filter(([key]) => REPORT_OPTIONS.includes(key))
       .reduce((acc, [key, value]) => {
         // Skip options that are equal to the default value
-        if (key !== 'regionalFilters' && isOptionEqual(Options[key], value)) {
+        if (key !== 'regionalFilters' && OptionsObserver.isOptionEqual(Options[key], value)) {
           return acc;
         }
 

--- a/src/background/telemetry/attribution.js
+++ b/src/background/telemetry/attribution.js
@@ -88,8 +88,13 @@ async function getAttributionFromUTMs() {
 }
 
 export default async function detectAttribution() {
-  const cookieAttribution = await getAttributionFromCookies();
-  if (cookieAttribution) return cookieAttribution;
+  try {
+    const cookieAttribution = await getAttributionFromCookies();
+    if (cookieAttribution) return cookieAttribution;
 
-  return getAttributionFromUTMs();
+    return getAttributionFromUTMs();
+  } catch (error) {
+    console.error('[telemetry] Error detecting attribution:', error);
+    return {};
+  }
 }

--- a/src/background/telemetry/index.js
+++ b/src/background/telemetry/index.js
@@ -48,28 +48,24 @@ const setup = asyncSetup('telemetry', [
 ]);
 
 let enabled = false;
-OptionsObserver.addListener(async function telemetry({ terms, feedback }) {
+OptionsObserver.addListener(async function telemetry({ terms, feedback }, lastOptions) {
+  // Update enabled state on every change
   enabled = terms && feedback;
+
+  // Skip the rest of the logic for sequential runs after the first one
+  // as the `terms` option can only by enabled once
+  if (lastOptions && lastOptions.terms) return;
 
   if (terms) {
     setup.pending && (await setup.pending);
 
     if (runner.isJustInstalled()) {
-      try {
-        const attribution = await detectAttribution();
-        runner.storage.utm_source = attribution.utm_source || '';
-        runner.storage.utm_campaign = attribution.utm_campaign || '';
-        await saveStorage(runner.storage);
-      } catch (error) {
-        console.error('[telemetry] Error detecting attribution:', error);
-      }
-
+      await runner.setUTMs(await detectAttribution());
       runner.ping('install');
     }
 
-    if (feedback) runner.ping('active');
-
     runner.setUninstallUrl();
+    if (feedback) runner.ping('active');
   } else {
     chrome.runtime.setUninstallURL('https://mygho.st/fresh-uninstalls');
   }

--- a/src/background/telemetry/metrics.js
+++ b/src/background/telemetry/metrics.js
@@ -121,6 +121,12 @@ export default class Metrics {
     return !this.storage.install_all;
   }
 
+  async setUTMs({ utm_source = '', utm_campaign = '' }) {
+    this.storage.utm_source = utm_source;
+    this.storage.utm_campaign = utm_campaign;
+    await this.saveStorage(this.storage);
+  }
+
   /**
    * Prepare data and send telemetry pings.
    * @param {string} type    type of the telemetry ping

--- a/src/utils/engines.js
+++ b/src/utils/engines.js
@@ -200,7 +200,7 @@ export async function update(name, { force = false, cache = true } = {}) {
     const urlName = name === 'trackerdb' ? 'trackerdbMv3' : `dnr-${name}-v2`;
     const listURL = CDN_URL + `adblocker/configs/${urlName}/allowed-lists.json`;
 
-    console.info(`[engines] Updating engine "${name}"...`);
+    if (!force) console.info(`[engines] Updating engine "${name}"...`);
 
     const data = await fetch(listURL, {
       cache: cache ? 'default' : 'no-store',

--- a/src/utils/options-observer.js
+++ b/src/utils/options-observer.js
@@ -46,7 +46,7 @@ export function addListener(...args) {
       const value = getValue(options);
       const lastValue = getLastValue(lastOptions);
 
-      if (isOptionEqual(value, lastValue)) return;
+      if (property && isOptionEqual(value, lastValue)) return;
 
       try {
         console.debug(`[options] Executing "${fn.name || property}" observer`);


### PR DESCRIPTION
Fixes the options observer to skip per-listener deep equality checks on whole-options listeners, preventing redundant work on every options change. Moves attribution detection out of setup into the first-run options observer, so it runs in the correct context and benefits from the same guard. Also wraps attribution detection in try/catch and refactors ping/UTM logic for clarity.