### PR TITLE
feat(managed): cache in local storage

### DIFF
--- a/src/store/managed-config.js
+++ b/src/store/managed-config.js
@@ -37,42 +37,43 @@ const ManagedConfig = {
   [store.connect]: async () => {
     if (__CHROMIUM__ && (isOpera() || isWebkit())) return {};
 
-    try {
-      // Try to get cached local version to mitigate slow Chrome
-      // managed storage initialization.
-      // We endure and expect the stale cache from local storage cache
-      // as service worker will restart frequently.
-      let { managedConfig } = await chrome.storage.local.get('managedConfig');
+    // Try to get cached local version to mitigate slow Chrome
+    // managed storage initialization.
+    // We endure and expect the stale cache from local storage cache
+    // as service worker will restart frequently.
+    let { managedConfig } = await chrome.storage.local.get('managedConfig');
 
-      // We will skip managed config in debug mode
-      // Also this local storage overriding in e2e tests
-      if (__DEBUG__) {
-        managedConfig ??= {};
-      } else {
-        // Firefox throws if storage.managed is not found unlike Chrome
-        // returning empty object
-        const managedConfigFromBackend = chrome.storage.managed
-          .get()
-          .then(function (managedConfig) {
-            chrome.storage.local.set({ managedConfig });
-            return managedConfig;
-          });
+    // We will skip managed config in debug mode
+    // Also this local storage overriding in e2e tests
+    if (__DEBUG__) {
+      managedConfig ??= {};
+    } else {
+      // Firefox throws if storage.managed is not found unlike Chrome
+      // returning empty object
+      const managedConfigFromBackend = chrome.storage.managed
+        .get()
+        .then(function (managedConfig) {
+          chrome.storage.local.set({ managedConfig });
+          return managedConfig;
+        })
+        .catch(function (e) {
+          // `e.message` equals `Managed storage manifest not found` here
+          if (__FIREFOX__ && e?.message.includes('not found')) return {};
+          throw e;
+        });
 
-        managedConfig ??= await managedConfigFromBackend;
-      }
-
-      // Translate `customFilters` storage.managed key (an array) to model structure
-      if (managedConfig.customFilters) {
-        managedConfig.customFilters = {
-          enabled: true,
-          filters: managedConfig.customFilters,
-        };
-      }
-
-      return managedConfig;
-    } catch {
-      return {};
+      managedConfig ??= await managedConfigFromBackend;
     }
+
+    // Translate `customFilters` storage.managed key (an array) to model structure
+    if (managedConfig.customFilters) {
+      managedConfig.customFilters = {
+        enabled: true,
+        filters: managedConfig.customFilters,
+      };
+    }
+
+    return managedConfig;
   },
 };
 

--- a/src/store/managed-config.js
+++ b/src/store/managed-config.js
@@ -56,10 +56,10 @@ const ManagedConfig = {
           chrome.storage.local.set({ managedConfig });
           return managedConfig;
         })
