### PR TITLE
fix(context-menu): disable context menu when `disableUserControl` is set

### DIFF
--- a/src/store/options.js
+++ b/src/store/options.js
@@ -253,6 +253,7 @@ async function manage(options) {
 
   if (managed.disableUserControl === true) {
     options.sync = false;
+    options.contextMenu = false;
 
     // Clear out the paused state, to overwrite with the current managed state
     options.paused = {};


### PR DESCRIPTION
When managed storage sets `disableUserControl` to `true`, the extension should restrict all user-facing controls, including the context menu. Previously, only sync and paused state were being disabled in this managed mode, leaving the context menu accessible.

This fix adds `options.contextMenu = false` alongside the existing `options.sync = false` assignment in the `manage` function within `src/store/options.js`, ensuring the context menu is consistently disabled when administrators configure the extension to disallow user control.