### PR TITLE
fix(trackers-preview): add missing Mobile Google SERP selectors

### DIFF
--- a/src/content_scripts/trackers-preview.js
+++ b/src/content_scripts/trackers-preview.js
@@ -88,7 +88,9 @@ const SELECTORS = [
   '[data-hveid] div.yuRUbf > div > a',
   '[data-hveid] div.xpd a.cz3goc',
   '[data-hveid] > .xpd > div.kCrYT:first-child > a',
+  // Mobile Google
   '[data-hveid] div.OhZyZc > a',
+  '[data-hveid] div.fqvXQb > a',
   // Bing
   'li[data-id] h2 > a',
   'li[data-id] div.b_algoheader > a',


### PR DESCRIPTION
The Ghostery tracker wheel was not appearing next to results on Google SERP on iOS Safari because mobile-specific result link selectors were missing from the list.

This adds the `[data-hveid] div.fqvXQb > a` selector used in mobile Google search results and annotates the existing `[data-hveid] div.OhZyZc > a` selector with a "Mobile Google" comment for clarity, ensuring the tracker count indicator is correctly displayed on mobile and iOS Safari search result pages.

Fixes #3318.