### PR TITLE
ci(release): build and upload Safari extension zip

### DIFF
--- a/.github/workflows/release-v3.yml
+++ b/.github/workflows/release-v3.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Build packages
         run: npm run package -- --simple
 
+      - name: Build Safari package
+        run: |
+          sh scripts/patch-safari.sh
+          (cd dist && zip -rq ../web-ext-artifacts/ghostery-safari.zip .)
+
       - name: Upload Firefox build
         uses: actions/upload-release-asset@v1
         env:
@@ -48,6 +53,16 @@ jobs:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: web-ext-artifacts/ghostery-chromium.zip
           asset_name: ghostery-chromium-${{ env.VERSION }}.zip
+          asset_content_type: application/gzip
+
+      - name: Upload Safari build
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: web-ext-artifacts/ghostery-safari.zip
+          asset_name: ghostery-safari-${{ env.VERSION }}.zip
           asset_content_type: application/gzip
 
       - name: Download source code archives

--- a/scripts/patch-safari.sh
+++ b/scripts/patch-safari.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-# verify dist/ is a Chromium MV3 build before patching
 node -e '
 const fs = require("fs");
 const p = "dist/manifest.json";
@@ -17,10 +16,8 @@ if (m.manifest_version !== 3) {
 }
 '
 
-# strip DNR rules that WebKit's URL filter parser cannot compile
 node scripts/filter-invalid-dnr-rules.js
 
-# rewrite manifest background.service_worker into background.scripts/persistent
 node -e '
 const fs = require("fs");
 const p = "dist/manifest.json";

--- a/scripts/patch-safari.sh
+++ b/scripts/patch-safari.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -e
+
+# verify dist/ is a Chromium MV3 build before patching
+node -e '
+const fs = require("fs");
+const p = "dist/manifest.json";
+if (!fs.existsSync(p)) {
+  console.error("patch-safari: " + p + " not found - run: npm run build -- chromium");
+  process.exit(1);
+}
+const m = JSON.parse(fs.readFileSync(p, "utf8"));
+if (m.manifest_version !== 3) {
+  console.error("patch-safari: expected manifest_version 3, got " + m.manifest_version);
+  process.exit(1);
+}
+'
+
+# strip DNR rules that WebKit's URL filter parser cannot compile
+node scripts/filter-invalid-dnr-rules.js
+
+# rewrite manifest background.service_worker into background.scripts/persistent
+node -e '
+const fs = require("fs");
+const p = "dist/manifest.json";
+const m = JSON.parse(fs.readFileSync(p, "utf8"));
+if (m.background && m.background.service_worker) {
+  m.background = { scripts: [m.background.service_worker], type: "module", persistent: false };
+  fs.writeFileSync(p, JSON.stringify(m, null, 2));
+  console.log("Patched manifest: background.service_worker -> background.scripts");
+}
+'

--- a/xcode/ci_scripts/build.sh
+++ b/xcode/ci_scripts/build.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-# go to the repo root (xcode/ci_scripts -> repo root)
 cd "$(dirname "$0")/../.."
 
 # Xcode runs build phases in a clean non-login shell, so recreate the toolchain PATH.
@@ -12,8 +11,6 @@ command -v npm >/dev/null 2>&1 || {
   exit 127
 }
 
-# run build script
 npm run build -- --clean
 
-# apply Safari-specific patches to dist/
 sh scripts/patch-safari.sh

--- a/xcode/ci_scripts/build.sh
+++ b/xcode/ci_scripts/build.sh
@@ -15,17 +15,5 @@ command -v npm >/dev/null 2>&1 || {
 # run build script
 npm run build -- --clean
 
-# strip DNR rules that WebKit's URL filter parser cannot compile
-node scripts/filter-invalid-dnr-rules.js
-
-# rewrite manifest background.service_worker into background.scripts/persistent
-node -e '
-const fs = require("fs");
-const p = "dist/manifest.json";
-const m = JSON.parse(fs.readFileSync(p, "utf8"));
-if (m.background && m.background.service_worker) {
-  m.background = { scripts: [m.background.service_worker], type: "module", persistent: false };
-  fs.writeFileSync(p, JSON.stringify(m, null, 2));
-  console.log("Patched manifest: background.service_worker -> background.scripts");
-}
-'
+# apply Safari-specific patches to dist/
+sh scripts/patch-safari.sh


### PR DESCRIPTION
Adds a Safari MV3 zip (`ghostery-safari-<version>.zip`) to every release alongside Firefox and Chromium. Extracts the Safari post-build patches from `xcode/ci_scripts/build.sh` into `scripts/patch-safari.sh` so the Xcode build and the release workflow share one implementation.
