### PR TITLE
fix(managed-config): unify trustedDomains managed config model

### DIFF
--- a/src/background/paused.js
+++ b/src/background/paused.js
@@ -13,7 +13,7 @@ import { store } from 'hybrids';
 
 import Options, { GLOBAL_PAUSE_ID, MODE_DEFAULT } from '/store/options.js';
 import * as OptionsObserver from '/utils/options-observer.js';
-import ManagedConfig, { TRUSTED_DOMAINS_NONE_ID } from '/store/managed-config';
+import ManagedConfig from '/store/managed-config';
 
 import { getDynamicRules, PAUSED_ID_RANGE, PAUSED_RULE_PRIORITY } from '/utils/dnr.js';
 
@@ -79,8 +79,7 @@ OptionsObserver.addListener(async function pausedSites(options, lastOptions) {
       (lastOptions && options.mode !== lastOptions.mode) ||
       // Managed mode can update the rules at any time - so we need to update
       // the rules on SW restart even if the paused state hasn't changed
-      (!lastOptions &&
-        (await store.resolve(ManagedConfig)).trustedDomains[0] !== TRUSTED_DOMAINS_NONE_ID))
+      (!lastOptions && (await store.resolve(ManagedConfig)).trustedDomains.enabled))
   ) {
     const currentRules = await getDynamicRules(PAUSED_ID_RANGE);
     const hostnames = Object.keys(options.paused);

--- a/src/store/managed-config.js
+++ b/src/store/managed-config.js
@@ -13,17 +13,13 @@ import { store } from 'hybrids';
 
 import { isOpera, isWebkit } from '/utils/browser-info.js';
 
-export const TRUSTED_DOMAINS_NONE_ID = '<none>';
-
 const ManagedConfig = {
   disableOnboarding: false,
   disableUserControl: false,
   disableUserAccount: false,
   disableTrackersPreview: false,
 
-  // TODO: Update the structure of `trustedDomains` as is with `customFilters`
-  // to have `enabled` flag and `domains` array
-  trustedDomains: [TRUSTED_DOMAINS_NONE_ID],
+  trustedDomains: { enabled: false, domains: [String] },
   customFilters: { enabled: false, filters: [String] },
 
   disableNotifications: (config) => config.disableOnboarding || config.disableUserControl,
@@ -31,7 +27,7 @@ const ManagedConfig = {
   disableModes: (config) =>
     config.disableOnboarding ||
     config.disableUserControl ||
-    config.trustedDomains[0] !== TRUSTED_DOMAINS_NONE_ID ||
+    config.trustedDomains.enabled ||
     config.customFilters.enabled,
 
   [store.connect]: async () => {
@@ -64,7 +60,14 @@ const ManagedConfig = {
         }
       }
 
-      // Translate `customFilters` storage.managed key (an array) to model structure
+      // Translate array storage.managed keys to model structure
+      if (managedConfig.trustedDomains) {
+        managedConfig.trustedDomains = {
+          enabled: true,
+          domains: managedConfig.trustedDomains,
+        };
+      }
+
       if (managedConfig.customFilters) {
         managedConfig.customFilters = {
           enabled: true,

--- a/src/store/options.js
+++ b/src/store/options.js
@@ -16,7 +16,7 @@ import { isOpera, isSafari } from '/utils/browser-info.js';
 import { findParentDomain } from '/utils/domains.js';
 
 import CustomFilters from './custom-filters.js';
-import ManagedConfig, { TRUSTED_DOMAINS_NONE_ID } from './managed-config.js';
+import ManagedConfig from './managed-config.js';
 import Notification from './notification.js';
 
 const UPDATE_OPTIONS_ACTION_NAME = 'updateOptions';
@@ -277,10 +277,9 @@ async function manage(options) {
   }
 
   // Apply trusted domains if they are configured
-  // (`trustedDomains` is empty or contain real domains)
-  if (managed.trustedDomains[0] !== TRUSTED_DOMAINS_NONE_ID) {
+  if (managed.trustedDomains.enabled) {
     options.paused ||= {};
-    managed.trustedDomains.forEach((domain) => {
+    managed.trustedDomains.domains.forEach((domain) => {
       options.paused[domain] = { revokeAt: 0, managed: true };
     });
   }


### PR DESCRIPTION
Managed policy handling for trusted domains was using an array sentinel pattern that diverged from the structured managed config model and required special-case checks in consumers. This could make pause rule initialization harder to reason about on service worker restart.

This change refactors trusted domains in managed config to use an `{ enabled, domains }` shape, aligned with how custom filters are represented. It updates the managed storage translation step to convert legacy array input into the structured object and adjusts consumers in options and paused background logic to use the enabled/domains fields directly. The result removes sentinel-specific branching and keeps managed mode behavior consistent across startup and options application.