### PR TITLE
Add setting to disable Ghostery context menu

### DIFF
--- a/src/background/context-menu.js
+++ b/src/background/context-menu.js
@@ -297,3 +297,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
 OptionsObserver.addListener('terms', (terms) => {
   chrome.contextMenus.update(ID_PARENT, { enabled: terms }).catch(console.error);
 });
+
+OptionsObserver.addListener('contextMenu', (contextMenu) => {
+  chrome.contextMenus.update(ID_PARENT, { visible: contextMenu }).catch(console.error);
+});

--- a/src/pages/settings/views/my-ghostery.js
+++ b/src/pages/settings/views/my-ghostery.js
@@ -193,6 +193,17 @@ export default {
                 </span>
               </settings-toggle>
 
+              <settings-toggle
+                icon="doc-m"
+                value="${options.contextMenu}"
+                onchange="${html.set(options, 'contextMenu')}"
+              >
+                Quick Actions
+                <span slot="description">
+                  Shows Ghostery options in your browser’s right-click menu.
+                </span>
+              </settings-toggle>
+
               <settings-option icon="websites">
                 Theme
                 <span slot="description">Changes application color theme.</span>

--- a/src/store/options.js
+++ b/src/store/options.js
@@ -93,6 +93,7 @@ const Options = {
 
   // UI
   panel: { statsType: 'graph', notifications: true },
+  contextMenu: true,
   theme: '',
 
   // Tracker exceptions


### PR DESCRIPTION
Ghostery's browser context menu was always present, even for users who do not use those quick actions and want a cleaner right-click menu. This change adds an explicit setting so the menu can be disabled without affecting other extension behavior.

The options store now persists a `contextMenu` flag enabled by default, and the My Ghostery settings view exposes it as a Quick Actions toggle. The background context menu code now listens for that option and hides or shows the parent Ghostery menu immediately when the setting changes. This keeps the current default behavior while making the menu opt-out for users who prefer it off.

<img width="810" height="116" alt="Zrzut ekranu 2026-05-21 o 13 21 00" src="https://github.com/user-attachments/assets/5d9e5009-59b7-425f-b621-29baea121096" />

