### PR TITLE
feat(context-menu): add context menu with pause, resume, and zap mode actions

### DIFF
--- a/src/background/context-menu.js
+++ b/src/background/context-menu.js
@@ -11,7 +11,7 @@
 
 import { store, msg } from 'hybrids';
 
-import Options from '/store/options.js';
+import Options, { MODE_ZAP } from '/store/options.js';
 import * as OptionsObserver from '/utils/options-observer.js';
 import { tabStats } from './stats.js';
 import { openElementPicker } from './element-picker.js';
@@ -20,6 +20,9 @@ const SETTINGS_URL = chrome.runtime.getURL('/pages/settings/index.html');
 
 const ID_PARENT = 'ghostery';
 const ID_PAUSE = 'ghostery:pause';
+const ID_RESUME = 'ghostery:resume';
+const ID_ZAP_ENABLE = 'ghostery:zap-enable';
+const ID_ZAP_DISABLE = 'ghostery:zap-disable';
 const ID_PAUSE_HOUR = 'ghostery:pause-hour';
 const ID_PAUSE_DAY = 'ghostery:pause-day';
 const ID_PAUSE_ALWAYS = 'ghostery:pause-always';
@@ -69,6 +72,33 @@ chrome.runtime.onInstalled.addListener(() => {
     });
 
     chrome.contextMenus.create({
+      id: ID_RESUME,
+      parentId: ID_PARENT,
+      title: msg`Resume`,
+      contexts: ['all'],
+      documentUrlPatterns: ['http://*/*', 'https://*/*'],
+      visible: false,
+    });
+
+    chrome.contextMenus.create({
+      id: ID_ZAP_ENABLE,
+      parentId: ID_PARENT,
+      title: msg`Block ads`,
+      contexts: ['all'],
+      documentUrlPatterns: ['http://*/*', 'https://*/*'],
+      visible: false,
+    });
+
+    chrome.contextMenus.create({
+      id: ID_ZAP_DISABLE,
+      parentId: ID_PARENT,
+      title: msg`Show ads`,
+      contexts: ['all'],
+      documentUrlPatterns: ['http://*/*', 'https://*/*'],
+      visible: false,
+    });
+
+    chrome.contextMenus.create({
       id: ID_SEPARATOR,
       parentId: ID_PARENT,
       type: 'separator',
@@ -95,6 +125,39 @@ chrome.runtime.onInstalled.addListener(() => {
     console.debug('[context-menu] Context menu created...');
   });
 });
+
+async function resumeSite(tab) {
+  const hostname = tabStats.get(tab.id)?.hostname;
+  if (!hostname) return;
+
+  const options = await store.resolve(Options);
+  await store.set(options, { paused: { [hostname]: null } });
+  await chrome.tabs.reload(tab.id);
+
+  console.debug(`[context-menu] Resumed ${hostname}`);
+}
+
+async function zapSite(tab) {
+  const hostname = tabStats.get(tab.id)?.hostname;
+  if (!hostname) return;
+
+  const options = await store.resolve(Options);
+  await store.set(options, { zapped: { [hostname]: true } });
+  await chrome.tabs.reload(tab.id);
+
+  console.debug(`[context-menu] Zapped ${hostname}`);
+}
+
+async function unzapSite(tab) {
+  const hostname = tabStats.get(tab.id)?.hostname;
+  if (!hostname) return;
+
+  const options = await store.resolve(Options);
+  await store.set(options, { zapped: { [hostname]: null } });
+  await chrome.tabs.reload(tab.id);
+
+  console.debug(`[context-menu] Unzapped ${hostname}`);
+}
 
 async function pauseSite(tab, id) {
   const hostname = tabStats.get(tab.id)?.hostname;
@@ -138,6 +201,15 @@ async function openSettings() {
 
 chrome.contextMenus.onClicked.addListener((info, tab) => {
   switch (info.menuItemId) {
+    case ID_RESUME:
+      resumeSite(tab).catch(console.error);
+      break;
+    case ID_ZAP_ENABLE:
+      zapSite(tab).catch(console.error);
+      break;
+    case ID_ZAP_DISABLE:
+      unzapSite(tab).catch(console.error);
+      break;
     case ID_PAUSE_HOUR:
     case ID_PAUSE_DAY:
     case ID_PAUSE_ALWAYS:
@@ -149,6 +221,45 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
     case ID_SETTINGS:
       openSettings().catch(console.error);
       break;
+  }
+});
+
+async function updateVisibility(tabId) {
+  if (tabId === undefined) return;
+
+  const hostname = tabStats.get(tabId)?.hostname;
+  const options = await store.resolve(Options);
+  const isZapMode = options.mode === MODE_ZAP;
+
+  let isPaused = false;
+  let isZapped = false;
+
+  if (hostname) {
+    if (isZapMode) {
+      isZapped = !!options.zapped?.[hostname];
+    } else {
+      const entry = options.paused?.[hostname];
+      isPaused = !!entry && (entry.revokeAt === 0 || entry.revokeAt > Date.now());
+    }
+  }
+
+  chrome.contextMenus.update(ID_PAUSE, { visible: !isZapMode && !isPaused }).catch(console.error);
+  chrome.contextMenus.update(ID_RESUME, { visible: !isZapMode && isPaused }).catch(console.error);
+  chrome.contextMenus
+    .update(ID_ZAP_ENABLE, { visible: isZapMode && !isZapped })
+    .catch(console.error);
+  chrome.contextMenus
+    .update(ID_ZAP_DISABLE, { visible: isZapMode && isZapped })
+    .catch(console.error);
+}
+
+chrome.tabs.onActivated.addListener(({ tabId }) => {
+  updateVisibility(tabId).catch(console.error);
+});
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+  if (changeInfo.status === 'complete') {
+    updateVisibility(tabId).catch(console.error);
   }
 });
 

