### PR TITLE
chore(deps): bump @duckduckgo/autoconsent, @ghostery/config, @types/chrome

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "10.5.45",
       "license": "GPL-3.0",
       "dependencies": {
-        "@duckduckgo/autoconsent": "^14.90.0",
+        "@duckduckgo/autoconsent": "^14.92.0",
         "@ghostery/adblocker": "^2.18.0",
         "@ghostery/adblocker-content": "^2.17.0",
         "@ghostery/adblocker-extended-selectors": "^2.17.0",
         "@ghostery/adblocker-webextension": "^2.18.0",
-        "@ghostery/config": "^0.0.12",
+        "@ghostery/config": "^0.0.14",
         "@ghostery/scriptlets": "github:ghostery/scriptlets",
         "@ghostery/urlfilter2dnr": "^2.0.4",
         "@github/relative-time-element": "^5.0.0",
@@ -32,7 +32,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/chrome": "^0.1.42",
+        "@types/chrome": "^0.1.43",
         "@wdio/browser-runner": "^9.27.2",
         "@wdio/cli": "^9.27.2",
         "@wdio/globals": "^9.27.0",
@@ -493,9 +493,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.90.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.90.0.tgz",
-      "integrity": "sha512-RQjiKY7Z4d52wUCBIun+WspDuKUSbCA2pQaaITyNUWD/TtWz1Rvnsdnl3DMsDwn6D3C5GAROhuJJ3GFE+HvlIg==",
+      "version": "14.92.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.92.0.tgz",
+      "integrity": "sha512-rP+pfRYhXigYyVfzHCRRVIstx0XIv926gzzmyzcSFcl/BlYKWiWbA8e+KKoAPTPYHRzSVRJen4xuJ7gviBd7BQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -1444,9 +1444,9 @@
       }
     },
     "node_modules/@ghostery/config": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@ghostery/config/-/config-0.0.12.tgz",
-      "integrity": "sha512-8ahPBfkD763iLx5ZsK7+KDg9kILskeQJQuks0p6X4LnGdX/kXETsxso21xWIswB1SnZTQDgM/2i4XnqMTlAX8Q==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@ghostery/config/-/config-0.0.14.tgz",
+      "integrity": "sha512-9qCIVgAOlNijFyxojXnZ5oBK4ylB5IfQXtwQtGB9OGtwylMJewjaa9jMigrPjP54YPZihHjP82BoVnTIhggHRQ==",
       "license": "MIT"
     },
     "node_modules/@ghostery/scriptlets": {
@@ -3682,9 +3682,9 @@
       }
     },
     "node_modules/@types/chrome": {
-      "version": "0.1.42",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.42.tgz",
-      "integrity": "sha512-tdT2roFqGecZZDjA9fUEAINb2STxSPifHMDvY6EfRjNRCjdrs/0FwKt5RCIA9MKMd1arAYZZL3nwEkp6ZLZu2w==",
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.43.tgz",
+      "integrity": "sha512-ukH/HhmR6ht+UTX3PLUWJxgJ/RQcK2Foj4lBzsF24SIWsXgqhGuXqjd8FFuwioPP7d/JUKLM4g8GZxw3F4HTcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@types/chrome": "^0.1.42",
+    "@types/chrome": "^0.1.43",
     "@wdio/browser-runner": "^9.27.2",
     "@wdio/cli": "^9.27.2",
     "@wdio/globals": "^9.27.0",
@@ -42,12 +42,12 @@
     "web-ext": "^10.3.0"
   },
   "dependencies": {
-    "@duckduckgo/autoconsent": "^14.90.0",
+    "@duckduckgo/autoconsent": "^14.92.0",
     "@ghostery/adblocker": "^2.18.0",
     "@ghostery/adblocker-content": "^2.17.0",
     "@ghostery/adblocker-extended-selectors": "^2.17.0",
     "@ghostery/adblocker-webextension": "^2.18.0",
-    "@ghostery/config": "^0.0.12",
+    "@ghostery/config": "^0.0.14",
     "@ghostery/scriptlets": "github:ghostery/scriptlets",
     "@ghostery/urlfilter2dnr": "^2.0.4",
     "@github/relative-time-element": "^5.0.0",


### PR DESCRIPTION
Bumps dependencies that were not covered by Dependabot's semver ranges:

| Package | From | To |
|---------|------|----|
| `@duckduckgo/autoconsent` | 14.90.0 | 14.92.0 |
| `@ghostery/config` | 0.0.12 | 0.0.14 |
| `@types/chrome` | 0.1.42 | 0.1.43 |