### PR TITLE
fix(context-menu): do not translate Ghostery brand name in parent menu title

### DIFF
--- a/src/background/context-menu.js
+++ b/src/background/context-menu.js
@@ -35,7 +35,7 @@ chrome.runtime.onInstalled.addListener(() => {
   chrome.contextMenus.removeAll(() => {
     chrome.contextMenus.create({
       id: ID_PARENT,
-      title: msg`Ghostery`,
+      title: 'Ghostery',
       contexts: ['all'],
       documentUrlPatterns: ['http://*/*', 'https://*/*'],
     });


### PR DESCRIPTION
The parent context menu item used the `msg` tagged template for the title "Ghostery", which incorrectly marked the brand name as a translatable string. Brand names should remain consistent across locales and not be exposed to translators.

Replaces the `msg\`Ghostery\`` tagged template with the plain string literal `'Ghostery'` for the parent context menu title in `src/background/context-menu.js`. All other localized strings in the file are preserved.