### PR TITLE
fix(utils/tabs): unify open tab logic

### DIFF
--- a/src/background/context-menu.js
+++ b/src/background/context-menu.js
@@ -13,6 +13,7 @@ import { store, msg } from 'hybrids';
 
 import Options, { MODE_ZAP } from '/store/options.js';
 import * as OptionsObserver from '/utils/options-observer.js';
+import { openTabWithUrl } from '/utils/tabs.js';
 import { tabStats } from './stats.js';
 import { openElementPicker } from './element-picker.js';
 
@@ -201,17 +202,7 @@ async function pauseSite(tab, id) {
 }
 
 async function openSettings() {
-  const tabs = await chrome.tabs.query({
-    url: SETTINGS_URL,
-    currentWindow: true,
-  });
-
-  if (tabs.length) {
-    await chrome.tabs.update(tabs[0].id, { active: true });
-  } else {
-    await chrome.tabs.create({ url: SETTINGS_URL });
-  }
-
+  await openTabWithUrl(SETTINGS_URL + '#@settings-privacy');
   console.debug('[context-menu] Opened settings page...');
 }
 
@@ -219,7 +210,7 @@ async function openWebsiteSettings(tab) {
   const hostname = tabStats.get(tab.id)?.hostname;
   const url = SETTINGS_URL + '#@settings-website-details?domain=' + (hostname || '');
 
-  await chrome.tabs.create({ url });
+  await openTabWithUrl(url);
 
   console.debug(`[context-menu] Opened website settings for ${hostname}...`);
 }

--- a/src/pages/panel/components/feedback-button.js
+++ b/src/pages/panel/components/feedback-button.js
@@ -11,7 +11,7 @@
 
 import { html } from 'hybrids';
 
