### PR TITLE
fix(logger): guard against undefined filter in filter-matched handler

### DIFF
--- a/src/background/logger.js
+++ b/src/background/logger.js
@@ -67,8 +67,14 @@ chrome.runtime.onConnect.addListener(async (port) => {
       const organizations = await getOrganizations();
       const engine = engines.get(engines.MAIN_ENGINE);
 
-      const logFilterMatched = function ({ filter }, { url, request, filterType, callerContext }) {
-        if (filterType === FilterType.COSMETIC && filter.isScriptInject()) {
+      const logFilterMatched = function (
+        { filter, exception },
+        { url, request, filterType, callerContext },
+      ) {
+        const matched = filter || exception;
+        if (!matched) return;
+
+        if (filter && filterType === FilterType.COSMETIC && filter.isScriptInject()) {
           filter = String(filter);
           const scriptInjectArgumentIndex = filter.indexOf('+js(') + 4; /* '+js('.length */
           filter =
@@ -76,7 +82,7 @@ chrome.runtime.onConnect.addListener(async (port) => {
             decodeURIComponent(filter.slice(scriptInjectArgumentIndex, -1)) +
             ')';
         } else {
-          filter = String(filter);
+          filter = String(matched);
         }
 
         let data = { filter, filterType, url, tabId: callerContext?.tabId };


### PR DESCRIPTION
The adblocker engine emits `filter-matched` with `filter: undefined` when a `$ghide` / `$shide` exception applies (only the exception is set). The logger's handler called `filter.isScriptInject()` unconditionally and threw `TypeError: Cannot read properties of undefined (reading 'isScriptInject')`.

The handler now also destructures `exception` and stringifies whichever side matched, so exception-only events are logged instead of crashing.