### PR TITLE
fix(config): update browser filter to use array instead of string

### DIFF
--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -61,8 +61,8 @@ export function filter(item) {
 
     // Browser check
     // Values from getBrowser() method
-    if (check && typeof item.filter.browser === 'string') {
-      check = getBrowser().name === item.filter.browser;
+    if (check && Array.isArray(item.filter.browser)) {
+      check = item.filter.browser.includes(getBrowser().name);
     }
 
     const extensionVersion = chrome.runtime.getManifest().version;

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -85,19 +85,19 @@ describe('Remote config', () => {
     });
 
     it('should return true if browser matches', () => {
-      assert.deepEqual(filter({ filter: { browser: 'chrome' } }), true);
+      assert.deepEqual(filter({ filter: { browser: ['chrome'] } }), true);
     });
 
     it('should return false if browser does not match', () => {
-      assert.deepEqual(filter({ filter: { browser: 'firefox' } }), false);
+      assert.deepEqual(filter({ filter: { browser: ['firefox'] } }), false);
     });
 
     it('should return true for firefox browser when set', () => {
       global.__CHROMIUM__ = false;
       global.__FIREFOX__ = true;
 
-      assert.deepEqual(filter({ filter: { browser: 'firefox' } }), true);
-      assert.deepEqual(filter({ filter: { browser: 'chrome' } }), false);
+      assert.deepEqual(filter({ filter: { browser: ['firefox'] } }), true);
+      assert.deepEqual(filter({ filter: { browser: ['chrome'] } }), false);
     });
 
     it('should return true if minVersion matches exactly', () => {


### PR DESCRIPTION
The `filter.browser` field in remote config was previously accepted as a string, while `filter.platform` already supports an array. Since the browser filter is not actively used on flags, this is a good moment to align both fields to the same array-based API.

This change updates the `filter()` function in `src/utils/config.js` to check `Array.isArray(item.filter.browser)` and use `.includes()` for matching, exactly mirroring the platform filter logic. Unit tests in `config.test.js` are updated accordingly to pass arrays instead of strings.