### PR TITLE
fix(context-menu): guard chrome.contextMenus for Firefox Android

### DIFF
--- a/src/background/context-menu.js
+++ b/src/background/context-menu.js
@@ -31,264 +31,292 @@ const ID_ELEMENT_PICKER = 'ghostery:element-picker';
 const ID_SEPARATOR = 'ghostery:separator';
 const ID_SETTINGS = 'ghostery:settings';
 const ID_WEBSITE_SETTINGS = 'ghostery:website-settings';
+const ID_DISABLE_CONTEXT_MENU = 'ghostery:disable-context-menu';
 
-chrome.runtime.onInstalled.addListener(() => {
-  chrome.contextMenus.removeAll(() => {
-    chrome.contextMenus.create({
-      id: ID_PARENT,
-      title: 'Ghostery',
-      contexts: ['all'],
-      documentUrlPatterns: ['http://*/*', 'https://*/*'],
-    });
+if (chrome.contextMenus) {
+  chrome.runtime.onInstalled.addListener(() => {
+    chrome.contextMenus.removeAll(() => {
+      chrome.contextMenus.create({
+        id: ID_PARENT,
+        title: 'Ghostery',
+        contexts: ['all'],
+        documentUrlPatterns: ['http://*/*', 'https://*/*'],
+      });
 
-    chrome.contextMenus.create({
-      id: ID_PAUSE,
-      parentId: ID_PARENT,
-      title: msg`Pause on this site`,
-      contexts: ['all'],
-      documentUrlPatterns: ['http://*/*', 'https://*/*'],
-    });
+      chrome.contextMenus.create({
+        id: ID_PAUSE,
+        parentId: ID_PARENT,
+        title: msg`Pause on this site`,
+        contexts: ['all'],
+        documentUrlPatterns: ['http://*/*', 'https://*/*'],
+      });
 
-    chrome.contextMenus.create({
-      id: ID_PAUSE_HOUR,
-      parentId: ID_PAUSE,
-      title: msg`1 hour`,
-      contexts: ['all'],
-      documentUrlPatterns: ['http://*/*', 'https://*/*'],
-    });
+      chrome.contextMenus.create({
+        id: ID_PAUSE_HOUR,
+        parentId: ID_PAUSE,
+        title: msg`1 hour`,
+        contexts: ['all'],
+        documentUrlPatterns: ['http://*/*', 'https://*/*'],
+      });
 
-    chrome.contextMenus.create({
-      id: ID_PAUSE_DAY,
-      parentId: ID_PAUSE,
-      title: msg`1 day`,
-      contexts: ['all'],
-      documentUrlPatterns: ['http://*/*', 'https://*/*'],
-    });
+      chrome.contextMenus.create({
+        id: ID_PAUSE_DAY,
+        parentId: ID_PAUSE,
+        title: msg`1 day`,
+        contexts: ['all'],
+        documentUrlPatterns: ['http://*/*', 'https://*/*'],
+      });
 
-    chrome.contextMenus.create({
-      id: ID_PAUSE_ALWAYS,
-      parentId: ID_PAUSE,
-      title: msg`Always`,
-      contexts: ['all'],
-      documentUrlPatterns: ['http://*/*', 'https://*/*'],
-    });
+      chrome.contextMenus.create({
+        id: ID_PAUSE_ALWAYS,
+        parentId: ID_PAUSE,
+        title: msg`Always`,
+        contexts: ['all'],
+        documentUrlPatterns: ['http://*/*', 'https://*/*'],
+      });
 
-    chrome.contextMenus.create({
-      id: ID_RESUME,
-      parentId: ID_PARENT,
-      title: msg`Resume`,
-      contexts: ['all'],
-      documentUrlPatterns: ['http://*/*', 'https://*/*'],
-      visible: false,
-    });
+      chrome.contextMenus.create({
+        id: ID_RESUME,
+        parentId: ID_PARENT,
+        title: msg`Resume`,
+        contexts: ['all'],
+        documentUrlPatterns: ['http://*/*', 'https://*/*'],
+        visible: false,
+      });
 
-    chrome.contextMenus.create({
-      id: ID_ZAP_ENABLE,
-      parentId: ID_PARENT,
-      title: msg`Block ads`,
-      contexts: ['all'],
-      documentUrlPatterns: ['http://*/*', 'https://*/*'],
-      visible: false,
-    });
+      chrome.contextMenus.create({
+        id: ID_ZAP_ENABLE,
+        parentId: ID_PARENT,
+        title: msg`Block ads`,
+        contexts: ['all'],
+        documentUrlPatterns: ['http://*/*', 'https://*/*'],
+        visible: false,
+      });
 
-    chrome.contextMenus.create({
-      id: ID_ZAP_DISABLE,
-      parentId: ID_PARENT,
-      title: msg`Show ads`,
-      contexts: ['all'],
-      documentUrlPatterns: ['http://*/*', 'https://*/*'],
-      visible: false,
-    });
+      chrome.contextMenus.create({
+        id: ID_ZAP_DISABLE,
+        parentId: ID_PARENT,
+        title: msg`Show ads`,
+        contexts: ['all'],
+        documentUrlPatterns: ['http://*/*', 'https://*/*'],
+        visible: false,
+      });
 
-    chrome.contextMenus.create({
-      id: `${ID_SEPARATOR}-1`,
-      parentId: ID_PARENT,
-      type: 'separator',
-      contexts: ['all'],
-      documentUrlPatterns: ['http://*/*', 'https://*/*'],
-    });
+      chrome.contextMenus.create({
+        id: `${ID_SEPARATOR}-1`,
+        parentId: ID_PARENT,
+        type: 'separator',
+        contexts: ['all'],
+        documentUrlPatterns: ['http://*/*', 'https://*/*'],
+      });
 
-    chrome.contextMenus.create({
-      id: ID_ELEMENT_PICKER,
-      parentId: ID_PARENT,
-      title: `${msg`Hide content block`}...`,
-      contexts: ['all'],
-      documentUrlPatterns: ['http://*/*', 'https://*/*'],
-    });
+      chrome.contextMenus.create({
+        id: ID_ELEMENT_PICKER,
+        parentId: ID_PARENT,
+        title: `${msg`Hide content block`}...`,
+        contexts: ['all'],
+        documentUrlPatterns: ['http://*/*', 'https://*/*'],
+      });
 
-    chrome.contextMenus.create({
-      id: ID_WEBSITE_SETTINGS,
-      parentId: ID_PARENT,
-      title: `${msg`Open website settings`}...`,
-      contexts: ['all'],
-      documentUrlPatterns: ['http://*/*', 'https://*/*'],
-    });
+      chrome.contextMenus.create({
+        id: ID_WEBSITE_SETTINGS,
+        parentId: ID_PARENT,
+        title: `${msg`Open website settings`}...`,
+        contexts: ['all'],
+        documentUrlPatterns: ['http://*/*', 'https://*/*'],
+      });
 
-    chrome.contextMenus.create({
-      id: `${ID_SEPARATOR}-2`,
-      parentId: ID_PARENT,
-      type: 'separator',
-      contexts: ['all'],
-      documentUrlPatterns: ['http://*/*', 'https://*/*'],
-    });
+      chrome.contextMenus.create({
+        id: `${ID_SEPARATOR}-2`,
+        parentId: ID_PARENT,
+        type: 'separator',
+        contexts: ['all'],
+        documentUrlPatterns: ['http://*/*', 'https://*/*'],
+      });
 
-    chrome.contextMenus.create({
-      id: ID_SETTINGS,
-      parentId: ID_PARENT,
-      title: `${msg`Open settings`}...`,
-      contexts: ['all'],
-      documentUrlPatterns: ['http://*/*', 'https://*/*'],
+      chrome.contextMenus.create({
+        id: ID_SETTINGS,
+        parentId: ID_PARENT,
+        title: `${msg`Open settings`}...`,
+        contexts: ['all'],
+        documentUrlPatterns: ['http://*/*', 'https://*/*'],
+      });
+
+      chrome.contextMenus.create({
+        id: `${ID_SEPARATOR}-3`,
+        parentId: ID_PARENT,
+        type: 'separator',
+        contexts: ['all'],
+        documentUrlPatterns: ['http://*/*', 'https://*/*'],
+      });
+
+      chrome.contextMenus.create({
+        id: ID_DISABLE_CONTEXT_MENU,
+        parentId: ID_PARENT,
+        title: msg`Disable context menu`,
+        contexts: ['all'],
+        documentUrlPatterns: ['http://*/*', 'https://*/*'],
+      });
+      console.debug('[context-menu] Context menu created...');
     });
-    console.debug('[context-menu] Context menu created...');
   });
-});
 
-async function resumeSite(tab) {
-  const hostname = tabStats.get(tab.id)?.hostname;
-  if (!hostname) return;
+  async function resumeSite(tab) {
+    const hostname = tabStats.get(tab.id)?.hostname;
+    if (!hostname) return;
 
-  const options = await store.resolve(Options);
-  await store.set(options, { paused: { [hostname]: null } });
-  await chrome.tabs.reload(tab.id);
+    const options = await store.resolve(Options);
+    await store.set(options, { paused: { [hostname]: null } });
+    await chrome.tabs.reload(tab.id);
 
-  console.debug(`[context-menu] Resumed ${hostname}`);
-}
-
-async function zapSite(tab) {
-  const hostname = tabStats.get(tab.id)?.hostname;
-  if (!hostname) return;
-
-  const options = await store.resolve(Options);
-  await store.set(options, { zapped: { [hostname]: true } });
-  await chrome.tabs.reload(tab.id);
-
-  console.debug(`[context-menu] Zapped ${hostname}`);
-}
-
-async function unzapSite(tab) {
-  const hostname = tabStats.get(tab.id)?.hostname;
-  if (!hostname) return;
-
-  const options = await store.resolve(Options);
-  await store.set(options, { zapped: { [hostname]: null } });
-  await chrome.tabs.reload(tab.id);
-
-  console.debug(`[context-menu] Unzapped ${hostname}`);
-}
-
-async function pauseSite(tab, id) {
-  const hostname = tabStats.get(tab.id)?.hostname;
-  if (!hostname) return;
-
-  const options = await store.resolve(Options);
-
-  let revokeAt;
-  if (id === ID_PAUSE_HOUR) {
-    revokeAt = Date.now() + 60 * 60 * 1000;
-  } else if (id === ID_PAUSE_DAY) {
-    revokeAt = Date.now() + 24 * 60 * 60 * 1000;
-  } else if (id === ID_PAUSE_ALWAYS) {
-    revokeAt = 0;
-  } else {
-    throw new Error('[context-menu] Unknown pause duration');
+    console.debug(`[context-menu] Resumed ${hostname}`);
   }
 
-  await store.set(options, { paused: { [hostname]: { revokeAt } } });
-  await chrome.tabs.reload(tab.id);
+  async function zapSite(tab) {
+    const hostname = tabStats.get(tab.id)?.hostname;
+    if (!hostname) return;
 
-  console.debug(
-    `[context-menu] Paused ${hostname} until ${revokeAt ? new Date(revokeAt).toLocaleString() : 'always'}`,
-  );
-}
+    const options = await store.resolve(Options);
+    await store.set(options, { zapped: { [hostname]: true } });
+    await chrome.tabs.reload(tab.id);
 
-async function openSettings() {
-  await openTabWithUrl(SETTINGS_URL + '#@settings-privacy');
-  console.debug('[context-menu] Opened settings page...');
-}
-
-async function openWebsiteSettings(tab) {
-  const hostname = tabStats.get(tab.id)?.hostname;
-  const url = SETTINGS_URL + '#@settings-website-details?domain=' + (hostname || '');
-
-  await openTabWithUrl(url);
-
-  console.debug(`[context-menu] Opened website settings for ${hostname}...`);
-}
-
-chrome.contextMenus.onClicked.addListener((info, tab) => {
-  switch (info.menuItemId) {
-    case ID_RESUME:
-      resumeSite(tab).catch(console.error);
-      break;
-    case ID_ZAP_ENABLE:
-      zapSite(tab).catch(console.error);
-      break;
-    case ID_ZAP_DISABLE:
-      unzapSite(tab).catch(console.error);
-      break;
-    case ID_PAUSE_HOUR:
-    case ID_PAUSE_DAY:
-    case ID_PAUSE_ALWAYS:
-      pauseSite(tab, info.menuItemId).catch(console.error);
-      break;
-    case ID_ELEMENT_PICKER:
-      openElementPicker(tab.id).catch(console.error);
-      break;
-    case ID_SETTINGS:
-      openSettings().catch(console.error);
-      break;
-    case ID_WEBSITE_SETTINGS:
-      openWebsiteSettings(tab).catch(console.error);
-      break;
+    console.debug(`[context-menu] Zapped ${hostname}`);
   }
-});
 
-async function updateVisibility(tabId) {
-  if (tabId === undefined) return;
+  async function unzapSite(tab) {
+    const hostname = tabStats.get(tab.id)?.hostname;
+    if (!hostname) return;
 
-  const hostname = tabStats.get(tabId)?.hostname;
-  const options = await store.resolve(Options);
-  const isZapMode = options.mode === MODE_ZAP;
+    const options = await store.resolve(Options);
+    await store.set(options, { zapped: { [hostname]: null } });
+    await chrome.tabs.reload(tab.id);
 
-  let isPaused = false;
-  let isZapped = false;
+    console.debug(`[context-menu] Unzapped ${hostname}`);
+  }
 
-  if (hostname) {
-    if (isZapMode) {
-      isZapped = !!options.zapped?.[hostname];
+  async function pauseSite(tab, id) {
+    const hostname = tabStats.get(tab.id)?.hostname;
+    if (!hostname) return;
+
+    const options = await store.resolve(Options);
+
+    let revokeAt;
+    if (id === ID_PAUSE_HOUR) {
+      revokeAt = Date.now() + 60 * 60 * 1000;
+    } else if (id === ID_PAUSE_DAY) {
+      revokeAt = Date.now() + 24 * 60 * 60 * 1000;
+    } else if (id === ID_PAUSE_ALWAYS) {
+      revokeAt = 0;
     } else {
-      const entry = options.paused?.[hostname];
-      isPaused = !!entry && (entry.revokeAt === 0 || entry.revokeAt > Date.now());
+      throw new Error('[context-menu] Unknown pause duration');
     }
+
+    await store.set(options, { paused: { [hostname]: { revokeAt } } });
+    await chrome.tabs.reload(tab.id);
+
+    console.debug(
+      `[context-menu] Paused ${hostname} until ${revokeAt ? new Date(revokeAt).toLocaleString() : 'always'}`,
+    );
   }
 
-  chrome.contextMenus.update(ID_PAUSE, { visible: !isZapMode && !isPaused }).catch(console.error);
-  chrome.contextMenus.update(ID_RESUME, { visible: !isZapMode && isPaused }).catch(console.error);
-  chrome.contextMenus
-    .update(ID_ZAP_ENABLE, { visible: isZapMode && !isZapped })
-    .catch(console.error);
-  chrome.contextMenus
-    .update(ID_ZAP_DISABLE, { visible: isZapMode && isZapped })
-    .catch(console.error);
-  chrome.contextMenus
-    .update(ID_ELEMENT_PICKER, { enabled: !isPaused && !isZapped })
-    .catch(console.error);
-}
+  async function openSettings() {
+    await openTabWithUrl(SETTINGS_URL + '#@settings-privacy');
+    console.debug('[context-menu] Opened settings page...');
+  }
 
-chrome.tabs.onActivated.addListener(({ tabId }) => {
-  updateVisibility(tabId).catch(console.error);
-});
+  async function disableContextMenu() {
+    const options = await store.resolve(Options);
+    await store.set(options, { contextMenu: false });
+    console.debug('[context-menu] Context menu disabled');
+  }
 
-chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
-  if (changeInfo.status === 'complete') {
+  async function openWebsiteSettings(tab) {
+    const hostname = tabStats.get(tab.id)?.hostname;
+    const url = SETTINGS_URL + '#@settings-website-details?domain=' + (hostname || '');
+
+    await openTabWithUrl(url);
+
+    console.debug(`[context-menu] Opened website settings for ${hostname}...`);
+  }
+
+  chrome.contextMenus.onClicked.addListener((info, tab) => {
+    switch (info.menuItemId) {
+      case ID_RESUME:
+        resumeSite(tab).catch(console.error);
+        break;
+      case ID_ZAP_ENABLE:
+        zapSite(tab).catch(console.error);
+        break;
+      case ID_ZAP_DISABLE:
+        unzapSite(tab).catch(console.error);
+        break;
+      case ID_PAUSE_HOUR:
+      case ID_PAUSE_DAY:
+      case ID_PAUSE_ALWAYS:
+        pauseSite(tab, info.menuItemId).catch(console.error);
+        break;
+      case ID_ELEMENT_PICKER:
+        openElementPicker(tab.id).catch(console.error);
+        break;
+      case ID_SETTINGS:
+        openSettings().catch(console.error);
+        break;
+      case ID_WEBSITE_SETTINGS:
+        openWebsiteSettings(tab).catch(console.error);
+        break;
+      case ID_DISABLE_CONTEXT_MENU:
+        disableContextMenu().catch(console.error);
+        break;
+    }
+  });
+
+  async function updateVisibility(tabId) {
+    if (tabId === undefined) return;
+
+    const hostname = tabStats.get(tabId)?.hostname;
+    const options = await store.resolve(Options);
+    const isZapMode = options.mode === MODE_ZAP;
+
+    let isPaused = false;
+    let isZapped = false;
+
+    if (hostname) {
+      if (isZapMode) {
+        isZapped = !!options.zapped?.[hostname];
+      } else {
+        const entry = options.paused?.[hostname];
+        isPaused = !!entry && (entry.revokeAt === 0 || entry.revokeAt > Date.now());
+      }
+    }
+
+    chrome.contextMenus.update(ID_PAUSE, { visible: !isZapMode && !isPaused }).catch(console.error);
+    chrome.contextMenus.update(ID_RESUME, { visible: !isZapMode && isPaused }).catch(console.error);
+    chrome.contextMenus
+      .update(ID_ZAP_ENABLE, { visible: isZapMode && !isZapped })
+      .catch(console.error);
+    chrome.contextMenus
+      .update(ID_ZAP_DISABLE, { visible: isZapMode && isZapped })
+      .catch(console.error);
+    chrome.contextMenus
+      .update(ID_ELEMENT_PICKER, { enabled: !isPaused && !isZapped })
+      .catch(console.error);
+  }
+
+  chrome.tabs.onActivated.addListener(({ tabId }) => {
     updateVisibility(tabId).catch(console.error);
-  }
-});
+  });
 
-OptionsObserver.addListener('terms', (terms) => {
-  chrome.contextMenus.update(ID_PARENT, { enabled: terms }).catch(console.error);
-});
+  chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+    if (changeInfo.status === 'complete') {
+      updateVisibility(tabId).catch(console.error);
+    }
+  });
 
-OptionsObserver.addListener('contextMenu', (contextMenu) => {
-  chrome.contextMenus.update(ID_PARENT, { visible: contextMenu }).catch(console.error);
-});
+  OptionsObserver.addListener('terms', (terms) => {
+    chrome.contextMenus.update(ID_PARENT, { enabled: terms }).catch(console.error);
+  });
+
+  OptionsObserver.addListener('contextMenu', (contextMenu) => {
+    chrome.contextMenus.update(ID_PARENT, { visible: contextMenu }).catch(console.error);
+  });
+}

--- a/src/pages/settings/views/my-ghostery.js
+++ b/src/pages/settings/views/my-ghostery.js
@@ -192,17 +192,19 @@ export default {
                   Turns Ghostery notifications displayed in the panel on or off.
                 </span>
               </settings-toggle>
-
-              <settings-toggle
-                icon="doc-m"
-                value="${options.contextMenu}"
-                onchange="${html.set(options, 'contextMenu')}"
-              >
-                Quick Actions
-                <span slot="description">
-                  Shows Ghostery options in your browser’s right-click menu.
-                </span>
-              </settings-toggle>
+              ${chrome.contextMenus &&
+              html`
+                <settings-toggle
+                  icon="doc-m"
+                  value="${options.contextMenu}"
+                  onchange="${html.set(options, 'contextMenu')}"
+                >
+                  Quick Actions
+                  <span slot="description">
+                    Shows Ghostery options in your browser’s right-click menu.
+                  </span>
+                </settings-toggle>
+              `}
 
               <settings-option icon="websites">
                 Theme


### PR DESCRIPTION
Firefox for Android does not support the `chrome.contextMenus` API, and the recently added `context-menu.js` module was unconditionally calling `chrome.contextMenus.onClicked.addListener(...)` at module load time. Since the module is imported in `background/index.js`, this caused a `TypeError` that crashed the entire background script on Firefox Android, resulting in zero active telemetry signals after v10.5.43 shipped.

All context menu setup, event listeners, and option observers are now wrapped in an `if (chrome.contextMenus)` guard, so the module gracefully does nothing on platforms where the API is unavailable. 

Additionally, a "Disable context menu" option has been added to the context menu itself, wiring up the existing `contextMenu` option so users can turn it off directly from the menu.