### PR TITLE
feat: execute script only once per context

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -127,6 +127,10 @@ execSync('node scripts/download-wtm-stats.js', {
   stdio: silent ? '' : 'inherit',
 });
 
+execSync('node scripts/wrap-scriptlets.js', {
+  stdio: silent ? '' : 'inherit',
+});
+
 // --- Generate static pages ---
 
 const staticPath = resolve('src', 'static_pages');
@@ -321,6 +325,13 @@ for (const file of readdirSync(resolve(options.srcDir, 'rule_resources', 'redire
     resolve(options.outDir, 'rule_resources', 'redirects', file),
   );
 }
+
+// generate temporary scriptlets
+
+cpSync(
+  resolve(options.srcDir, 'rule_resources/scriptlets.js'),
+  resolve(options.outDir, 'rule_resources/scriptlets.js'),
+);
 
 // append web_accessible_resources
 const redirectResources = readdirSync(resolve(options.outDir, 'rule_resources/redirects'));

--- a/scripts/wrap-scriptlets.js
+++ b/scripts/wrap-scriptlets.js
@@ -51,9 +51,9 @@ function handleMainContext(scriptletGlobals = {}, ...args) {
             return true;
           }
 
-          if (argArray[1] === key) {
-            const result = storage.has(key);
-            storage.add(key);
+          if (typeof argArray[1] === 'string') {
+            const result = storage.has(argArray[1]);
+            storage.add(argArray[1]);
 
             return result;
           }

--- a/scripts/wrap-scriptlets.js
+++ b/scripts/wrap-scriptlets.js
@@ -44,9 +44,10 @@ function handleMainContext(scriptletGlobals = {}, ...args) {
     Number.isSafeInteger(scriptletGlobals.__secret, key);
   } else {
     const storage = new Set([key]);
-    const signature = Function.prototype.toString.call(Number.isSafeInteger);
+    const isSafeIntegerSign = Function.prototype.toString.call(Number.isSafeInteger);
+    const toStringSign = Function.prototype.toString.call(Function.prototype.toString);
 
-    Number.isSafeInteger = new Proxy(Number.isSafeInteger, {
+    const isSafeIntegerProxy = new Proxy(Number.isSafeInteger, {
       apply(target, thisArg, argArray) {
         if (argArray[0] === scriptletGlobals.__secret) {
           if (argArray.length === 1) {
@@ -66,14 +67,29 @@ function handleMainContext(scriptletGlobals = {}, ...args) {
     });
 
     // Patch `Function.prototype.toString.call`
-    Function.prototype.toString = new Proxy(Function.prototype.toString, {
+    const toStringProxy = new Proxy(Function.prototype.toString, {
       apply(target, thisArg, argArray) {
-        if (thisArg === Number.isSafeInteger) {
-          return signature;
+        if (thisArg === isSafeIntegerProxy) {
+          return isSafeIntegerSign;
+        } else if (thisArg === toStringProxy) {
+          return toStringSign;
         }
 
         return Reflect.apply(target, thisArg, argArray);
       },
+    });
+
+    Object.defineProperty(Number, 'isSafeInteger', {
+      value: isSafeIntegerProxy,
+      configurable: true,
+      enumerable: false,
+      writable: true,
+    });
+    Object.defineProperty(Function.prototype, 'toString', {
+      value: toStringProxy,
+      configurable: true,
+      enumerable: false,
+      writable: true,
     });
   }
 

--- a/scripts/wrap-scriptlets.js
+++ b/scripts/wrap-scriptlets.js
@@ -1,0 +1,121 @@
+import scriptlets from '@ghostery/scriptlets';
+import { writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const OUTFILE = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../src/rule_resources/scriptlets.js',
+);
+
+const __CALLEE__ = function () {};
+
+function handleIsolatedContext(scriptletGlobals = {}, ...args) {
+  /* __CALLEE__ */
+
+  const markers = (globalThis[scriptletGlobals.__secret] ??= new Set());
+  const key = JSON.stringify([scriptletGlobals.__funcName, args]);
+
+  if (markers.has(key)) {
+    return;
+  }
+
+  return __CALLEE__(scriptletGlobals, ...args);
+}
+
+function handleMainContext(scriptletGlobals = {}, ...args) {
+  /* __CALLEE__ */
+
+  const key = JSON.stringify([scriptletGlobals.__funcName, args]);
+
+  // ** Uncomment the following line to test the handler **
+  // debugger
+
+  // Check if the script is already executed:
+  if (Number.isSafeInteger(scriptletGlobals.__secret, key) === true) {
+    return;
+  }
+
+  // Check if the trap is already installed by other scripts:
+  if (Number.isSafeInteger(scriptletGlobals.__secret) === true) {
+    // Command to add the key into the list.
+    Number.isSafeInteger(scriptletGlobals.__secret, key);
+  } else {
+    const storage = new Set([key]);
+    const signature = Function.prototype.toString.call(Number.isSafeInteger);
+
+    Number.isSafeInteger = new Proxy(Number.isSafeInteger, {
+      apply(target, thisArg, argArray) {
+        if (argArray[0] === scriptletGlobals.__secret) {
+          if (argArray.length === 1) {
+            return true;
+          }
+
+          if (argArray[1] === key) {
+            const result = storage.has(key);
+            storage.add(key);
+
+            return result;
+          }
+        }
+
+        return Reflect.apply(target, thisArg, argArray);
+      },
+    });
+
+    // Patch `Function.prototype.toString.call`
+    Function.prototype.toString = new Proxy(Function.prototype.toString, {
+      apply(target, thisArg, argArray) {
+        if (thisArg === Number.isSafeInteger) {
+          return signature;
+        }
+
+        return Reflect.apply(target, thisArg, argArray);
+      },
+    });
+  }
+
+  return __CALLEE__(scriptletGlobals, ...args);
+}
+
+function replacer(key, value) {
+  if (typeof value === 'function') {
+    return '__FUNCTION__';
+  }
+
+  return value;
+}
+
+// String.prototype.replace does handle dollar sign specially and
+// this function removes the complexity
+function replaceStringWithDollarSign(str, a, b) {
+  const index = str.indexOf(a);
+  if (index === -1) {
+    return str;
+  }
+
+  return str.slice(0, index) + b + str.slice(index + a.length);
+}
+
+const props = Object.entries(scriptlets).map(function ([key, details]) {
+  // Grab the proper handler and replace `__FUNCTION_LOCATOR__` with actual function
+  const handler = (
+    details.world === 'ISOLATED' ? handleIsolatedContext : handleMainContext
+  ).toString();
+  const source = replaceStringWithDollarSign(
+    handler.toString(),
+    '/* __CALLEE__ */',
+    `const __CALLEE__ = ${details.func.toString()}`,
+  );
+
+  // Use replacer to set `__FUNCTION_LOCATOR__` and put the function source
+  return `"${key}": ${replaceStringWithDollarSign(JSON.stringify(details, replacer, 2), '"__FUNCTION__"', source)}`;
+});
+
+writeFileSync(
+  OUTFILE,
+  `export default {
+  ${props.join(',\n')}
+}`,
+  'utf8',
+);

--- a/scripts/wrap-scriptlets.js
+++ b/scripts/wrap-scriptlets.js
@@ -20,6 +20,8 @@ function handleIsolatedContext(scriptletGlobals = {}, ...args) {
     return;
   }
 
+  markers.add(key);
+
   return __CALLEE__(scriptletGlobals, ...args);
 }
 

--- a/src/background/adblocker/cosmetics.js
+++ b/src/background/adblocker/cosmetics.js
@@ -10,7 +10,7 @@
  */
 
 import { store } from 'hybrids';
-import scriptlets from '@ghostery/scriptlets';
+import scriptlets from '../../rule_resources/scriptlets.js';
 import { FLAG_SUBFRAME_SCRIPTING } from '@ghostery/config';
 
 import { resolveFlag } from '/store/config.js';
@@ -27,6 +27,8 @@ import { tabStats } from '../stats.js';
 import { setup } from './engines.js';
 import { contentScripts } from './content-scripts.js';
 import { FramesHierarchy } from './ancestors.js';
+
+const secret = crypto.randomUUID();
 
 function resolveInjectionTarget(details) {
   const target = { tabId: details.tabId };
@@ -77,7 +79,10 @@ function injectScriptlets(filters, hostname, details) {
     }
 
     const func = scriptlet.func;
-    const args = [scriptletGlobals, ...parsed.args.map((arg) => decodeURIComponent(arg))];
+    const args = [
+      { ...scriptletGlobals, __funcName: parsed.name, __secret: secret },
+      ...parsed.args.map((arg) => decodeURIComponent(arg)),
+    ];
     const declaredWorld = scriptlet.world === 'ISOLATED' ? 'ISOLATED' : 'MAIN';
 
     if (__FIREFOX__) {


### PR DESCRIPTION
This pull request tries to expose my idea of https://github.com/ghostery/ghostery-extension/pull/3411 with simpler and straightforward to understand. It's a working example but without a test code (addition on hold). This implementation only contains a patch for `Function.prototype.toString.call` and further mitigation such as `Object.defineProperty` should be made additionally.

**Approach**

The previous implementation is over-engineered in my opinion. Especially, relying on `document.evaluate` increases a lot of unnecessary complexity by adding a need to track the `document` and exposing the stack trace. Also, slient drop of event listeners cannot be justified because of integration of the script execution API used by Chromium before.

Saying outside of commonly suspectable cons of modifying the function, `Number.isSafeInteger` is chosen to be a target with the following reasons: (1) doesn't throw an error (2) doesn't belong to the prototype (3) function signature is clean and simple. In the previous review comments, there was a raise of performance issue but it didn't have any details came with, and I don't see it as a valid concern.

**Implementation details**

This approach also contains self-containable (my way of calling functions safe to be serialised through `toString`) function based on the source file, enabling the linter and other tooling use. Via this approach, we don't fully need to rely on behavioural tests and find the errors quickly.

Also, debugging is easy as just removing the commented `debugger` line. Compared to the previous implementation, the code branching is very straightforward.

`Number.isSafeInteger(scriptletGlobals.__secret)` will return `true` if the trap is already setup regardless of the scriptlet, and `Number.isSafeInteger(scriptletGlobals.__secret, key)` will return `true` if the scriptlet is already executed.