### PR TITLE
fix(release): use gh pr list to find existing release PR

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -47,8 +47,9 @@ lastTag=$(git describe --tags --abbrev=0 --match "v*" origin/main)
 prBody=$(git log --oneline "$lastTag"..origin/main)
 
 # Create or update the PR
-if gh pr view release >/dev/null 2>&1; then
-  gh pr edit release --title "Release v$version" --body "$prBody"
+prNumber=$(gh pr list --head release --state open --json number --jq '.[0].number')
+if [ -n "$prNumber" ]; then
+  gh pr edit "$prNumber" --title "Release v$version" --body "$prBody"
 else
   gh pr create --base main --head release --title "Release v$version" --body "$prBody"
 fi


### PR DESCRIPTION
The original PR create/update logic used `gh pr view release` to detect an existing PR, but this command looks up by branch name as a positional argument which is unreliable and can fail when the PR already exists under a different state or reference.

The fix replaces this check with `gh pr list --head release --state open --json number --jq '.[0].number'`, which explicitly queries open PRs for the `release` head branch and extracts the PR number. The `gh pr edit` call then targets that number directly, making the detection robust and consistent across repeated release runs.