### PR TITLE
feat(telemetry): capture install reason

### DIFF
--- a/src/background/telemetry/index.js
+++ b/src/background/telemetry/index.js
@@ -91,8 +91,6 @@ chrome.runtime.onInstalled.addListener((details) => {
     if (!runner) return;
 
     await runner.setInstallReason(details.reason);
-    // Refresh so the uninstall URL also carries the reason for churn analysis
-    runner.setUninstallUrl();
   })();
 });
 

--- a/src/background/telemetry/index.js
+++ b/src/background/telemetry/index.js
@@ -85,6 +85,17 @@ OptionsObserver.addListener(async function telemetry({ terms, feedback }, lastOp
   }
 });
 
+chrome.runtime.onInstalled.addListener((details) => {
+  (async () => {
+    setup.pending && (await setup.pending);
+    if (!runner) return;
+
+    await runner.setInstallReason(details.reason);
+    // Refresh so the uninstall URL also carries the reason for churn analysis
+    runner.setUninstallUrl();
+  })();
+});
+
 export async function recordSerpVisit() {
   setup.pending && (await setup.pending);
   if (!runner) return;

--- a/src/background/telemetry/metrics.js
+++ b/src/background/telemetry/metrics.js
@@ -127,6 +127,13 @@ export default class Metrics {
     await this.saveStorage(this.storage);
   }
 
+  async setInstallReason(reason) {
+    // Freeze the reason once install has pinged so later update events don't overwrite it.
+    if (this.storage.install_all || this.storage.installReason === reason) return;
+    this.storage.installReason = reason;
+    await this.saveStorage(this.storage);
+  }
+
   /**
    * Prepare data and send telemetry pings.
    * @param {string} type    type of the telemetry ping
@@ -202,7 +209,9 @@ export default class Metrics {
       // Onboarding complete
       buildQueryPair('oc', this.storage.install_complete_all ? '1' : '0') +
       // Feedback state
-      buildQueryPair('hw', conf.options.terms && conf.options.feedback ? '1' : '0');
+      buildQueryPair('hw', conf.options.terms && conf.options.feedback ? '1' : '0') +
+      // 'na' here flags an install ping with no fresh-install lifecycle event
+      buildQueryPair('rsn', this.storage.installReason || 'na');
 
     if (type !== 'uninstall') {
       metrics_url +=

--- a/src/pages/settings/components/devtools.js
+++ b/src/pages/settings/components/devtools.js
@@ -215,6 +215,12 @@ export default {
                           <span data-qa="text:install-date">${storage.installDate || 'N/A'}</span>
                         </ui-text>
                         <ui-text type="body-m" color="secondary">
+                          <ui-text type="label-m">Install reason:</ui-text>
+                          <span data-qa="text:install-reason"
+                            >${storage.installReason || 'N/A'}</span
+                          >
+                        </ui-text>
+                        <ui-text type="body-m" color="secondary">
                           <ui-text type="label-m">Source:</ui-text>
                           <span data-qa="text:utm-source">${storage.utm_source || 'N/A'}</span>
                         </ui-text>


### PR DESCRIPTION
Tags telemetry pings with the `chrome.runtime.onInstalled` reason (`ir` param) so install events can be reconciled against Chrome Web Store counts, separating genuine fresh installs from storage-reset/bot anomalies.

## Test plan
- Install in a clean profile and complete onboarding.
- In Settings, reveal Developer tools (click the version 5+ times) and confirm **Install reason** shows `install`.