--- a/src/background/context-menu.js
+++ b/src/background/context-menu.js
@@ -1,0 +1,152 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { store, msg } from 'hybrids';
+
+import Options from '/store/options.js';
+import * as OptionsObserver from '/utils/options-observer.js';
+import { tabStats } from './stats.js';
+import { openElementPicker } from './element-picker.js';
+
+const SETTINGS_URL = chrome.runtime.getURL('/pages/settings/index.html');
+
+const ID_PARENT = 'ghostery';
+const ID_PAUSE = 'ghostery:pause';
+const ID_PAUSE_HOUR = 'ghostery:pause-hour';
+const ID_PAUSE_DAY = 'ghostery:pause-day';
+const ID_PAUSE_ALWAYS = 'ghostery:pause-always';
+const ID_ELEMENT_PICKER = 'ghostery:element-picker';
+const ID_SEPARATOR = 'ghostery:separator';
+const ID_SETTINGS = 'ghostery:settings';
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.removeAll(() => {
+    chrome.contextMenus.create({
+      id: ID_PARENT,
+      title: msg`Ghostery`,
+      contexts: ['all'],
+      documentUrlPatterns: ['http://*/*', 'https://*/*'],
+    });
+
+    chrome.contextMenus.create({
+      id: ID_PAUSE,
+      parentId: ID_PARENT,
+      title: msg`Pause on this site`,
+      contexts: ['all'],
+      documentUrlPatterns: ['http://*/*', 'https://*/*'],
+    });
+
+    chrome.contextMenus.create({
+      id: ID_PAUSE_HOUR,
+      parentId: ID_PAUSE,
+      title: msg`1 hour`,
+      contexts: ['all'],
+      documentUrlPatterns: ['http://*/*', 'https://*/*'],
+    });
+
+    chrome.contextMenus.create({
+      id: ID_PAUSE_DAY,
+      parentId: ID_PAUSE,
+      title: msg`1 day`,
+      contexts: ['all'],
+      documentUrlPatterns: ['http://*/*', 'https://*/*'],
+    });
+
+    chrome.contextMenus.create({
+      id: ID_PAUSE_ALWAYS,
+      parentId: ID_PAUSE,
+      title: msg`Always`,
+      contexts: ['all'],
+      documentUrlPatterns: ['http://*/*', 'https://*/*'],
+    });
+
+    chrome.contextMenus.create({
+      id: ID_SEPARATOR,
+      parentId: ID_PARENT,
+      type: 'separator',
+      contexts: ['all'],
+      documentUrlPatterns: ['http://*/*', 'https://*/*'],
+    });
+
+    chrome.contextMenus.create({
+      id: ID_ELEMENT_PICKER,
+      parentId: ID_PARENT,
+      title: `${msg`Hide content block`}...`,
+      contexts: ['all'],
+      documentUrlPatterns: ['http://*/*', 'https://*/*'],
+    });
+
+    chrome.contextMenus.create({
+      id: ID_SETTINGS,
+      parentId: ID_PARENT,
+      title: `${msg`Open settings`}...`,
+      contexts: ['all'],
+      documentUrlPatterns: ['http://*/*', 'https://*/*'],
+    });
+
+    console.debug('[context-menu] Context menu created...');
+  });
+});
+
+async function pauseSite(tab, id) {
+  const hostname = tabStats.get(tab.id)?.hostname;
+  if (!hostname) return;
+
+  const options = await store.resolve(Options);
+
+  let revokeAt;
+  if (id === ID_PAUSE_HOUR) {
+    revokeAt = Date.now() + 60 * 60 * 1000;
+  } else if (id === ID_PAUSE_DAY) {
+    revokeAt = Date.now() + 24 * 60 * 60 * 1000;
+  } else if (id === ID_PAUSE_ALWAYS) {
+    revokeAt = 0;
+  } else {
+    throw new Error('[context-menu] Unknown pause duration');
+  }
+
+  await store.set(options, { paused: { [hostname]: { revokeAt } } });
+  await chrome.tabs.reload(tab.id);
+
+  console.debug(`[context-menu] Paused ${hostname} until ${new Date(revokeAt).toLocaleString()}`);
+}
+
+async function openSettings() {
+  const tabs = await chrome.tabs.query({
+    url: SETTINGS_URL,
+    currentWindow: true,
+  });
+
+  if (tabs.length) {
+    await chrome.tabs.update(tabs[0].id, { active: true });
+  } else {
+    await chrome.tabs.create({ url: SETTINGS_URL });
+  }
+
+  console.debug('[context-menu] Opened settings page...');
+}
+
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+  switch (info.menuItemId) {
+    case ID_PAUSE_HOUR:
+    case ID_PAUSE_DAY:
+    case ID_PAUSE_ALWAYS:
+      return pauseSite(tab, info.menuItemId);
+    case ID_ELEMENT_PICKER:
+      return openElementPicker(tab.id);
+    case ID_SETTINGS:
+      return openSettings();
+  }
+});
+
+OptionsObserver.addListener('terms', (terms) => {
+  chrome.contextMenus.update(ID_PARENT, { enabled: terms });
+});

