### PR TITLE
feat(errors): expand Sentry tags & update once parameter

### DIFF
--- a/src/store/errors.js
+++ b/src/store/errors.js
@@ -11,7 +11,7 @@
 import { store } from 'hybrids';
 
 const Errors = {
-  onceIds: store.record(false),
+  onceIds: store.record(0),
   [store.connect]: {
     async get() {
       const { errors = {} } = await chrome.storage.local.get('errors');

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -55,7 +55,12 @@ const config = {
 Sentry.init(config);
 
 getBrowserInfo().then(
-  ({ token }) => Sentry.setTag('ua', token),
+  ({ token, version, os, osVersion }) => {
+    Sentry.setTag('ua', token);
+    Sentry.setTag('uaVersion', version);
+    Sentry.setTag('os', os);
+    Sentry.setTag('osVersion', osVersion);
+  },
   // empty error handled for tests
   () => {},
 );
@@ -77,12 +82,13 @@ export async function captureException(error, { critical = false, once = false }
 
     const errors = await store.resolve(Errors);
 
-    // Already sent this error, skip it
-    if (errors.onceIds[id]) {
+    // Already sent this error within the last 24 hours, skip it
+    const DAY_MS = 24 * 60 * 60 * 1000;
+    if (Date.now() - errors.onceIds[id] < DAY_MS) {
       return;
     }
 
-    await store.set(errors, { onceIds: { [id]: true } });
+    await store.set(errors, { onceIds: { [id]: Date.now() } });
   }
 
   const newError = new Error(error.message);


### PR DESCRIPTION
This PR enhances error reporting by expanding the Sentry tags to include detailed browser and OS information (`ua`, `uaVersion`, `os`, `osVersion`).

Additionally, it changes the error reporting logic for the `once` option: errors are now reported at most once per day instead of once per lifetime. This ensures recurring issues are not missed while still reducing noise.

- Adds `os` and `osVersion` to Sentry tags
- Ensures legacy boolean values in error store are handled safely
- Updates logic to allow daily error reporting for repeated errors

Motivation: Improve diagnostics and allow recurring error visibility without flooding Sentry.

No breaking changes. Targets `main`.