### PR TITLE
fix(onboarding): wait for config sync before opening onboarding

### DIFF
--- a/src/background/config.js
+++ b/src/background/config.js
@@ -86,6 +86,32 @@ export default async function syncConfig() {
   }
 }
 
+export function waitForConfigSync(timeout = 5000) {
+  return new Promise((resolve) => {
+    store.resolve(Config).then((config) => {
+      if (config.updatedAt > 0) {
+        resolve();
+        return;
+      }
+
+      let unobserve;
+
+      const timer = setTimeout(() => {
+        unobserve();
+        resolve();
+      }, timeout);
+
+      unobserve = store.observe(Config, (_, config) => {
+        if (config.updatedAt > 0) {
+          clearTimeout(timer);
+          unobserve();
+          resolve();
+        }
+      });
+    });
+  });
+}
+
 if (__DEBUG__) {
   // Enable all available flags
   store.set(Config, {

--- a/src/background/onboarding.js
+++ b/src/background/onboarding.js
@@ -17,6 +17,8 @@ import Options from '/store/options.js';
 import { isBrave } from '/utils/browser-info.js';
 import * as OptionsObserver from '/utils/options-observer.js';
 
+import { waitForConfigSync } from './config.js';
+
 export const SURVEY_URL =
   'https://blocksurvey.io/install-survey-postonboarding-R6q0d5dGR9OY6202iNPmGQ?v=o';
 
@@ -27,6 +29,10 @@ OptionsObserver.addListener('onboarding', async (onboarding) => {
   // The onboarding page should not be shown in debug mode especially for the e2e tests
   // which fails if after initializing the extension additional tabs are opened
   if (__DEBUG__) return;
+
+  // TODO: Remove this after the `modes` flag is completed, as then the onboarding
+  // page will not depend on the config and can be shown immediately
+  await waitForConfigSync();
 
   const tab = await chrome.tabs.create({
     url: chrome.runtime.getURL('/pages/onboarding/index.html'),


### PR DESCRIPTION
When the remote config is fetched and stored, the onboarding page reactively updates any flag-dependent UI — including the destination of the "Enable Ghostery" button — because the `Config` store propagates changes via `chrome.storage.onChanged`. However, on a fresh install the sync is delayed (10 s `setTimeout`) and the CDN request itself takes additional time, so a user who clicks the button before the sync completes is routed to the `Success` view instead of the `Modes` view even though the `modes` flag is enabled at 100%.

This fix adds a `waitForConfigSync(timeout = 5000)` helper to `background/config.js`. It resolves immediately if `config.updatedAt > 0` (already synced), otherwise it registers a one-shot `store.observe` listener that resolves as soon as the config is updated. A 5-second fallback ensures the onboarding tab is never permanently blocked if the CDN is unreachable. `background/onboarding.js` now awaits this helper before opening the onboarding tab, guaranteeing that feature flags are known at the moment the page first renders.