### PR TITLE
chore(deps): update all dependencies to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,17 @@
       "version": "10.5.48",
       "license": "GPL-3.0",
       "dependencies": {
-        "@duckduckgo/autoconsent": "^14.97.0",
+        "@duckduckgo/autoconsent": "^15.1.0",
         "@ghostery/adblocker": "^2.18.0",
         "@ghostery/adblocker-content": "^2.17.0",
         "@ghostery/adblocker-extended-selectors": "^2.17.0",
         "@ghostery/adblocker-webextension": "^2.18.0",
-        "@ghostery/config": "^0.0.14",
+        "@ghostery/config": "^0.0.15",
         "@ghostery/scriptlets": "github:ghostery/scriptlets",
         "@ghostery/urlfilter2dnr": "^2.0.4",
         "@github/relative-time-element": "^5.2.0",
-        "@sentry/browser": "^10.58.0",
-        "@whotracksme/reporting": "^10.1.0",
+        "@sentry/browser": "^10.60.0",
+        "@whotracksme/reporting": "^11.0.0",
         "apexsankey": "github:ghostery/apexsankey",
         "bowser": "^2.14.1",
         "csv-stringify": "^6.8.0",
@@ -28,11 +28,11 @@
         "lottie-web": "^5.13.0",
         "minixxh": "^0.3.1",
         "plotly.js-basic-dist": "^3.6.0",
-        "tldts-experimental": "^7.4.3"
+        "tldts-experimental": "^7.4.4"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/chrome": "^0.1.43",
+        "@types/chrome": "^0.2.0",
         "@wdio/browser-runner": "^9.29.0",
         "@wdio/cli": "^9.29.0",
         "@wdio/globals": "^9.27.0",
@@ -41,7 +41,7 @@
         "eslint": "^10.5.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.6",
-        "globals": "^17.5.0",
+        "globals": "^17.7.0",
         "license-report": "^6.8.5",
         "prettier": "^3.8.4",
         "vite": "^8.0.16",
@@ -493,9 +493,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.97.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.97.0.tgz",
-      "integrity": "sha512-fNgWlM3RIhEMu+cVKgViei5eurenBoYORtRzinoY2aoH+wOKbCSTclCNJU0CXQvvLlt4T3ZjKDfN+XmpCCPwjQ==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-15.1.0.tgz",
+      "integrity": "sha512-BirbOjabN7gDY0uqJMlR7X/whW3MP6g7DNgzeghFpudDqE5e7sU/ox7Q+9+zO9kBFsOYXUY6nUwKDEoWJjeAag==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -1454,9 +1454,9 @@
       }
     },
     "node_modules/@ghostery/config": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@ghostery/config/-/config-0.0.14.tgz",
