### PR TITLE
fix(custom-filters): guard against DNR dynamic and regex rule limits

### DIFF
--- a/src/background/custom-filters.js
+++ b/src/background/custom-filters.js
@@ -12,7 +12,12 @@
 import { store } from 'hybrids';
 import { parseFilters, FilterType } from '@ghostery/adblocker';
 
-import { CUSTOM_FILTERS_ID_RANGE, getDynamicRulesIds } from '/utils/dnr.js';
+import {
+  CUSTOM_FILTERS_ID_RANGE,
+  CUSTOM_FILTERS_MAX_DYNAMIC_RULES,
+  CUSTOM_FILTERS_MAX_REGEX_RULES,
+  getDynamicRulesIds,
+} from '/utils/dnr.js';
 import convert from '/utils/dnr-converter.js';
 import * as engines from '/utils/engines.js';
 import * as OptionsObserver from '/utils/options-observer.js';
@@ -46,6 +51,22 @@ function encodeScriptletArguments(filter) {
 }
 
 async function updateDNRRules(dnrRules) {
+  if (dnrRules.length > CUSTOM_FILTERS_MAX_DYNAMIC_RULES) {
+    throw new Error(
+      `Too many custom network filters: ${dnrRules.length} exceeds the maximum of ${CUSTOM_FILTERS_MAX_DYNAMIC_RULES} dynamic rules.`,
+    );
+  }
+
+  const regexRulesCount = dnrRules.reduce(
+    (count, rule) => count + (rule.condition?.regexFilter ? 1 : 0),
+    0,
+  );
+  if (regexRulesCount > CUSTOM_FILTERS_MAX_REGEX_RULES) {
+    throw new Error(
+      `Too many custom regex network filters: ${regexRulesCount} exceeds the maximum of ${CUSTOM_FILTERS_MAX_REGEX_RULES} regex rules.`,
+    );
+  }
+
   const removeRuleIds = await getDynamicRulesIds(CUSTOM_FILTERS_ID_RANGE);
 
   if (removeRuleIds.length) {
@@ -198,7 +219,12 @@ export async function updateCustomFilters(input, options) {
         return filterIdToRawLine.get(filter.getId());
       });
     const { rules, errors } = await convert(acceptedNetworkFilters);
-    result.dnrRules = await updateDNRRules(rules);
+    try {
+      result.dnrRules = await updateDNRRules(rules);
+    } catch (e) {
+      result.dnrRules = [];
+      result.errors.push(e.message);
+    }
 
     if (errors?.length) {
       result.errors.push(...errors);

--- a/src/utils/dnr.js
+++ b/src/utils/dnr.js
@@ -11,18 +11,31 @@
 
 // Dynamic Rules ID Ranges and Priorities
 
+export const PAUSED_RULE_PRIORITY = 10_000_000;
 export const PAUSED_ID_RANGE = { start: 1, end: 1_000_000 };
+
 export const CUSTOM_FILTERS_ID_RANGE = { start: 1_000_000, end: 2_000_000 };
+// Reserved budget for non-custom-filter dynamic rules (fixes, exceptions,
+// distractions, redirect protection, paused, GPC, etc.). Fixes alone is the
+// largest contributor (~2000 rules).
+// Maximum number of dynamic rules custom filters may add.
+export const CUSTOM_FILTERS_MAX_DYNAMIC_RULES =
+  globalThis.chrome?.declarativeNetRequest?.MAX_NUMBER_OF_DYNAMIC_RULES - 5_000;
+
+// Reserved budget for regex rules used by static rulesets and dynamic fixes.
+// The dynamic fixes ruleset mirrors the static one, so they are counted once.
+// Current maximum across all enabled static rulesets is ~370 regex rules.
+// Maximum number of regex rules custom filters may add.
+export const CUSTOM_FILTERS_MAX_REGEX_RULES =
+  globalThis.chrome?.declarativeNetRequest?.MAX_NUMBER_OF_REGEX_RULES - 500;
+
+export const EXCEPTIONS_RULE_PRIORITY = 2_000_000;
 export const EXCEPTIONS_ID_RANGE = { start: 2_000_000, end: 3_000_000 };
+
 export const FIXES_ID_RANGE = { start: 3_000_000, end: 4_000_000 };
-export const REDIRECT_PROTECTION_ID_RANGE = {
-  start: 4_000_000,
-  end: 5_000_000,
-};
-export const REDIRECT_PROTECTION_EXCEPTIONS_ID_RANGE = {
-  start: 5_000_000,
-  end: 6_000_000,
-};
+
+export const REDIRECT_PROTECTION_ID_RANGE = { start: 4_000_000, end: 5_000_000 };
+export const REDIRECT_PROTECTION_EXCEPTIONS_ID_RANGE = { start: 5_000_000, end: 6_000_000 };
 
 export const GPC_RULE_ID = 6_000_000;
 export const GPC_RULE_PRIORITY = 40_000;
@@ -30,9 +43,6 @@ export const GPC_RULE_PRIORITY = 40_000;
 export const DISTRACTIONS_ID_RANGE = { start: 6_000_001, end: 7_000_000 };
 
 export const REDIRECT_PROTECTION_SESSION_OFFSET = 100_000;
-
-export const PAUSED_RULE_PRIORITY = 10_000_000;
-export const EXCEPTIONS_RULE_PRIORITY = 2_000_000;
 export const MAX_RULE_PRIORITY = 1_073_741_823;
 
 export const ALL_RESOURCE_TYPES = [

--- a/tests/e2e/spec/custom-filters.spec.js
+++ b/tests/e2e/spec/custom-filters.spec.js
@@ -15,10 +15,28 @@ import {
   setAdditionalFiltersToggle,
   setCustomFilters,
   disableCustomFilters,
+  waitForIdleBackgroundTasks,
   switchFrame,
   PAGE_DOMAIN,
   PAGE_URL,
 } from '../utils.js';
+
+async function setCustomFiltersInput(lines) {
+  await setAdditionalFiltersToggle('custom-filters', true);
+
+  const input = await getExtensionElement('input:custom-filters');
+  await browser.execute(
+    (el, value) => {
+      el.value = value;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    },
+    input,
+    lines.join('\n'),
+  );
+
+  await getExtensionElement('button:custom-filters:save').click();
+  await waitForIdleBackgroundTasks();
+}
 
 describe('Custom Filters', function () {
   before(enableExtension);
@@ -135,6 +153,24 @@ describe('Custom Filters', function () {
 
       const text = await errors.getText();
       await expect(text).toContain('Filter not supported');
+    });
+
+    it('shows error when exceeding max dynamic rules', async function () {
+      const lines = Array.from({ length: 25001 }, (_, i) => `||f${i}.invalid^`);
+      await setCustomFiltersInput(lines);
+
+      const errors = await getExtensionElement('component:custom-filters:errors');
+      const text = await errors.getText();
+      await expect(text).toContain('Too many custom network filters');
+    });
+
+    it('shows error when exceeding max regex rules', async function () {
+      const lines = Array.from({ length: 501 }, (_, i) => `/rx${i}x.invalid/`);
+      await setCustomFiltersInput(lines);
+
+      const errors = await getExtensionElement('component:custom-filters:errors');
+      const text = await errors.getText();
+      await expect(text).toContain('Too many custom regex network filters');
     });
   }
 


### PR DESCRIPTION
Chrome's `declarativeNetRequest` API enforces hard limits on dynamic rules (`MAX_NUMBER_OF_DYNAMIC_RULES`) and regex rules (`MAX_NUMBER_OF_REGEX_RULES`). Without guards, exceeding these limits causes silent failures when saving custom filters.

This adds runtime validation in `updateDNRRules()` before calling the API. Two constants derived from live API values are added to `src/utils/dnr.js`: `CUSTOM_FILTERS_MAX_DYNAMIC_RULES` (`MAX_NUMBER_OF_DYNAMIC_RULES − 5000`) reserves budget for all other dynamic rule consumers (fixes, exceptions, distractions, redirect protection, GPC, paused), and `CUSTOM_FILTERS_MAX_REGEX_RULES` (`MAX_NUMBER_OF_REGEX_RULES − 500`) reserves budget for regex rules from static rulesets (currently up to ~370). When either limit is exceeded, a descriptive error is thrown and caught in `updateCustomFilters()`, pushed into `result.errors`, and surfaced to the user via the existing error list in the settings page.

**Note on a related Edge/Chromium bug:** During this work, a reported issue was investigated where `getAvailableStaticRuleCount()` did not reset after manually uninstalling the extension on Edge on a clean profile — causing the subsequent reinstall to fail to enable static rulesets. The root cause is in `GlobalRulesTracker`: the global quota is tracked in-memory and re-initialized from prefs at browser start; if Edge wipes extension prefs *before* `OnExtensionUninstalled` fires, `ClearExtensionAllocation` cannot find the stored allocation and the in-memory counter is never decremented, persisting until the next browser restart. No specific upstream fix was found in Chromium source (`global_rules_tracker.cc` has had no functional changes since its 2020 introduction). The issue is no longer reproducible in current browser versions, suggesting it may have been silently fixed in a browser update, but we still receive error reports from affected users — likely on older Edge versions or in specific profile states. 