### PR TITLE
chore(release): add 'package' label and AdamGhst reviewer to PR creation

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -51,7 +51,7 @@ prNumber=$(gh pr list --head release --state open --json number --jq '.[0].numbe
 if [ -n "$prNumber" ]; then
   gh pr edit "$prNumber" --title "Release v$version" --body "$prBody"
 else
-  gh pr create --base main --head release --title "Release v$version" --body "$prBody"
+  gh pr create --base main --head release --title "Release v$version" --body "$prBody" --label "package" --reviewer "AdamGhst"
 fi
 
 # Open Xcode


### PR DESCRIPTION
## What changed
The `release.sh` script now passes `--label "package"` and `--reviewer "AdamGhst"` when creating the release PR via `gh pr create`.

## Why
Ensures the release PR is consistently labelled as `package` and has AdamGhst set as the sole reviewer, without requiring manual steps after running the script.