### PR TITLE
Show excepted filters correctly in the Logger

### DIFF
--- a/src/background/logger.js
+++ b/src/background/logger.js
@@ -120,7 +120,7 @@ chrome.runtime.onConnect.addListener(async (port) => {
 
       engine.on('filter-matched', logFilterMatched);
 
-      const offReplace = engines.onReplace(engines.MAIN_ENGINE, (nextEngine) => {
+      const unsubscribeSaveListener = engines.addSaveListener(engines.MAIN_ENGINE, (nextEngine) => {
         engine.unsubscribe('filter-matched', logFilterMatched);
         engine = nextEngine;
         engine.on('filter-matched', logFilterMatched);
@@ -131,7 +131,7 @@ chrome.runtime.onConnect.addListener(async (port) => {
         console.log('[logger] Disconnected logger with id', port.sender.tab.id);
 
         if (ports.size === 0) {
-          offReplace();
+          unsubscribeSaveListener();
           engine.unsubscribe('filter-matched', logFilterMatched);
         }
       });

--- a/src/background/logger.js
+++ b/src/background/logger.js
@@ -65,7 +65,7 @@ chrome.runtime.onConnect.addListener(async (port) => {
       setup.pending && (await setup.pending);
 
       const organizations = await getOrganizations();
-      const engine = engines.get(engines.MAIN_ENGINE);
+      let engine = engines.get(engines.MAIN_ENGINE);
 
       const logFilterMatched = function (
         { filter, exception: matchedException },
@@ -120,11 +120,18 @@ chrome.runtime.onConnect.addListener(async (port) => {
 
       engine.on('filter-matched', logFilterMatched);
 
+      const offReplace = engines.onReplace(engines.MAIN_ENGINE, (nextEngine) => {
+        engine.unsubscribe('filter-matched', logFilterMatched);
+        engine = nextEngine;
+        engine.on('filter-matched', logFilterMatched);
+      });
+
       port.onDisconnect.addListener(() => {
         ports.delete(port);
         console.log('[logger] Disconnected logger with id', port.sender.tab.id);
 
         if (ports.size === 0) {
+          offReplace();
           engine.unsubscribe('filter-matched', logFilterMatched);
         }
       });

--- a/src/pages/logger/views/main.js
+++ b/src/pages/logger/views/main.js
@@ -227,8 +227,17 @@ export default {
                 >
                   <ui-text type="body-s" color="tertiary"> ${log.time} </ui-text>
                   <ui-text type="body-s" color="secondary"> ${log.typeLabel} </ui-text>
-                  <ui-text ellipsis>${log.filter}</ui-text>
+                  <ui-text ellipsis color="${log.exception ? 'tertiary' : 'primary'}"
+                    >${log.filter}</ui-text
+                  >
                   <div layout="row gap:0.5">
+                    ${log.exception &&
+                    html`<ui-icon
+                      name="pause"
+                      color="tertiary"
+                      layout="size:2"
+                      title="Exception — filter matched but not applied"
+                    ></ui-icon>`}
                     ${log.blocked &&
                     html`<ui-icon name="block-s" color="danger-primary" layout="size:2"></ui-icon>`}
                     ${log.modified &&

--- a/src/utils/engines.js
+++ b/src/utils/engines.js
@@ -37,6 +37,7 @@ export const TRACKERDB_ENGINE = 'trackerdb';
 export const DISTRACTIONS_ENGINE = 'distractions';
 
 const engines = new Map();
+const engineReplaceListeners = new Map();
 
 export function isPersistentEngine(name) {
   return (
@@ -76,6 +77,23 @@ function loadFromMemory(name) {
 
 function saveToMemory(name, engine) {
   engines.set(name, engine);
+
+  const listeners = engineReplaceListeners.get(name);
+  if (listeners) {
+    for (const callback of listeners) callback(engine);
+  }
+}
+
+// The in-memory engine instance is replaced (not mutated) on reload, so holders must re-bind.
+export function onReplace(name, callback) {
+  let listeners = engineReplaceListeners.get(name);
+  if (!listeners) {
+    listeners = new Set();
+    engineReplaceListeners.set(name, listeners);
+  }
+  listeners.add(callback);
+
+  return () => listeners.delete(callback);
 }
 
 const DB_NAME = registerDatabase('engines');

--- a/src/utils/engines.js
+++ b/src/utils/engines.js
@@ -37,7 +37,7 @@ export const TRACKERDB_ENGINE = 'trackerdb';
 export const DISTRACTIONS_ENGINE = 'distractions';
 
 const engines = new Map();
-const engineReplaceListeners = new Map();
+const saveListeners = new Map();
 
 export function isPersistentEngine(name) {
   return (
@@ -78,18 +78,18 @@ function loadFromMemory(name) {
 function saveToMemory(name, engine) {
   engines.set(name, engine);
 
-  const listeners = engineReplaceListeners.get(name);
+  const listeners = saveListeners.get(name);
   if (listeners) {
     for (const callback of listeners) callback(engine);
   }
 }
 
 // The in-memory engine instance is replaced (not mutated) on reload, so holders must re-bind.
-export function onReplace(name, callback) {
-  let listeners = engineReplaceListeners.get(name);
+export function addSaveListener(name, callback) {
+  let listeners = saveListeners.get(name);
   if (!listeners) {
     listeners = new Set();
-    engineReplaceListeners.set(name, listeners);
+    saveListeners.set(name, listeners);
   }
   listeners.add(callback);
 


### PR DESCRIPTION
The Logger rendered matched-but-excepted filters identically to applied ones, so an excepted filter (e.g. a scriptlet disabled by an exception) looked like it was still active. It also silently stopped logging once the main engine was rebuilt — for example after saving custom filters — because it stayed subscribed to the stale engine instance.

## Changes

- The Logger now flags exceptions: the filter text is dimmed and a pause icon with an explanatory tooltip is shown next to it, based on the exception state reported by the filter matching.
- `engines` exposes `addSaveListener()`, which notifies subscribers whenever an engine instance is replaced in memory. The background logger uses it to re-bind its `filter-matched` subscription to the new main engine, so logging survives engine rebuilds.

## Test plan

1. Open the Logger and visit a page where filters match — matched filters appear as before.
2. Add an exception for one of the matched filters (e.g. a `#@#` or scriptlet exception in custom filters) and reload the page — the excepted filter shows up dimmed with a pause icon instead of looking applied.
3. Keep the Logger open, save custom filters (this rebuilds the engine), then reload the page — new entries keep appearing in the Logger.