--- a/src/background/context-menu.js
+++ b/src/background/context-menu.js
@@ -29,6 +29,7 @@ const ID_PAUSE_ALWAYS = 'ghostery:pause-always';
 const ID_ELEMENT_PICKER = 'ghostery:element-picker';
 const ID_SEPARATOR = 'ghostery:separator';
 const ID_SETTINGS = 'ghostery:settings';
+const ID_WEBSITE_SETTINGS = 'ghostery:website-settings';
 
 chrome.runtime.onInstalled.addListener(() => {
   chrome.contextMenus.removeAll(() => {
@@ -99,7 +100,7 @@ chrome.runtime.onInstalled.addListener(() => {
     });
 
     chrome.contextMenus.create({
-      id: ID_SEPARATOR,
+      id: `${ID_SEPARATOR}-1`,
       parentId: ID_PARENT,
       type: 'separator',
       contexts: ['all'],
@@ -115,13 +116,28 @@ chrome.runtime.onInstalled.addListener(() => {
     });
 
     chrome.contextMenus.create({
+      id: ID_WEBSITE_SETTINGS,
+      parentId: ID_PARENT,
+      title: `${msg`Open website settings`}...`,
+      contexts: ['all'],
+      documentUrlPatterns: ['http://*/*', 'https://*/*'],
+    });
+
+    chrome.contextMenus.create({
+      id: `${ID_SEPARATOR}-2`,
+      parentId: ID_PARENT,
+      type: 'separator',
+      contexts: ['all'],
+      documentUrlPatterns: ['http://*/*', 'https://*/*'],
+    });
+
+    chrome.contextMenus.create({
       id: ID_SETTINGS,
       parentId: ID_PARENT,
       title: `${msg`Open settings`}...`,
       contexts: ['all'],
       documentUrlPatterns: ['http://*/*', 'https://*/*'],
     });
-
     console.debug('[context-menu] Context menu created...');
   });
 });
@@ -199,6 +215,15 @@ async function openSettings() {
   console.debug('[context-menu] Opened settings page...');
 }
 
+async function openWebsiteSettings(tab) {
+  const hostname = tabStats.get(tab.id)?.hostname;
+  const url = SETTINGS_URL + '#@settings-website-details?domain=' + (hostname || '');
+
+  await chrome.tabs.create({ url });
+
+  console.debug(`[context-menu] Opened website settings for ${hostname}...`);
+}
+
 chrome.contextMenus.onClicked.addListener((info, tab) => {
   switch (info.menuItemId) {
     case ID_RESUME:
@@ -220,6 +245,9 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
       break;
     case ID_SETTINGS:
       openSettings().catch(console.error);
+      break;
+    case ID_WEBSITE_SETTINGS:
+      openWebsiteSettings(tab).catch(console.error);
       break;
   }
 });

--- a/src/background/context-menu.js
+++ b/src/background/context-menu.js
@@ -116,7 +116,9 @@ async function pauseSite(tab, id) {
   await store.set(options, { paused: { [hostname]: { revokeAt } } });
   await chrome.tabs.reload(tab.id);
 
-  console.debug(`[context-menu] Paused ${hostname} until ${new Date(revokeAt).toLocaleString()}`);
+  console.debug(
+    `[context-menu] Paused ${hostname} until ${revokeAt ? new Date(revokeAt).toLocaleString() : 'always'}`,
+  );
 }
 
 async function openSettings() {
@@ -139,14 +141,17 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
     case ID_PAUSE_HOUR:
     case ID_PAUSE_DAY:
     case ID_PAUSE_ALWAYS:
-      return pauseSite(tab, info.menuItemId);
+      pauseSite(tab, info.menuItemId).catch(console.error);
+      break;
     case ID_ELEMENT_PICKER:
-      return openElementPicker(tab.id);
+      openElementPicker(tab.id).catch(console.error);
+      break;
     case ID_SETTINGS:
-      return openSettings();
+      openSettings().catch(console.error);
+      break;
   }
 });
 
 OptionsObserver.addListener('terms', (terms) => {
-  chrome.contextMenus.update(ID_PARENT, { enabled: terms });
+  chrome.contextMenus.update(ID_PARENT, { enabled: terms }).catch(console.error);
 });

