### PR TITLE
fix(e2e): pin geckodriver to 0.36.0 to avoid installAddon regression

### DIFF
--- a/tests/e2e/wdio.conf.js
+++ b/tests/e2e/wdio.conf.js
@@ -24,6 +24,13 @@ import { readFileSync, cpSync, existsSync, rmSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { $, $$ } from '@wdio/globals';
 
+// Pin geckodriver to 0.36.0 — when installing an extension via base64
+// (installAddOn API), the file is removed from the filesystem after install,
+// causing issues like broken extension reload and content scripts not loading.
+// v0.37.0 made this worse; 0.36.0 is the last known good version.
+// TODO: check https://github.com/mozilla/geckodriver/issues/2248 and remove the pin once fixed.
+process.env.GECKODRIVER_VERSION = '0.36.0';
+
 import { setupTestPage } from './page/server.js';
 
 import { getExtensionPageURL, setExtensionBaseUrl, PAGE_PORT, PAGE_URL } from './utils.js';


### PR DESCRIPTION
## Summary

geckodriver 0.37.0 introduced a regression where extensions installed via the base64 `installAddon` WebDriver API have their temporary file removed after browser bootstrap. This causes:

- **Content scripts not injected** — the extension installs successfully but content scripts never run on matching pages
- **Extension reload fails** — clicking reload in `about:debugging` throws `NS_ERROR_FILE_NOT_FOUND`

Pinning to 0.36.0 via `GECKODRIVER_VERSION` env var (set at the top of `wdio.conf.js`) resolves both issues.

## Changes

- `tests/e2e/wdio.conf.js`: Set `process.env.GECKODRIVER_VERSION = '0.36.0'` with a TODO linking to the upstream bug report

## References

- Upstream geckodriver issue: https://github.com/mozilla/geckodriver/issues/2248