### PR TITLE
fix(logger): prevent auto-translation

### DIFF
--- a/src/pages/logger/views/main.js
+++ b/src/pages/logger/views/main.js
@@ -174,7 +174,7 @@ export default {
         <ui-line></ui-line>
         ${__CHROMIUM__ &&
         html`
-          <div layout="row items:center gap padding:1:2 ::background:secondary">
+          <div translate="no" layout="row items:center gap padding:1:2 ::background:secondary">
             <ui-icon name="info" color="tertiary" layout="size:2"></ui-icon>
             <ui-text type="body-s" color="tertiary">
               In this browser, only cosmetic filters can be disabled at runtime. Network filtering


### PR DESCRIPTION
An informational note in the logger view — explaining that only cosmetic filters can be disabled at runtime in Chromium-based browsers — was missing the `translate="no"` attribute, causing browser auto-translation services to translate it even though it shouldn't be translated as it contains technical content.

Each call to the `html` tagged template literal in Hybrids creates a separate template function with its own root element. Because of this, the `translate="no"` attribute must be set on the root element of each individual template, rather than just on a parent — it does not propagate automatically to nested templates. This fix adds `translate="no"` to the root `div` of the conditional Chromium-only template in `src/pages/logger/views/main.js`, preventing the phrase from being incorrectly auto-translated.