### PR TITLE
Build: shorten long file paths to avoid windows limits

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -411,6 +411,69 @@ function mapPaths(paths) {
   }, {});
 }
 
+const PATH_LIMIT = 110;
+const MIN_SHORTEN_BASE = 6;
+
+function splitSegment(segment) {
+  const dotIdx = segment.lastIndexOf('.');
+  if (dotIdx <= 0) return { base: segment, ext: '' };
+  return { base: segment.slice(0, dotIdx), ext: segment.slice(dotIdx) };
+}
+
+let shortNameCounter = 0;
+const shortNameBySegment = new Map();
+const originalByOutput = new Map();
+
+// Rename the longest segments to short counter values: "0", "1", ..., "z", "10", ...
+function shortenPath(path, limit) {
+  const segments = path.split('/');
+
+  while (segments.join('/').length > limit) {
+    let longestIdx = -1;
+    let longestLength = MIN_SHORTEN_BASE;
+
+    for (let i = 0; i < segments.length; i++) {
+      const { base } = splitSegment(segments[i]);
+      if (base.length > longestLength) {
+        longestLength = base.length;
+        longestIdx = i;
+      }
+    }
+
+    if (longestIdx === -1) break;
+
+    const segment = segments[longestIdx];
+    let short = shortNameBySegment.get(segment);
+    if (short === undefined) {
+      short = (shortNameCounter++).toString(36) + splitSegment(segment).ext;
+      shortNameBySegment.set(segment, short);
+    }
+    segments[longestIdx] = short;
+  }
+
+  return segments.join('/');
+}
+
+// If a short name collides with a real file, append "-1", "-2", ... until unique.
+function makeUnique(path, original) {
+  const taken = (candidate) =>
+    originalByOutput.has(candidate) && originalByOutput.get(candidate) !== original;
+
+  if (!taken(path)) return path;
+
+  const slash = path.lastIndexOf('/');
+  const dir = path.slice(0, slash + 1);
+  const { base, ext } = splitSegment(path.slice(slash + 1));
+
+  let suffix = 1;
+  let candidate = `${dir}${base}-${suffix}${ext}`;
+  while (taken(candidate)) {
+    suffix += 1;
+    candidate = `${dir}${base}-${suffix}${ext}`;
+  }
+  return candidate;
+}
+
 const buildPromise = build({
   ...config,
   build: {
@@ -442,10 +505,26 @@ const buildPromise = build({
             .replace(/["<>:|]/g, '_')
             .replace(/node_modules/g, 'npm');
 
-          const path = name.replace(pwd, '');
-          if (path.length > 110 && !argv['no-filename-limit']) {
+          const hasPwd = name.startsWith(pwd);
+          const original = hasPwd ? name.slice(pwd.length) : name;
+          let relPath = original;
+
+          if (relPath.length > PATH_LIMIT) {
+            relPath = makeUnique(shortenPath(relPath, PATH_LIMIT), original);
+            name = hasPwd ? pwd + relPath : relPath;
+          }
+
+          const claimed = originalByOutput.get(relPath);
+          if (claimed !== undefined && claimed !== original) {
             throw new Error(
-              `Filename too long: ${path} (${path.length}) (pass --no-filename-limit to disable; for instance, "npm run build -- --no-filename-limit")`,
+              `Path collision: "${original}" and "${claimed}" both map to "${relPath}"`,
+            );
+          }
+          originalByOutput.set(relPath, original);
+
+          if (relPath.length > PATH_LIMIT && !argv['no-filename-limit']) {
+            throw new Error(
+              `Filename too long: ${relPath} (${relPath.length}) (pass --no-filename-limit to disable; for instance, "npm run build -- --no-filename-limit")`,
             );
           }
 
@@ -457,6 +536,24 @@ const buildPromise = build({
   plugins: [
     ...config.plugins,
 
+    {
+      name: 'shortened-path-banner',
+      buildStart() {
+        shortNameCounter = 0;
+        shortNameBySegment.clear();
+        originalByOutput.clear();
+      },
+      generateBundle(_, bundle) {
+        for (const [fileName, chunk] of Object.entries(bundle)) {
+          if (chunk.type !== 'chunk') continue;
+          const outputPath = '/' + fileName;
+          const original = originalByOutput.get(outputPath);
+          if (original && original !== outputPath) {
+            chunk.code = `/* original: ${original} */\n` + chunk.code;
+          }
+        }
+      },
+    },
     // Keep offscreen documents from @whotracksme/reporting
     {
       name: 'copy-reporting-assets',


### PR DESCRIPTION
Shorten long file paths in build output to avoid Windows path length limits

With preserveModules: true, some dependencies (e.g. @adguard/agtree) produce output paths that can exceed Windows' MAX_PATH limit. The build already renames node_modules to npm, but deeply nested packages with long filenames still cause issues.

This adds a generic path shortening mechanism in sanitizeFileName: when a relative path exceeds 110 characters, the longest segments are iteratively replaced with a deterministic short name (e.g. ubo-scriptlet-injection-body-deserializer.js → 0.js). Shortened files get a /* original: ... */ banner comment for traceability.

Names are enumerated like that (#3462)
("0", "1", ..., "z", "10", ...)
with optional "-1", "-2", ... appended to resolve conflicts

Follow-up on https://github.com/ghostery/ghostery-extension/pull/3122 (identical, but with the conflict resolved)