### PR TITLE
feat(devtools): add session toggles to disable individual filtering subsystems

### DIFF
--- a/src/background/adblocker/cosmetics.js
+++ b/src/background/adblocker/cosmetics.js
@@ -16,6 +16,7 @@ import { FLAG_SUBFRAME_SCRIPTING } from '@ghostery/config';
 import { resolveFlag } from '/store/config.js';
 import Options, { getPausedDetails } from '/store/options.js';
 import DisabledFilters from '/store/disabled-filters.js';
+import FilteringDebug from '/store/filtering-debug.js';
 
 import * as engines from '/utils/engines.js';
 import * as OptionsObserver from '/utils/options-observer.js';
@@ -182,6 +183,12 @@ async function injectCosmetics(details, config) {
 
   const engine = engines.get(engines.MAIN_ENGINE);
 
+  const debug = store.get(FilteringDebug);
+  const debugReady = store.ready(debug);
+  const cssEnabled = !debugReady || debug.cosmeticsCSS;
+  const scriptletsEnabled = !debugReady || debug.cosmeticsScriptlets;
+  const extendedCSSEnabled = !debugReady || debug.cosmeticsExtendedCSS;
+
   let ancestors = undefined;
   if (SUBFRAME_SCRIPTING.enabled && typeof parentFrameId === 'number') {
     if (__FIREFOX__) {
@@ -242,7 +249,7 @@ async function injectCosmetics(details, config) {
     }
 
     if (isBootstrap) {
-      injectScriptlets(scriptFilters, hostname, details);
+      injectScriptlets(scriptletsEnabled ? scriptFilters : [], hostname, details);
     }
 
     if (scriptletsOnly) {
@@ -258,11 +265,11 @@ async function injectCosmetics(details, config) {
       getBaseRules: false,
     });
 
-    if (styles) {
+    if (styles && cssEnabled) {
       injectStyles(styles, details);
     }
 
-    if (extended && extended.length > 0) {
+    if (extended && extended.length > 0 && extendedCSSEnabled) {
       chrome.tabs
         .sendMessage(tabId, { action: 'evaluateExtendedSelectors', extended }, { frameId })
         // In case the frame is destroyed before the message is delivered, we can get an error
@@ -272,7 +279,7 @@ async function injectCosmetics(details, config) {
 
   // Global cosmetic filters (styles only)
   // Execution: bootstrap
-  if (isBootstrap) {
+  if (isBootstrap && cssEnabled) {
     const { styles } = engine.getCosmeticsFilters({
       domain,
       hostname,

--- a/src/background/adblocker/network.js
+++ b/src/background/adblocker/network.js
@@ -14,6 +14,7 @@ import { filterRequestHTML, updateResponseHeadersWithCSP } from '@ghostery/adblo
 
 import Options, { getPausedDetails } from '/store/options.js';
 import DisabledFilters from '/store/disabled-filters.js';
+import FilteringDebug from '/store/filtering-debug.js';
 
 import * as exceptions from '/utils/exceptions.js';
 import * as engines from '/utils/engines.js';
@@ -51,6 +52,12 @@ if (__FIREFOX__) {
   }
 
   function isMatchableRequest(details, request) {
+    // Network filtering disabled for the session (dev tools)
+    const debug = store.get(FilteringDebug);
+    if (store.ready(debug) && !debug.network) {
+      return false;
+    }
+
     // Extension context request
     if (
       (details.tabId === -1 && details.url.startsWith('moz-extension://')) ||

--- a/src/background/dnr.js
+++ b/src/background/dnr.js
@@ -11,8 +11,9 @@
 
 import { store } from 'hybrids';
 
-import { ENGINES, isGloballyPaused } from '/store/options.js';
+import Options, { ENGINES, isGloballyPaused } from '/store/options.js';
 import Resources from '/store/resources.js';
+import FilteringDebug from '/store/filtering-debug.js';
 
 import { FIXES_ID_RANGE, getDynamicRulesIds } from '/utils/dnr.js';
 import * as OptionsObserver from '/utils/options-observer.js';
@@ -71,7 +72,10 @@ if (__CHROMIUM__) {
   }
 
   function getIds(options) {
-    if (!options.terms || isGloballyPaused(options)) return [];
+    const debug = store.get(FilteringDebug);
+    const networkDisabled = store.ready(debug) && !debug.network;
+
+    if (!options.terms || isGloballyPaused(options) || networkDisabled) return [];
 
     const ids = ENGINES.reduce((acc, { name, key }) => {
       if (options[key] && DNR_RESOURCES.includes(name)) acc.push(name);
@@ -101,7 +105,7 @@ if (__CHROMIUM__) {
   // Ensure that DNR rulesets are equal to those from options.
   // eg. when web extension updates, the rulesets are reset
   // to the value from the manifest.
-  OptionsObserver.addListener(async function dnr(options, lastOptions) {
+  async function syncDNR(options, lastOptions) {
     const nextRulesetIds = getIds(options);
 
     if (
@@ -252,5 +256,13 @@ if (__CHROMIUM__) {
         captureException(e, { critical: true, once: true });
       }
     }
+  }
+
+  OptionsObserver.addListener(syncDNR);
+
+  // Re-sync rulesets when network filtering is toggled for the session (dev tools)
+  store.observe(FilteringDebug, async (_, debug, lastDebug) => {
+    if (!lastDebug || debug.network === lastDebug.network) return;
+    syncDNR(await store.resolve(Options));
   });
 }

--- a/src/background/never-consent/autoconsent.js
+++ b/src/background/never-consent/autoconsent.js
@@ -18,10 +18,17 @@ import { store } from 'hybrids';
 import Options, { getPausedDetails } from '/store/options.js';
 import Config from '/store/config.js';
 import Resources from '/store/resources.js';
+import FilteringDebug from '/store/filtering-debug.js';
 import { parseWithCache } from '/utils/request.js';
 
 async function initialize(msg, sender) {
-  const [options, config] = await Promise.all([store.resolve(Options), store.resolve(Config)]);
+  const [options, config, debug] = await Promise.all([
+    store.resolve(Options),
+    store.resolve(Config),
+    store.resolve(FilteringDebug),
+  ]);
+
+  if (!debug.autoconsent) return;
 
   if (options.terms && options.blockAnnoyances) {
     const { tab, frameId } = sender;

--- a/src/background/reporting/webrequest-reporter.js
+++ b/src/background/reporting/webrequest-reporter.js
@@ -15,6 +15,7 @@ import { ACTION_DISABLE_ANTITRACKING_MODIFICATION } from '@ghostery/config';
 
 import Options, { getPausedDetails } from '/store/options.js';
 import Config from '/store/config.js';
+import FilteringDebug from '/store/filtering-debug.js';
 
 import Request from '/utils/request.js';
 
@@ -40,6 +41,11 @@ if (chrome.webRequest) {
       isRequestAllowed: (state) => {
         const options = store.get(Options);
         const hostname = state.tabUrlParts.hostname;
+
+        const debug = store.get(FilteringDebug);
+        if (store.ready(debug) && !debug.antitracking) {
+          return true;
+        }
 
         return (
           !options.blockTrackers ||

--- a/src/pages/settings/components/devtools.js
+++ b/src/pages/settings/components/devtools.js
@@ -22,6 +22,7 @@ import Options from '/store/options.js';
 import Config from '/store/config.js';
 import Notification from '/store/notification.js';
 import Resources from '/store/resources.js';
+import FilteringDebug from '/store/filtering-debug.js';
 import * as telemetry from '/utils/telemetry.js';
 
 import { longDateFormatter } from '/ui/labels.js';
@@ -97,7 +98,8 @@ export default {
   config: store(Config),
   notifications: store([Notification]),
   resources: store(Resources),
-  render: ({ visible, counter, options, config, notifications, resources }) => html`
+  filteringDebug: store(FilteringDebug),
+  render: ({ visible, counter, options, config, notifications, resources, filteringDebug }) => html`
     <template layout="column gap:3 margin:top:2">
       ${(visible || counter > 5) &&
       html`
@@ -180,6 +182,62 @@ export default {
                 Ghostery specific fixes
               </settings-toggle>
             </div>
+            ${store.ready(filteringDebug) &&
+            html`
+              <settings-card static layout="column gap:3" translate="no">
+                <div layout="column gap:0.5">
+                  <ui-text type="headline-s">Filtering (this session)</ui-text>
+                  <ui-text type="body-xs" color="tertiary">
+                    Disable individual filtering capabilities for the current browser session. These
+                    overrides reset when the browser restarts.
+                  </ui-text>
+                </div>
+                <div layout="column gap">
+                  <settings-toggle
+                    value="${filteringDebug.network}"
+                    onchange="${html.set(filteringDebug, 'network')}"
+                    data-qa="toggle:filtering-debug:network"
+                  >
+                    Network filtering
+                  </settings-toggle>
+                  <settings-toggle
+                    value="${filteringDebug.cosmeticsCSS}"
+                    onchange="${html.set(filteringDebug, 'cosmeticsCSS')}"
+                    data-qa="toggle:filtering-debug:cosmetics-css"
+                  >
+                    Cosmetic filters (CSS)
+                  </settings-toggle>
+                  <settings-toggle
+                    value="${filteringDebug.cosmeticsScriptlets}"
+                    onchange="${html.set(filteringDebug, 'cosmeticsScriptlets')}"
+                    data-qa="toggle:filtering-debug:cosmetics-scriptlets"
+                  >
+                    Cosmetic filters (scriptlets)
+                  </settings-toggle>
+                  <settings-toggle
+                    value="${filteringDebug.cosmeticsExtendedCSS}"
+                    onchange="${html.set(filteringDebug, 'cosmeticsExtendedCSS')}"
+                    data-qa="toggle:filtering-debug:cosmetics-extended-css"
+                  >
+                    Cosmetic filters (extended CSS)
+                  </settings-toggle>
+                  <settings-toggle
+                    value="${filteringDebug.antitracking}"
+                    onchange="${html.set(filteringDebug, 'antitracking')}"
+                    data-qa="toggle:filtering-debug:antitracking"
+                  >
+                    Anti-tracking
+                  </settings-toggle>
+                  <settings-toggle
+                    value="${filteringDebug.autoconsent}"
+                    onchange="${html.set(filteringDebug, 'autoconsent')}"
+                    data-qa="toggle:filtering-debug:autoconsent"
+                  >
+                    Never-Consent (autoconsent)
+                  </settings-toggle>
+                </div>
+              </settings-card>
+            `}
             <settings-card static layout="column gap:3">
               ${store.ready(notifications) &&
               html`

--- a/src/store/filtering-debug.js
+++ b/src/store/filtering-debug.js
@@ -1,0 +1,46 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { store } from 'hybrids';
+
+const STORAGE_KEY = 'filteringDebug';
+
+// Session-scoped overrides; `true` means the capability is enabled (the default).
+const FilteringDebug = {
+  network: true,
+  cosmeticsCSS: true,
+  cosmeticsScriptlets: true,
+  cosmeticsExtendedCSS: true,
+  antitracking: true,
+  autoconsent: true,
+  [store.connect]: {
+    async get() {
+      if (!chrome.storage.session) return {};
+
+      const { [STORAGE_KEY]: values = {} } = await chrome.storage.session.get([STORAGE_KEY]);
+      return values;
+    },
+    async set(_, values) {
+      if (chrome.storage.session) {
+        await chrome.storage.session.set({ [STORAGE_KEY]: values });
+      }
+      return values;
+    },
+  },
+};
+
+chrome.storage.onChanged.addListener((changes, areaName) => {
+  if (areaName === 'session' && changes[STORAGE_KEY]) {
+    store.clear(FilteringDebug, false);
+  }
+});
+
+export default FilteringDebug;


### PR DESCRIPTION
Adds per-session dev-menu toggles to disable individual filtering subsystems: network filtering, CSS / scriptlet / extended-CSS cosmetics, anti-tracking, and autoconsent. Overrides are stored in `chrome.storage.session` and reset on browser restart.

## Test plan
- Open Settings → reveal the developer tools section (click the version number repeatedly).
- In the new "Filtering (this session)" card, turn off a toggle and confirm that capability stops applying on a reloaded page (e.g. disable cosmetics and verify hidden elements reappear).
- Restart the browser and confirm all toggles return to enabled.