-      "integrity": "sha512-9qCIVgAOlNijFyxojXnZ5oBK4ylB5IfQXtwQtGB9OGtwylMJewjaa9jMigrPjP54YPZihHjP82BoVnTIhggHRQ==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@ghostery/config/-/config-0.0.15.tgz",
+      "integrity": "sha512-EL4nog4ClHhdq5QYktzLgF8Z+WHzYvbKwxtKyJe1Xka0Q26RO2O7WDGoUgCBDAgNqOiV6CaxxDxZo2F1C1/nVw==",
       "license": "MIT"
     },
     "node_modules/@ghostery/scriptlets": {
@@ -3298,75 +3298,75 @@
       "license": "MIT"
     },
     "node_modules/@sentry/browser": {
-      "version": "10.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.58.0.tgz",
-      "integrity": "sha512-Syf6h6HDwC15fk86+/0ql8ebwwJFw2wp+lvOX9GfLTJVOqrSILCrtLKNI+f4v/3w8mzImsv9ttJGGbUugLNvcA==",
+      "version": "10.60.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.60.0.tgz",
+      "integrity": "sha512-20vzPKGrmupJPCaWd+soCOLkZRwKZxt0AVF4XGPNoGp7D7wVPRlHf+FWwVMx+rRRkahKupFefM2D9YoiUiBeag==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser-utils": "10.58.0",
-        "@sentry/core": "10.58.0",
-        "@sentry/feedback": "10.58.0",
-        "@sentry/replay": "10.58.0",
-        "@sentry/replay-canvas": "10.58.0"
+        "@sentry/browser-utils": "10.60.0",
+        "@sentry/core": "10.60.0",
+        "@sentry/feedback": "10.60.0",
+        "@sentry/replay": "10.60.0",
+        "@sentry/replay-canvas": "10.60.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/browser-utils": {
-      "version": "10.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.58.0.tgz",
-      "integrity": "sha512-TzXrhZq3Llj6qPSv0ZVG5N5c7C6qNN/aRKJXhq2LombJrLwiQrWdgizp7zdHA0FGlZ7F5YpyRA2JIpkhvrFqYA==",
+      "version": "10.60.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.60.0.tgz",
+      "integrity": "sha512-YhdPeMJnMaKVi5NQ2tD9RJ2AxU7cav5khmiMHFppmbP3I3Os2EHVaQjAVb6/ePAINr/d5mj5SxpnWmFX17iXsg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.58.0"
+        "@sentry/core": "10.60.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.58.0.tgz",
-      "integrity": "sha512-bkIbh2c6dzwhrWn/FGWu7j8hf6TAat2XxpkGM91LiN09fLYUXIMwcohVsXqze5l2cq35TnvqmSROAbRNr27GVw==",
+      "version": "10.60.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.60.0.tgz",
+      "integrity": "sha512-szN7ccOJAEaLb1BBQzCQhABGMTJmKNUk0G2sc7rWhajeXoZoMKIbNkI9RvJrFuV69cbad/d/BKGBjbpJhySAzw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/feedback": {
-      "version": "10.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.58.0.tgz",
-      "integrity": "sha512-VmIlR/0O0GXITbvgjPkQqd6yM0JDEk52WXv6Rs1kTdaIDU5h3Y64VDVN4MAbYVRHqSz7F1arjRRk2FkaKC7ZOQ==",
+      "version": "10.60.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.60.0.tgz",
+      "integrity": "sha512-RcGUgaI8yrIXunhNLpdNLsBUJIDvnEGDRmFhC5v0oMltoGtovrIqrEhPXEiSWQvNB0x4q33ejkLeJRJoSDOp2w==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.58.0"
+        "@sentry/core": "10.60.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "10.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.58.0.tgz",
-      "integrity": "sha512-EVasQNUenpwJksK9DI1TQ78YytpjLAhxn0UTiHqA3sU/s1fHK5XZdZJPr/9uEGedRoInIP0UIWmbOtOEX8HHDg==",
+      "version": "10.60.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.60.0.tgz",
+      "integrity": "sha512-j+w774BP1p+v/ga1hJAJSn0cXgTiB2VWwQCAxukF7AEXscny/OCXzTTsaPxdovw9kDHI641vKV+/yixLV2nKIQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser-utils": "10.58.0",
-        "@sentry/core": "10.58.0"
+        "@sentry/browser-utils": "10.60.0",
+        "@sentry/core": "10.60.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/replay-canvas": {
-      "version": "10.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.58.0.tgz",
-      "integrity": "sha512-ufFmaJ968DXGe6u9W/UqNVjCCTtAqT2bNtSu1jHAjIFFpWIuM80lcR33grK6SuGnFxceu5iJFaIW6JRyfbM0Sw==",
+      "version": "10.60.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.60.0.tgz",
+      "integrity": "sha512-mYyQRJbhRRaqUkRvkJZyqt9AWdomh4108LOAph1YJvV1jW7tKYPPFNAUveJd7YkYCyhUOtekN0DKNJveK802qA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.58.0",
-        "@sentry/replay": "10.58.0"
+        "@sentry/core": "10.60.0",
+        "@sentry/replay": "10.60.0"
       },
       "engines": {
         "node": ">=18"
@@ -3692,9 +3692,9 @@
       }
     },
     "node_modules/@types/chrome": {
-      "version": "0.1.43",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.43.tgz",
-      "integrity": "sha512-ukH/HhmR6ht+UTX3PLUWJxgJ/RQcK2Foj4lBzsF24SIWsXgqhGuXqjd8FFuwioPP7d/JUKLM4g8GZxw3F4HTcA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.2.0.tgz",
+      "integrity": "sha512-K/i7EKEVSpmyXXjE0ev5oASWBYMY6yM8LFSutG2PkM1DmxJUggZsoaTc0W1RsVwDDKrsZEjpHFAbqqxlRxGsSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5313,9 +5313,9 @@
       }
     },
     "node_modules/@whotracksme/reporting": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@whotracksme/reporting/-/reporting-10.1.0.tgz",
-      "integrity": "sha512-HMIUbtFZyu0oOH/S3yjeqeCtIGMzKjwTHDNhh1P93c+PmG0bkTE21M1XHHVc/7XBqAT6VhobIwGJvvKboOVbEA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@whotracksme/reporting/-/reporting-11.0.0.tgz",
+      "integrity": "sha512-kNsAfePQ6pMkjwVx7bN4+ASIx6RZX4RKYCz/RrorBTZ25jYulAjTDB6Eh24zoBY88IHYqeaA+WsWU/uoSkqfIA==",
       "license": "MPL-2.0",
       "workspaces": [
         "reporting",
@@ -9594,9 +9594,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15011,18 +15011,18 @@
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.3.tgz",
-      "integrity": "sha512-C7+TxJdmrhTA2fs1VvOcGrnFhK1qvOgYIAFJ0Q9L5GaoQ7QkR0TLm9ooXTgF4d4xgL6qm6qYtiYN3AX0DWwgBA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.4.tgz",
+      "integrity": "sha512-L1xvJQNZQFrhjyAFmFlOoijmd9lSOvK6bGs0+z8Nz91UCAIyVIShwOsPPStuQH4XCFwif5Hlmcr6DnEz7Ag7Xw==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.3"
+        "tldts-core": "^7.4.4"
       }
     },
     "node_modules/tldts-experimental/node_modules/tldts-core": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.3.tgz",
