### PR TITLE
feat(telemetry): add segment users parameters

### DIFF
--- a/src/background/serp.js
+++ b/src/background/serp.js
@@ -16,6 +16,7 @@ import trackersPreviewCSS from '/content_scripts/trackers-preview.css?raw';
 import Options, { isGloballyPaused } from '/store/options.js';
 import { getWTMStats } from '/utils/wtm-stats.js';
 import { parseWithCache } from '/utils/request.js';
+import { recordSerpVisit } from './telemetry/index.js';
 
 // Trackers preview messages
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
@@ -45,6 +46,8 @@ const SERP_URL_REGEXP =
 // SERP tracking prevention and trackers preview content scripts
 chrome.webNavigation.onCommitted.addListener(async (details) => {
   if (details.url.match(SERP_URL_REGEXP)) {
+    recordSerpVisit();
+
     const options = await store.resolve(Options);
 
     if (options.wtmSerpReport) {

--- a/src/background/telemetry/index.js
+++ b/src/background/telemetry/index.js
@@ -13,6 +13,7 @@ import { store } from 'hybrids';
 
 import Options from '/store/options.js';
 import Config from '/store/config.js';
+import DailyStats from '/store/daily-stats.js';
 import asyncSetup from '/utils/setup.js';
 import * as OptionsObserver from '/utils/options-observer.js';
 import { getStorage, saveStorage } from '/utils/telemetry.js';
@@ -36,12 +37,24 @@ const setup = asyncSetup('telemetry', [
       EXTENSION_VERSION: version,
       storage: metrics,
       saveStorage,
-      getConf: async () => ({
-        options: await store.resolve(Options),
-        config: await store.resolve(Config),
-        userSettings: __CHROMIUM__ ? await chrome.action?.getUserSettings?.() : undefined,
-        isAllowedIncognitoAccess: await chrome.extension.isAllowedIncognitoAccess(),
-      }),
+      getConf: async () => {
+        const yesterdayId = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+        const [options, config, dailyStats] = await Promise.all([
+          store.resolve(Options),
+          store.resolve(Config),
+          store.resolve(DailyStats, yesterdayId),
+        ]);
+
+        return {
+          options,
+          config,
+          // Use the previous full UTC day so the bucket doesn't depend on
+          // the time-of-day at which the ping fires.
+          yesterdayPages: dailyStats.pages,
+          userSettings: __CHROMIUM__ ? await chrome.action?.getUserSettings?.() : undefined,
+          isAllowedIncognitoAccess: await chrome.extension.isAllowedIncognitoAccess(),
+        };
+      },
       log: console.debug.bind(console, '[telemetry]'),
     });
   })(),
@@ -70,6 +83,13 @@ OptionsObserver.addListener(async function telemetry({ terms, feedback }, lastOp
     chrome.runtime.setUninstallURL('https://mygho.st/fresh-uninstalls');
   }
 });
+
+export async function recordSerpVisit() {
+  setup.pending && (await setup.pending);
+  if (!runner) return;
+
+  await runner.recordSerpVisit();
+}
 
 chrome.runtime.onMessage.addListener((msg) => {
   if (enabled && msg.action.startsWith('telemetry:')) {

--- a/src/background/telemetry/metrics.js
+++ b/src/background/telemetry/metrics.js
@@ -217,7 +217,11 @@ export default class Metrics {
       // Allowed Incognito Access
       buildQueryPair('aia', conf.isAllowedIncognitoAccess ? '1' : '0') +
       // Onboarding complete
-      buildQueryPair('oc', this.storage.install_complete_all ? '1' : '0');
+      buildQueryPair('oc', this.storage.install_complete_all ? '1' : '0') +
+      // Page views yesterday (0=none, 1=<10, 2=>=10)
+      buildQueryPair('pv', conf.yesterdayPages >= 10 ? '2' : conf.yesterdayPages > 0 ? '1' : '0') +
+      // SERP visits yesterday (0=none, 1=<10, 2=>=10)
+      buildQueryPair('se', this._getSearchSignal());
 
     if (type !== 'uninstall') {
       metrics_url +=
@@ -415,6 +419,47 @@ export default class Metrics {
     const engaged_daily_velocity = this.storage.engaged_daily_velocity || [];
     const today = Math.floor(Date.now() / 86400000);
     return engaged_daily_velocity.filter((el) => el > today - 7).length;
+  }
+
+  /**
+   * Get the SERP visit signal for the previous full UTC day.
+   * Using yesterday avoids bias from the time-of-day at which the
+   * ping fires, since today's counter is mid-aggregation.
+   * @private
+   * @return {string} '0' = no visits, '1' = less than 10, '2' = 10 or more
+   */
+  _getSearchSignal() {
+    const yesterday = Math.floor(Date.now() / 86400000) - 1;
+    let count = 0;
+
+    if (this.storage.serpCountPrevDay === yesterday) {
+      count = this.storage.serpCountPrev || 0;
+    } else if (this.storage.serpCountDay === yesterday) {
+      // No SERP visit happened today yet, so yesterday's total is still
+      // sitting in the current-day counter.
+      count = this.storage.serpCount || 0;
+    }
+
+    return count >= 10 ? '2' : count > 0 ? '1' : '0';
+  }
+
+  /**
+   * Count a SERP visit for today. Rolls the current day's counter
+   * into `serpCountPrev` when the UTC day changes.
+   */
+  async recordSerpVisit() {
+    const today = Math.floor(Date.now() / 86400000);
+
+    if (this.storage.serpCountDay !== today) {
+      this.storage.serpCountPrev = this.storage.serpCount || 0;
+      this.storage.serpCountPrevDay = this.storage.serpCountDay;
+      this.storage.serpCountDay = today;
+      this.storage.serpCount = 1;
+    } else {
+      this.storage.serpCount = (this.storage.serpCount || 0) + 1;
+    }
+
+    await this.saveStorage(this.storage);
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/ghostery/journal/issues/553.

Two new query parameters are added to telemetry pings: `pv` (page views) and `se` (SERP visits), each encoded as `0` (none), `1` (fewer than 10), or `2` (10 or more) for the previous day. 

Page view counts are sourced from the existing `DailyStats` store, while SERP visit counts are tracked in telemetry storage via a new `recordSerpVisit()` method on the `Metrics` class, called from `serp.js` on every SERP page navigation.