### PR TITLE
fix(managed-config): add default value for fallback local storage lookup

### DIFF
--- a/src/store/managed-config.js
+++ b/src/store/managed-config.js
@@ -57,7 +57,8 @@ const ManagedConfig = {
           chrome.storage.local.set({ managedConfig });
         } else {
           // Try to get local version as fallback
-          const { managedConfig: fallbackConfig } = await chrome.storage.local.get('managedConfig');
+          const { managedConfig: fallbackConfig = {} } =
+            await chrome.storage.local.get('managedConfig');
 
           managedConfig = fallbackConfig;
         }


### PR DESCRIPTION
On Chromium-based browsers, when the managed storage is empty, the extension falls back to a locally cached copy of the managed config. If that local copy was never saved (e.g. on first run with no managed policy), `chrome.storage.local.get('managedConfig')` returns `{}` — causing the destructured `fallbackConfig` to be `undefined`, which was then assigned to `managedConfig`.

This added `= {}` as a destructuring default so that when the `managedConfig` key is absent from local storage, `fallbackConfig` resolves to `{}` instead of `undefined`. Without this, `managedConfig.customFilters` would throw a TypeError that was silently caught by the outer try/catch, causing the store to always return `{}` via the error path rather than the normal return path.