### PR TITLE
fix(distractions): narrow Instagram reels filter to avoid breaking the page

### DIFF
--- a/src/background/rule_resources/distractions.json
+++ b/src/background/rule_resources/distractions.json
@@ -15,8 +15,8 @@
     "youtube.com##ytd-grid-video-renderer:has(a[href^=\"/shorts/\"])",
     "youtube.com##ytm-pivot-bar-item-renderer:has(a[href^=\"/shorts\"])",
     "instagram.com##a[href=\"/reels/\"]",
-    "instagram.com##div[role=\"link\"]:has(> a[href*=\"/reel/\"])",
-    "instagram.com##article:has(a[href*=\"/reel/\"])",
+    "instagram.com##div[role=\"link\"]:has(> a[href^=\"/reel\"])",
+    "instagram.com##main article:has(a[href^=\"/reel\"])",
     "facebook.com##div[aria-label=\"Reels\"]",
     "facebook.com##div[role=\"navigation\"] a[href*=\"/reel/\"]",
     "facebook.com##div[data-pagelet=\"Reels\"]"


### PR DESCRIPTION
Reported in https://github.com/ghostery/ghostery-extension/pull/3366#pullrequestreview-4356324400: after opening a reel on Instagram, the whole page becomes unclickable when the "Short Video Feeds" distraction option is enabled.

The previous `article:has(a[href*="/reel/"])` filter was too broad — it also matched the reel viewer article when opened, causing it to be hidden and the page to become unresponsive. The filter is now scoped to `main article` to avoid matching the viewer overlay, and the href selector is changed from `*="/reel/"` (substring) to `^="/reel"` (starts-with) to also correctly match reel feed items whose anchors point to `/reels/` (the reels hub URL) rather than a specific reel URL. The same starts-with fix is applied to the `div[role="link"]` filter.