-import { openTabWithUrl } from '/utils/tabs.js';
+import { openHref } from '/utils/tabs.js';
 
 export default {
   type: { value: '', reflect: true },
@@ -24,7 +24,7 @@ export default {
       <ui-button inert="${!href}" layout="grow">
         <a
           href="${href}"
-          onclick="${external && openTabWithUrl}"
+          onclick="${external && openHref}"
           layout="column center padding:0.5 gap:0"
         >
           <div layout="row items:center gap:0.5 height:22px">

--- a/src/pages/panel/components/menu-item.js
+++ b/src/pages/panel/components/menu-item.js
@@ -11,7 +11,7 @@
 
 import { html } from 'hybrids';
 
-import { openTabWithUrl } from '/utils/tabs.js';
+import { openHref } from '/utils/tabs.js';
 
 export default {
   href: '',
@@ -24,7 +24,7 @@ export default {
         <a
           href="${href}"
           layout="grid:max|1|max items:center:start gap:1.5 padding margin:0:1"
-          onclick="${internal ? undefined : openTabWithUrl}"
+          onclick="${internal ? undefined : openHref}"
         >
           <ui-icon name="${icon}" color="secondary" layout="size:2.5"></ui-icon>
           <ui-text type="label-m" ellipsis layout="column width::0:full" color="inherit">

--- a/src/pages/panel/components/notification.js
+++ b/src/pages/panel/components/notification.js
@@ -11,7 +11,7 @@
 
 import { html, store } from 'hybrids';
 
-import { openTabWithUrl } from '/utils/tabs.js';
+import { openHref } from '/utils/tabs.js';
 
 import Notification from '../store/notification.js';
 
@@ -26,7 +26,7 @@ export default {
       <ui-action>
         <a
           href="${notification.url}"
-          onclick="${openTabWithUrl}"
+          onclick="${openHref}"
           layout="row gap:2 items:stretch padding:1.5"
         >
           ${(notification.icon || notification.img) &&

--- a/src/pages/panel/views/main.js
+++ b/src/pages/panel/views/main.js
@@ -11,7 +11,7 @@
 
 import { html, store, router, msg } from 'hybrids';
 
-import { getCurrentTab, openTabWithUrl } from '/utils/tabs.js';
+import { getCurrentTab, openHref } from '/utils/tabs.js';
 
 import Options, {
   isGloballyPaused,
@@ -272,7 +272,7 @@ export default {
               </panel-actions-button>
               <panel-actions-button>
                 <a
-                  onclick="${openTabWithUrl}"
+                  onclick="${openHref}"
                   href="${chrome.runtime.getURL(
                     '/pages/settings/index.html#@settings-website-details?domain=' + stats.hostname,
                   )}"
@@ -290,7 +290,7 @@ export default {
         html`
           <div layout="::background:danger-primary">
             <ui-button type="danger" layout="height:6 margin:1.5" data-qa="button:enable">
-              <a href="${ONBOARDING_URL}" layout="row center gap:0.5" onclick="${openTabWithUrl}">
+              <a href="${ONBOARDING_URL}" layout="row center gap:0.5" onclick="${openHref}">
                 <ui-icon name="play"></ui-icon>
                 Enable Ghostery
               </a>
@@ -529,7 +529,7 @@ export default {
               class="${{
                 last: managedConfig.disableUserControl || !store.ready(notification),
               }}"
-              onclick="${openTabWithUrl}"
+              onclick="${openHref}"
               layout="block margin:1.5:1.5:0.5"
               layout.last="margin:bottom:1.5"
             >

--- a/src/pages/panel/views/menu.js
+++ b/src/pages/panel/views/menu.js
@@ -14,7 +14,7 @@ import { html, router, store } from 'hybrids';
 import Options from '/store/options.js';
 import TabStats from '/store/tab-stats.js';
 
-import { openTabWithUrl } from '/utils/tabs.js';
+import { openHref } from '/utils/tabs.js';
 import { BECOME_A_CONTRIBUTOR_PAGE_URL } from '/utils/urls.js';
 
 import ReportCategory from './report-category.js';
@@ -75,7 +75,7 @@ export default {
             <ui-button type="outline-primary" layout="margin:1:1.5">
               <a
                 href="${BECOME_A_CONTRIBUTOR_PAGE_URL}?utm_source=gbe&utm_campaign=menu-becomeacontributor"
-                onclick="${openTabWithUrl}"
+                onclick="${openHref}"
               >
                 <ui-icon name="heart"></ui-icon>
                 Become a Contributor

--- a/src/pages/panel/views/pause-assistant.js
+++ b/src/pages/panel/views/pause-assistant.js
@@ -14,7 +14,7 @@ import { html, router, store } from 'hybrids';
 import TabStats from '/store/tab-stats.js';
 import Config from '/store/config.js';
 
-import { openTabWithUrl } from '/utils/tabs.js';
+import { openHref } from '/utils/tabs.js';
 import { PAUSE_ASSISTANT_LEARN_MORE_URL } from '/utils/urls.js';
 
 export default {
@@ -33,7 +33,7 @@ export default {
           ${issueUrl &&
           html`
             <ui-action>
-              <a href="${issueUrl}" onclick="${openTabWithUrl}" layout="row gap:2">
+              <a href="${issueUrl}" onclick="${openHref}" layout="row gap:2">
                 <ui-icon name="doc-m" color="tertiary" layout="size:3"></ui-icon>
                 <div layout="column grow gap:0.5">
                   <ui-text type="label-m">Broken page report</ui-text>
@@ -47,11 +47,7 @@ export default {
             </ui-action>
           `}
           <ui-action>
-            <a
-              href="${PAUSE_ASSISTANT_LEARN_MORE_URL}"
-              onclick="${openTabWithUrl}"
-              layout="row gap:2"
-            >
+            <a href="${PAUSE_ASSISTANT_LEARN_MORE_URL}" onclick="${openHref}" layout="row gap:2">
               <ui-icon name="info" color="tertiary" layout="size:3"></ui-icon>
               <div layout="column grow gap:0.5">
                 <ui-text type="label-m">How Browsing Assistant works</ui-text>

--- a/src/pages/panel/views/report-form.js
+++ b/src/pages/panel/views/report-form.js
@@ -11,7 +11,7 @@
 
 import { html, router, store, msg } from 'hybrids';
 
-import { getCurrentTab, openTabWithUrl } from '/utils/tabs.js';
+import { getCurrentTab, openHref } from '/utils/tabs.js';
 import { SUPPORT_PAGE_URL } from '/utils/urls.js';
 
 import ReportConfirm from './report-confirm.js';
@@ -158,7 +158,7 @@ export default {
               </ui-text>
               <ui-text type="body-s" color="secondary" underline>
                 ${msg.html`
-                  Please go to <a href="${SUPPORT_PAGE_URL}" onclick="${openTabWithUrl}">Ghostery Support</a>
+                  Please go to <a href="${SUPPORT_PAGE_URL}" onclick="${openHref}">Ghostery Support</a>
                 `}
               </ui-text>
             </panel-card>

--- a/src/pages/panel/views/tracker-details.js
+++ b/src/pages/panel/views/tracker-details.js
@@ -17,7 +17,7 @@ import TabStats from '/store/tab-stats.js';
 import ManagedConfig from '/store/managed-config.js';
 
 import * as exceptions from '/utils/exceptions.js';
-import { openTabWithUrl } from '/utils/tabs.js';
+import { openHref } from '/utils/tabs.js';
 
 import ProtectionStatus from './protection-status.js';
 
@@ -101,7 +101,7 @@ export default {
                   href="${chrome.runtime.getURL(
                     `/pages/settings/index.html#@settings-tracker-details?tracker=${tracker.id}`,
                   )}"
-                  onclick="${openTabWithUrl}"
+                  onclick="${openHref}"
                 >
                   <ui-icon name="settings-m" layout="size:2"></ui-icon>
                 </a>
@@ -119,7 +119,7 @@ export default {
             ${wtmUrl &&
             html`
               <ui-text type="label-xs" color="brand-primary" underline>
-                <a href="${wtmUrl}" onclick="${openTabWithUrl}">Read more on WhoTracks.Me</a>
+                <a href="${wtmUrl}" onclick="${openHref}">Read more on WhoTracks.Me</a>
               </ui-text>
             `}
           </div>
@@ -190,9 +190,7 @@ export default {
                 underline
                 layout="padding margin:-1"
               >
-                <a href="${tracker.websiteUrl}" onclick="${openTabWithUrl}">
-                  ${tracker.websiteUrl}
-                </a>
+                <a href="${tracker.websiteUrl}" onclick="${openHref}"> ${tracker.websiteUrl} </a>
               </ui-text>
             </div>
           `}
@@ -210,7 +208,7 @@ export default {
                   underline
                   layout="padding margin:-1"
                 >
-                  <a href="${tracker.organization.websiteUrl}" onclick="${openTabWithUrl}">
+                  <a href="${tracker.organization.websiteUrl}" onclick="${openHref}">
                     ${tracker.organization.websiteUrl}
                   </a>
                 </ui-text>
@@ -228,7 +226,7 @@ export default {
                   underline
                   layout="padding margin:-1"
                 >
-                  <a href="${tracker.organization.privacyPolicy}" onclick="${openTabWithUrl}">
+                  <a href="${tracker.organization.privacyPolicy}" onclick="${openHref}">
                     ${tracker.organization.privacyPolicy}
                   </a>
                 </ui-text>
@@ -250,7 +248,7 @@ export default {
                     href="${tracker.organization.contact.startsWith('http')
                       ? ''
                       : 'mailto:'}${tracker.organization.contact}"
-                    onclick="${openTabWithUrl}"
+                    onclick="${openHref}"
                   >
                     ${tracker.organization.contact}
                   </a>

--- a/src/pages/panel/views/whotracksme.js
+++ b/src/pages/panel/views/whotracksme.js
@@ -15,7 +15,7 @@ import { parse } from 'tldts-experimental';
 import TabStats from '/store/tab-stats.js';
 
 import { WTM_PAGE_URL } from '/utils/urls.js';
-import { openTabWithUrl } from '/utils/tabs.js';
+import { openHref } from '/utils/tabs.js';
 
 function hasWTMStats(domain) {
   return chrome.runtime.sendMessage({
@@ -41,7 +41,7 @@ export default {
           <ui-action>
             <a
               href="${chrome.runtime.getURL('/pages/whotracksme/index.html')}"
-              onclick="${openTabWithUrl}"
+              onclick="${openHref}"
               layout="row gap:2"
             >
               <ui-icon name="whotracksme" color="tertiary" layout="size:3"></ui-icon>
@@ -61,7 +61,7 @@ export default {
                 link &&
                 html`
                   <ui-action>
-                    <a href="${link}" onclick="${openTabWithUrl}" layout="row gap:2">
+                    <a href="${link}" onclick="${openHref}" layout="row gap:2">
                       <ui-icon name="stats-report" color="tertiary" layout="size:3"></ui-icon>
                       <div layout="column gap:0.5">
                         <ui-text type="label-m"> Website Statistical Report </ui-text>

--- a/src/utils/tabs.js
+++ b/src/utils/tabs.js
@@ -11,7 +11,7 @@
 
 import { getOS } from './browser-info.js';
 
-export async function openTabWithUrl(host, event) {
+export async function openHref(host, event) {
   // Firefox does not support Tabs API in iframes (Trackers Preview)
   // Firefox Android does not allow using `window.close()` in async event listeners
   if (__FIREFOX__ && (!chrome.tabs || getOS() === 'android')) {
@@ -25,27 +25,30 @@ export async function openTabWithUrl(host, event) {
   const { href } = event.currentTarget;
   event.preventDefault();
 
+  await openTabWithUrl(href);
+
+  window.close();
+}
+
+export async function openTabWithUrl(url) {
   try {
     const tabs = await chrome.tabs.query({
-      url: href.split('#')[0],
+      url: url.split('#')[0],
       currentWindow: true,
     });
 
     if (tabs.length) {
       await chrome.tabs.update(tabs[0].id, {
         active: true,
-        url: href !== tabs[0].url ? href : undefined,
+        url: url !== tabs[0].url ? url : undefined,
       });
-
-      window.close();
       return;
     }
   } catch (e) {
     console.error('[utils|tabs] Error while try to find existing tab:', e);
   }
 
-  chrome.tabs.create({ url: href });
-  window.close();
+  await chrome.tabs.create({ url });
 }
 
 export async function getCurrentTab() {


### PR DESCRIPTION
The tab-opening logic in the panel was duplicated across a local `src/pages/panel/utils/tabs.js` wrapper and the core `src/utils/tabs.js`, making it harder to reuse the same behaviour from background scripts like the context menu.

The event-handler function is renamed to `openHref` and moved into `src/utils/tabs.js`, delegating to a new standalone `openTabWithUrl(url)` helper that handles finding an existing tab (including hash-aware URL comparison) or creating a new one. The local panel wrapper file is removed and all panel imports are updated to use `openHref` from `/utils/tabs.js` directly. `openWebsiteSettings` and `openSettings` in `context-menu.js` now call `openTabWithUrl` so the settings tab is reused rather than duplicated.