### PR TITLE
chore(release): automate PR creation in release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -39,5 +39,19 @@ buildVersion=$(cat ./xcode/Ghostery.xcodeproj/project.pbxproj | sed -n -e 's/^.*
 git add .
 git commit -m "Release v$version-$buildVersion"
 
+# Push the release branch
+git push -u origin release --force
+
+# Build PR description from commits since the last version tag (excluding this branch's commit)
+lastTag=$(git describe --tags --abbrev=0 --match "v*" origin/main)
+prBody=$(git log --oneline "$lastTag"..origin/main)
+
+# Create or update the PR
+if gh pr view release >/dev/null 2>&1; then
+  gh pr edit release --title "Release v$version" --body "$prBody"
+else
+  gh pr create --base main --head release --title "Release v$version" --body "$prBody"
+fi
+
 # Open Xcode
 xed xcode


### PR DESCRIPTION
The release script previously required manually creating or updating the release PR after running, adding friction to the release process.

This change extends `scripts/release.sh` to automatically push the release branch with `--force` and then create or update the GitHub PR using the `gh` CLI. It builds the PR body from the commit log since the last version tag on `main`, and uses `gh pr view` to decide whether to call `gh pr create` or `gh pr edit`, ensuring the script is idempotent when run multiple times.