-      "integrity": "sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.4.tgz",
+      "integrity": "sha512-vwVLJVvvpslm7vqAH7+XNj/neA/Ynq7DT2EEcMuwc5YzN5XaMyRAqxwU+uX3azZ1FQtB2gvrvnLnAEkvYlVdfg==",
       "license": "MIT"
     },
     "node_modules/tmp": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@types/chrome": "^0.1.43",
+    "@types/chrome": "^0.2.0",
     "@wdio/browser-runner": "^9.29.0",
     "@wdio/cli": "^9.29.0",
     "@wdio/globals": "^9.27.0",
@@ -35,24 +35,24 @@
     "eslint": "^10.5.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",
-    "globals": "^17.5.0",
+    "globals": "^17.7.0",
     "license-report": "^6.8.5",
     "prettier": "^3.8.4",
     "vite": "^8.0.16",
     "web-ext": "^10.4.0"
   },
   "dependencies": {
-    "@duckduckgo/autoconsent": "^14.97.0",
+    "@duckduckgo/autoconsent": "^15.1.0",
     "@ghostery/adblocker": "^2.18.0",
     "@ghostery/adblocker-content": "^2.17.0",
     "@ghostery/adblocker-extended-selectors": "^2.17.0",
     "@ghostery/adblocker-webextension": "^2.18.0",
-    "@ghostery/config": "^0.0.14",
+    "@ghostery/config": "^0.0.15",
     "@ghostery/scriptlets": "github:ghostery/scriptlets",
     "@ghostery/urlfilter2dnr": "^2.0.4",
     "@github/relative-time-element": "^5.2.0",
-    "@sentry/browser": "^10.58.0",
-    "@whotracksme/reporting": "^10.1.0",
+    "@sentry/browser": "^10.60.0",
+    "@whotracksme/reporting": "^11.0.0",
     "apexsankey": "github:ghostery/apexsankey",
     "bowser": "^2.14.1",
     "csv-stringify": "^6.8.0",
@@ -61,7 +61,7 @@
     "lottie-web": "^5.13.0",
     "minixxh": "^0.3.1",
     "plotly.js-basic-dist": "^3.6.0",
-    "tldts-experimental": "^7.4.3"
+    "tldts-experimental": "^7.4.4"
   },
   "dataDependencies": {
     "redirect-resources": "737ccfe7d0c3dbe4c429986aeb9793bd6e559a875d52f1d643b3b87cbb6a945e",


### PR DESCRIPTION
Keeps all npm dependencies current. Several packages had fallen behind their latest releases and required range updates in package.json.

Updated packages: `@duckduckgo/autoconsent` 14.97.0→15.1.0, `@ghostery/config` 0.0.14→0.0.15, `@sentry/browser` 10.58.0→10.60.0, `@types/chrome` 0.1.43→0.2.0, `@whotracksme/reporting` 10.1.0→11.0.0, `globals` 17.6.0→17.7.0, and `tldts-experimental` 7.4.3→7.4.4. The package.json version ranges for packages with major/minor bumps were updated accordingly, and package-lock.json was regenerated.