--- a/src/background/context-menu.js
+++ b/src/background/context-menu.js
@@ -251,6 +251,9 @@ async function updateVisibility(tabId) {
   chrome.contextMenus
     .update(ID_ZAP_DISABLE, { visible: isZapMode && isZapped })
     .catch(console.error);
+  chrome.contextMenus
+    .update(ID_ELEMENT_PICKER, { enabled: !isPaused && !isZapped })
+    .catch(console.error);
 }
 
 chrome.tabs.onActivated.addListener(({ tabId }) => {

--- a/src/background/element-picker.js
+++ b/src/background/element-picker.js
@@ -17,6 +17,15 @@ import ElementPickerSelectors from '/store/element-picker-selectors.js';
 
 import { setup, reloadMainEngine } from './adblocker/engines.js';
 
+export async function openElementPicker(tabId) {
+  await chrome.scripting.executeScript({
+    injectImmediately: true,
+    world: chrome.scripting.ExecutionWorld?.ISOLATED ?? 'ISOLATED',
+    target: { tabId },
+    files: ['/content_scripts/element-picker.js'],
+  });
+}
+
 // Observe element picker selectors to update the adblocker engine
 store.observe(ElementPickerSelectors, async (_, model, lastModel) => {
   let entries = Object.entries(model.hostnames);

--- a/src/background/helpers.js
+++ b/src/background/helpers.js
@@ -16,6 +16,7 @@ import Config from '/store/config.js';
 import * as OptionsObserver from '/utils/options-observer.js';
 import { hasWTMStats } from '/utils/wtm-stats';
 import { updateEngines } from './adblocker/engines.js';
+import { openElementPicker } from './element-picker.js';
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   switch (msg.action) {
@@ -44,21 +45,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       break;
 
     case 'openElementPicker':
-      chrome.scripting.executeScript(
-        {
-          injectImmediately: true,
-          world: chrome.scripting.ExecutionWorld?.ISOLATED ?? 'ISOLATED',
-          target: {
-            tabId: msg.tabId,
-          },
-          files: ['/content_scripts/element-picker.js'],
-        },
-        () => {
-          if (chrome.runtime.lastError) {
-            console.error(chrome.runtime.lastError);
-          }
-        },
-      );
+      openElementPicker(msg.tabId).catch(console.error);
       break;
 
     case 'updateEngines':

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -9,6 +9,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
+import '/ui/localize.js';
+
 import './onboarding.js';
 import './config.js';
 
@@ -20,6 +22,7 @@ import './element-picker.js';
 import './dnr.js';
 import './redirect-protection.js';
 import './exceptions.js';
+import './context-menu.js';
 import './paused.js';
 import './zapped.js';
 import './stats.js';

--- a/src/manifest.chromium.json
+++ b/src/manifest.chromium.json
@@ -7,6 +7,7 @@
   "description": "__MSG_manifest_short_description__",
   "permissions": [
     "alarms",
+    "contextMenus",
     "cookies",
     "declarativeNetRequest",
     "declarativeNetRequestFeedback",

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -7,6 +7,7 @@
   "description": "__MSG_manifest_short_description__",
   "permissions": [
     "alarms",
+    "contextMenus",
     "cookies",
     "storage",
     "scripting",

--- a/src/ui/localize.js
+++ b/src/ui/localize.js
@@ -10,8 +10,10 @@
  */
 import { localize } from 'hybrids';
 
-// Set the document language attribute based on the browser's UI language
-document.documentElement.setAttribute('lang', chrome.i18n.getUILanguage());
-
 // Localize wrapper for chrome.i18n
 localize(chrome.i18n.getMessage.bind(chrome.i18n), { format: 'chrome.i18n' });
+
+// Set the document language attribute based on the browser's UI language
+if (typeof document !== 'undefined') {
+  document.documentElement.setAttribute('lang', chrome.i18n.getUILanguage());
+}


### PR DESCRIPTION
The extension lacked any browser context menu integration, requiring users to open the panel to pause a site or access settings — adding unnecessary friction for common actions.

This PR adds a "Ghostery" entry to the browser context menu (visible on http/https pages) with the following actions:

**Pause on this site** (submenu, shown in default mode when site is not paused):
- 1 hour
- 1 day
- Always

**Resume** (shown in default mode when site is already paused — replaces "Pause on this site")

**Block ads** (shown in zap mode when site is not zapped)

**Show ads** (shown in zap mode when site is zapped)

**Other actions:**
- Hide content block... — opens the element picker
- Open settings... — focuses or opens the settings tab

Additional details:
- Pause/Resume and Block/Show ads visibility updates on tab activation and page load
- The entire menu is disabled until the user accepts the terms
- `contextMenus` permission added to both Chromium and Firefox manifests
- `openElementPicker` logic extracted from `helpers.js` into `background/element-picker.js` for reuse
- `ui/localize.js` imported in the background process so `msg` template tags resolve correctly

> **Note:** The browser's context menu API does not expose which element was right-clicked, so "Hide content block" opens the element picker without a pre-selected element. Other extensions with similar functionality use the same approach.

Dedault mode:
<img width="614" height="274" alt="Zrzut ekranu 2026-05-11 o 16 06 10" src="https://github.com/user-attachments/assets/68a20f95-c977-4e3d-89b6-c81b4a7e6fda" />
<img width="445" height="141" alt="Zrzut ekranu 2026-05-12 o 15 16 27" src="https://github.com/user-attachments/assets/754982fe-d4e3-4206-966e-2ba50aa84eb2" />

Zap mode:
<img width="436" height="152" alt="Zrzut ekranu 2026-05-12 o 15 16 53" src="https://github.com/user-attachments/assets/48d0ecde-c1ad-4b13-b09e-c8085e1bbd74" />
<img width="440" height="156" alt="Zrzut ekranu 2026-05-12 o 15 17 01" src="https://github.com/user-attachments/assets/e726d865-5457-42d9-8664-5463ec608d1f" />
