### PR TITLE
fix(custom-filters): preserve scriptlet arguments at injection time

### DIFF
--- a/src/background/custom-filters.js
+++ b/src/background/custom-filters.js
@@ -30,6 +30,21 @@ function isTrustedScriptInject(scriptName) {
   );
 }
 
+function encodeScriptletArguments(filter) {
+  if (!filter.isScriptInject() || !filter.selector) {
+    return;
+  }
+
+  const parsed = filter.parseScript();
+  if (!parsed || !parsed.name) {
+    return;
+  }
+
+  const encodedArgs = parsed.args.map((arg) => encodeURIComponent(arg));
+  filter.selector = [parsed.name, ...encodedArgs].join(', ');
+  filter.scriptletDetails = undefined;
+}
+
 async function updateDNRRules(dnrRules) {
   const removeRuleIds = await getDynamicRulesIds(CUSTOM_FILTERS_ID_RANGE);
 
@@ -112,6 +127,10 @@ async function collectFilters(text, { isTrustedScriptInjectAllowed }) {
 
     return true;
   });
+
+  for (const filter of acceptedCosmeticFilters) {
+    encodeScriptletArguments(filter);
+  }
 
   /**
    * @type {Map<number, string>}

--- a/tests/e2e/spec/custom-filters.spec.js
+++ b/tests/e2e/spec/custom-filters.spec.js
@@ -137,4 +137,11 @@ describe('Custom Filters', function () {
       await expect(text).toContain('Filter not supported');
     });
   }
+
+  it('preserves escaped commas and special characters in scriptlet arguments', async function () {
+    await setCustomFilters([`${PAGE_DOMAIN}##+js(rpnt, h1, Test Page, 100%\\, escaped)`]);
+
+    await browser.url(PAGE_URL);
+    await expect($('h1')).toHaveText('100%, escaped');
+  });
 });


### PR DESCRIPTION
## Summary
- Encode scriptlet arguments for accepted custom cosmetic filters so they survive injection unchanged

## Test plan
- [ ] Add a custom cosmetic filter that injects a scriptlet with arguments containing commas, quotes, or other special characters
- [ ] Reload the affected page and confirm the scriptlet runs with the original argument values
- [ ] Verify existing custom filters without scriptlet arguments continue to work