### PR TITLE
fix(ci): prevent duplicate artifact-upload runs on release PR

### DIFF
--- a/.github/workflows/artifact-upload.yml
+++ b/.github/workflows/artifact-upload.yml
@@ -8,6 +8,10 @@ on:
       - synchronize
       - labeled
 
+concurrency:
+  group: artifact-upload-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   artifact-upload:
     if: contains(github.event.pull_request.labels.*.name, 'package')


### PR DESCRIPTION
When `npm run release` opens the release PR with the `package` label, GitHub fires both the `opened` and `labeled` events at creation. Both pass the workflow's `package` label gate, so the `artifact-upload` workflow runs twice for the initial PR.

This adds a workflow-level `concurrency` group keyed on the PR number with `cancel-in-progress: true`, so the two near-simultaneous runs collapse into one and the redundant run is cancelled. Later `synchronize` pushes and labeling existing PRs continue to behave as before.