### PR TITLE
Inject the "pauseState" also to the requestReporter

### DIFF
--- a/src/background/reporting/url-reporter.js
+++ b/src/background/reporting/url-reporter.js
@@ -19,22 +19,24 @@ import config from './config.js';
 import StorageLocal from './storage-chrome-local.js';
 import prefixedIndexedDBKeyValueStore from './storage-indexeddb.js';
 
+export const pauseState = {
+  getFilteringMode: () => store.get(Options).mode,
+  isHostnamePaused: (hostname) => !!getPausedDetails(store.get(Options), hostname),
+  connectHostnamePausingEvents: (notify) => {
+    chrome.runtime.onMessage.addListener((msg) => {
+      if (msg.action === 'reporting:updateHostnamePause') {
+        const { hostname, paused } = msg;
+        notify({ hostname, paused });
+      }
+    });
+  },
+};
+
 export default new UrlReporter({
   config: config.url,
   storage: new StorageLocal('reporting'),
   connectDatabase: prefixedIndexedDBKeyValueStore('reporting'),
   communication,
 
-  pauseState: {
-    getFilteringMode: () => store.get(Options).mode,
-    isHostnamePaused: (hostname) => !!getPausedDetails(store.get(Options), hostname),
-    connectHostnamePausingEvents: (notify) => {
-      chrome.runtime.onMessage.addListener((msg) => {
-        if (msg.action === 'reporting:updateHostnamePause') {
-          const { hostname, paused } = msg;
-          notify({ hostname, paused });
-        }
-      });
-    },
-  },
+  pauseState,
 });

--- a/src/background/reporting/webrequest-reporter.js
+++ b/src/background/reporting/webrequest-reporter.js
@@ -22,7 +22,7 @@ import { updateTabStats } from '../stats.js';
 
 import config from './config.js';
 import communication from './communication.js';
-import urlReporter from './url-reporter.js';
+import urlReporter, { pauseState } from './url-reporter.js';
 
 let webRequestReporter = null;
 
@@ -37,6 +37,7 @@ if (chrome.webRequest) {
       onMessageReady: urlReporter.forwardRequestReporterMessage.bind(urlReporter),
       countryProvider: urlReporter.countryProvider,
       trustedClock: communication.trustedClock,
+      pauseState,
       isRequestAllowed: (state) => {
         const options = store.get(Options);
         const hostname = state.tabUrlParts.hostname;


### PR DESCRIPTION
Used to extend the tp_events by adblocker information (pause + mode) like wtm.popularity does.

refs https://github.com/whotracksme/webextension-packages/pull/214