-        .catch(function (e) {
-          // `e.message` equals `Managed storage manifest not found` here
-          if (__FIREFOX__ && e?.message.includes('not found')) return {};
-          throw e;
+        .catch(function () {
+          // We intend to catch all errors and make the function safe
+          // Returning empty object here will handle every case
+          return {};
         });
 
       managedConfig ??= await managedConfigFromBackend;

--- a/src/store/managed-config.js
+++ b/src/store/managed-config.js
@@ -45,18 +45,11 @@ const ManagedConfig = {
       let { managedConfig } = await chrome.storage.local.get('managedConfig');
 
       // Firefox throws if storage.managed is not available unlike Chrome
-      let managedConfigFromBackend = chrome.storage.managed
-        .get()
-        .catch(function (e) {
-          // Allow fallback in debug mode (for e2e tests)
-          if (__DEBUG__) return {};
-          throw e;
-        })
-        .then(function (managedConfig) {
-          // Prevent local storage overriding in debug mode (for e2e tests)
-          if (!__DEBUG__) chrome.storage.local.set({ managedConfig });
-          return managedConfig;
-        });
+      let managedConfigFromBackend = chrome.storage.managed.get().then(function (managedConfig) {
+        // Prevent local storage overriding in debug mode (for e2e tests)
+        if (!__DEBUG__) chrome.storage.local.set({ managedConfig });
+        return managedConfig;
+      });
 
       managedConfig ??= await managedConfigFromBackend;
 

--- a/src/store/managed-config.js
+++ b/src/store/managed-config.js
@@ -38,41 +38,36 @@ const ManagedConfig = {
     if (__CHROMIUM__ && (isOpera() || isWebkit())) return {};
 
     try {
-      // Firefox uses filesystem configuration on every platform
-      // and throws if storage.managed is not available,
-      // so we can skip fallback for it
-      let managedConfig = await chrome.storage.managed.get().catch((e) => {
-        // Allow fallback in debug mode (for e2e tests)
-        if (__DEBUG__) return {};
-        throw e;
+      // Try to get cached local version to mitigate slow Chrome
+      // managed storage initialization.
+      // We endure and expect the stale cache from local storage cache
+      // as service worker will restart frequently.
+      let { managedConfig } = await chrome.storage.local.get('managedConfig');
+
+      // Allow fallback in debug mode (for e2e tests)
+      if (__DEBUG__) {
+        return managedConfig || {};
+      }
+
+      // Firefox throws if storage.managed is not available unlike Chrome
+      let managedConfigFromBackend = chrome.storage.managed.get().then(function (managedConfig) {
+        chrome.storage.local.set({ managedConfig });
+        return managedConfig;
       });
 
-      // Chromium-based browsers just return an empty object,
-      // and it might be available later (especially on the browser restart),
-      // so we try to read it with fallback from local storage
-      if (__CHROMIUM__ || __DEBUG__) {
-        if (Object.keys(managedConfig).length) {
-          // Save local version for fallback usage
-          // Don't await - we don't need to block on this
-          chrome.storage.local.set({ managedConfig });
-        } else {
-          // Try to get local version as fallback
-          const { managedConfig: fallbackConfig = {} } =
-            await chrome.storage.local.get('managedConfig');
+      if (!managedConfig) {
+        managedConfig = await managedConfigFromBackend;
 
-          managedConfig = fallbackConfig;
+        // Translate `customFilters` storage.managed key (an array) to model structure
+        if (managedConfig.customFilters) {
+          managedConfig.customFilters = {
+            enabled: true,
+            filters: managedConfig.customFilters,
+          };
         }
       }
 
-      // Translate `customFilters` storage.managed key (an array) to model structure
-      if (managedConfig.customFilters) {
-        managedConfig.customFilters = {
-          enabled: true,
-          filters: managedConfig.customFilters,
-        };
-      }
-
-      return managedConfig || {};
+      return managedConfig;
     } catch {
       return {};
     }

--- a/src/store/managed-config.js
+++ b/src/store/managed-config.js
@@ -44,14 +44,22 @@ const ManagedConfig = {
       // as service worker will restart frequently.
       let { managedConfig } = await chrome.storage.local.get('managedConfig');
 
-      // Firefox throws if storage.managed is not available unlike Chrome
-      let managedConfigFromBackend = chrome.storage.managed.get().then(function (managedConfig) {
-        // Prevent local storage overriding in debug mode (for e2e tests)
-        if (!__DEBUG__) chrome.storage.local.set({ managedConfig });
-        return managedConfig;
-      });
+      // We will skip managed config in debug mode
+      // Also this local storage overriding in e2e tests
+      if (__DEBUG__) {
+        managedConfig ??= {};
+      } else {
+        // Firefox throws if storage.managed is not found unlike Chrome
+        // returning empty object
+        const managedConfigFromBackend = chrome.storage.managed
+          .get()
+          .then(function (managedConfig) {
+            chrome.storage.local.set({ managedConfig });
+            return managedConfig;
+          });
 
-      managedConfig ??= await managedConfigFromBackend;
+        managedConfig ??= await managedConfigFromBackend;
+      }
 
       // Translate `customFilters` storage.managed key (an array) to model structure
       if (managedConfig.customFilters) {

--- a/src/store/managed-config.js
+++ b/src/store/managed-config.js
@@ -44,16 +44,20 @@ const ManagedConfig = {
       // as service worker will restart frequently.
       let { managedConfig } = await chrome.storage.local.get('managedConfig');
 
-      // Allow fallback in debug mode (for e2e tests)
-      if (__DEBUG__) {
-        return managedConfig || {};
-      }
-
       // Firefox throws if storage.managed is not available unlike Chrome
-      let managedConfigFromBackend = chrome.storage.managed.get().then(function (managedConfig) {
-        chrome.storage.local.set({ managedConfig });
-        return managedConfig;
-      });
+      let managedConfigFromBackend = chrome.storage.managed
+        .get()
+        .catch(function (e) {
+          // Allow fallback in debug mode (for e2e tests)
+          if (__DEBUG__) {
+            return {};
+          }
+          throw e;
+        })
+        .then(function (managedConfig) {
+          chrome.storage.local.set({ managedConfig });
+          return managedConfig;
+        });
 
       if (!managedConfig) {
         managedConfig = await managedConfigFromBackend;

--- a/src/store/managed-config.js
+++ b/src/store/managed-config.js
@@ -45,13 +45,18 @@ const ManagedConfig = {
       let { managedConfig } = await chrome.storage.local.get('managedConfig');
 
       // Firefox throws if storage.managed is not available unlike Chrome
-      let managedConfigFromBackend = __DEBUG__
-        ? // Allow fallback in debug mode (for e2e tests)
-          (managedConfig ??= {})
-        : chrome.storage.managed.get().then(function (managedConfig) {
-            chrome.storage.local.set({ managedConfig });
-            return managedConfig;
-          });
+      let managedConfigFromBackend = chrome.storage.managed
+        .get()
+        .catch(function (e) {
+          // Allow fallback in debug mode (for e2e tests)
+          if (__DEBUG__) return {};
+          throw e;
+        })
+        .then(function (managedConfig) {
+          // Prevent local storage overriding in debug mode (for e2e tests)
+          if (!__DEBUG__) chrome.storage.local.set({ managedConfig });
+          return managedConfig;
+        });
 
       managedConfig ??= await managedConfigFromBackend;
 

--- a/src/store/managed-config.js
+++ b/src/store/managed-config.js
@@ -45,30 +45,22 @@ const ManagedConfig = {
       let { managedConfig } = await chrome.storage.local.get('managedConfig');
 
       // Firefox throws if storage.managed is not available unlike Chrome
-      let managedConfigFromBackend = chrome.storage.managed
-        .get()
-        .catch(function (e) {
-          // Allow fallback in debug mode (for e2e tests)
-          if (__DEBUG__) {
-            return {};
-          }
-          throw e;
-        })
-        .then(function (managedConfig) {
-          chrome.storage.local.set({ managedConfig });
-          return managedConfig;
-        });
+      let managedConfigFromBackend = __DEBUG__
+        ? // Allow fallback in debug mode (for e2e tests)
+          (managedConfig ??= {})
+        : chrome.storage.managed.get().then(function (managedConfig) {
+            chrome.storage.local.set({ managedConfig });
+            return managedConfig;
+          });
 
-      if (!managedConfig) {
-        managedConfig = await managedConfigFromBackend;
+      managedConfig ??= await managedConfigFromBackend;
 
-        // Translate `customFilters` storage.managed key (an array) to model structure
-        if (managedConfig.customFilters) {
-          managedConfig.customFilters = {
-            enabled: true,
-            filters: managedConfig.customFilters,
-          };
-        }
+      // Translate `customFilters` storage.managed key (an array) to model structure
+      if (managedConfig.customFilters) {
+        managedConfig.customFilters = {
+          enabled: true,
+          filters: managedConfig.customFilters,
+        };
       }
 
       return managedConfig;


### PR DESCRIPTION
fixes #3367

It modifies managed config initialisation process not to be held by `chrome.storage.managed.get` call, which takes more than 6 seconds depends on the environment. Despite it only happens on fresh start of Google Chrome, 6 seconds is enough for most of users to start browsing and it shouldn't be the case for users without managed policy.

Exact reason for Chrome's policy service hanging so long in the initialisation is not known and it doesn't seem to be controllable from the extension level.

As requested in https://github.com/ghostery/ghostery-extension/pull/3368#pullrequestreview-4361983635, this version doesn't support options update on the fly. It still tries to receive data from `chrome.storage.managed.onChanged` as having up-to-date data is important.

<details>

<summary>Log screenshot when Chrome Policy Service is already initialised</summary>

<img width="907" height="1032" alt="image" src="https://github.com/user-attachments/assets/18f15f8d-7be1-4c8f-9432-eb9258125643" />

</details>

<details>

<summary>Log screenshot when Chrome Policy Service is not ready</summary>

**Make sure Google Chrome is fully shut downed before testing this**

<img width="907" height="1032" alt="image" src="https://github.com/user-attachments/assets/336ecee9-100b-4304-b5a3-f3971c8c01b0" />

</details>