### PR TITLE
CI: cancel duplicate test runs on new commits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When multiple dependency PRs are merged in quick succession, each merge triggers a separate CI run on `main`, causing redundant parallel runs. Similarly, pushing a new commit to an open PR while a previous run is still in progress wastes CI resources.

Adds a `concurrency` block to the test workflow that groups runs by workflow name and PR number (falling back to `github.ref` for branch pushes). Any in-progress run for the same PR or branch is automatically cancelled when a newer commit triggers a new run.