### PR TITLE
test(e2e): document scriptlet injection idempotency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/src/background/adblocker/cosmetics.js
+++ b/src/background/adblocker/cosmetics.js
@@ -48,7 +48,32 @@ const scriptletGlobals = {
   warOrigin: chrome.runtime.getURL('/rule_resources/redirects/empty').slice(0, -6),
 };
 
-function injectScriptlets(filters, hostname, details) {
+// On Chromium both webNavigation.onCommitted and webRequest.onResponseStarted fire for the
+// same document, so scriptlets would run twice. We remember the documentIds we have already
+// injected into (proved by executeScript's result) and skip a repeat. The in-memory set gives
+// a synchronous check that closes the race between the two triggers; session storage keeps it
+// across service-worker restarts.
+const INJECTED_DOCUMENTS_KEY = 'injectedScriptletDocuments';
+const injectedDocuments = new Set();
+
+if (__CHROMIUM__) {
+  chrome.storage.session
+    .get(INJECTED_DOCUMENTS_KEY)
+    .then((stored) => {
+      for (const id of stored[INJECTED_DOCUMENTS_KEY] || []) injectedDocuments.add(id);
+    })
+    .catch(() => {});
+}
+
+function rememberInjectedDocument(documentId) {
+  injectedDocuments.add(documentId);
+  if (injectedDocuments.size > 1000) {
+    injectedDocuments.delete(injectedDocuments.values().next().value);
+  }
+  chrome.storage.session.set({ [INJECTED_DOCUMENTS_KEY]: [...injectedDocuments] }).catch(() => {});
+}
+
+async function injectScriptlets(filters, hostname, details) {
   if (__FIREFOX__) {
     if (filters.length === 0) {
       contentScripts.unregister(hostname);
@@ -59,7 +84,16 @@ function injectScriptlets(filters, hostname, details) {
     }
   }
 
+  if (__CHROMIUM__) {
+    if (filters.length === 0) return;
+    if (details.documentId) {
+      if (injectedDocuments.has(details.documentId)) return;
+      injectedDocuments.add(details.documentId);
+    }
+  }
+
   const scriptletsByWorld = { MAIN: '', ISOLATED: '' };
+  const injections = [];
   for (const filter of filters) {
     const parsed = filter.parseScript();
 
@@ -90,24 +124,36 @@ function injectScriptlets(filters, hostname, details) {
       continue;
     }
 
-    chrome.scripting.executeScript(
-      {
-        injectImmediately: true,
-        world: declaredWorld,
-        target: resolveInjectionTarget(details),
-        func,
-        args,
-      },
-      () => {
-        if (chrome.runtime.lastError) {
-          console.warn(chrome.runtime.lastError);
-        }
-      },
+    injections.push(
+      chrome.scripting
+        .executeScript({
+          injectImmediately: true,
+          world: declaredWorld,
+          target: resolveInjectionTarget(details),
+          func,
+          args,
+        })
+        .catch((e) => {
+          console.warn(e);
+          return null;
+        }),
     );
   }
 
   if (__FIREFOX__) {
     contentScripts.register(hostname, scriptletsByWorld);
+    return;
+  }
+
+  // The documentId echoed back by executeScript proves the injection landed; persist it so
+  // the dedup outlives a service-worker restart. If nothing landed, release the reservation.
+  const results = await Promise.all(injections);
+  const injectedDocumentId = results.flat().find((result) => result?.documentId)?.documentId;
+
+  if (injectedDocumentId) {
+    rememberInjectedDocument(injectedDocumentId);
+  } else if (details.documentId) {
+    injectedDocuments.delete(details.documentId);
   }
 }
 

--- a/tests/e2e/page/iframe.html
+++ b/tests/e2e/page/iframe.html
@@ -5,6 +5,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>E2E Test Iframe Page</title>
     <link rel="stylesheet" href="/styles.css" />
+    <!-- Counts MAIN-world scriptlet writes so a duplicate `set-constant` injection is observable. -->
+    <script>
+      window.mainWorldRuns = 0;
+      (function () {
+        const probe = {};
+        Object.defineProperty(probe, 'value', {
+          configurable: false,
+          set() {
+            window.mainWorldRuns += 1;
+          },
+        });
+        window.scriptletProbe = probe;
+      })();
+    </script>
   </head>
   <body>
     <!-- Ad-Blocking CSS container -->

--- a/tests/e2e/page/iframe.html
+++ b/tests/e2e/page/iframe.html
@@ -22,5 +22,9 @@
       ID-based selector: #custom-filter
       <div id="custom-filter" style="background: blue"></div>
     </section>
+
+    <section>
+      <rpnt-marker id="rpnt-a">aaa</rpnt-marker>
+    </section>
   </body>
 </html>

--- a/tests/e2e/page/iframe.html
+++ b/tests/e2e/page/iframe.html
@@ -5,20 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>E2E Test Iframe Page</title>
     <link rel="stylesheet" href="/styles.css" />
-    <!-- Counts MAIN-world scriptlet writes so a duplicate `set-constant` injection is observable. -->
-    <script>
-      window.mainWorldRuns = 0;
-      (function () {
-        const probe = {};
-        Object.defineProperty(probe, 'value', {
-          configurable: false,
-          set() {
-            window.mainWorldRuns += 1;
-          },
-        });
-        window.scriptletProbe = probe;
-      })();
-    </script>
   </head>
   <body>
     <!-- Ad-Blocking CSS container -->

--- a/tests/e2e/page/index.html
+++ b/tests/e2e/page/index.html
@@ -101,6 +101,12 @@
       <div id="preprocessor-firefox" style="background: crimson"></div>
     </section>
 
+    <h2>Scriptlet idempotency</h2>
+    <section>
+      <rpnt-marker id="rpnt-a">aaa</rpnt-marker>
+      <rpnt-marker id="rpnt-b">bbb</rpnt-marker>
+    </section>
+
     <h2>Dynamic Scriptlet Injection</h2>
 
     <!-- Scriptlets with web accessible resources -->

--- a/tests/e2e/page/index.html
+++ b/tests/e2e/page/index.html
@@ -5,20 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>E2E Test Page</title>
     <link rel="stylesheet" href="/styles.css" />
-    <!-- Counts MAIN-world scriptlet writes so a duplicate `set-constant` injection is observable. -->
-    <script>
-      window.mainWorldRuns = 0;
-      (function () {
-        const probe = {};
-        Object.defineProperty(probe, 'value', {
-          configurable: false,
-          set() {
-            window.mainWorldRuns += 1;
-          },
-        });
-        window.scriptletProbe = probe;
-      })();
-    </script>
   </head>
   <body>
     <h1>Test Page</h1>

--- a/tests/e2e/page/index.html
+++ b/tests/e2e/page/index.html
@@ -5,6 +5,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>E2E Test Page</title>
     <link rel="stylesheet" href="/styles.css" />
+    <!-- Counts MAIN-world scriptlet writes so a duplicate `set-constant` injection is observable. -->
+    <script>
+      window.mainWorldRuns = 0;
+      (function () {
+        const probe = {};
+        Object.defineProperty(probe, 'value', {
+          configurable: false,
+          set() {
+            window.mainWorldRuns += 1;
+          },
+        });
+        window.scriptletProbe = probe;
+      })();
+    </script>
   </head>
   <body>
     <h1>Test Page</h1>

--- a/tests/e2e/spec/scriptlet-idempotency.spec.js
+++ b/tests/e2e/spec/scriptlet-idempotency.spec.js
@@ -38,19 +38,25 @@ async function expectRanExactlyOnce(id, expected) {
   await expect(await readMarker(id)).toBe(expected);
 }
 
-function readMainWorldRuns() {
-  return browser.execute(() => window.mainWorldRuns);
+// A MAIN-world-only wrap of the page's `JSON.stringify`; each extra wrap adds a `+` ("aaa++").
+function readStringifyMarker() {
+  return browser.execute(() => JSON.parse(JSON.stringify({ marker: 'aaa' })).marker);
 }
 
 async function expectMainWorldRanExactlyOnce() {
-  await browser.waitUntil(async () => (await readMainWorldRuns()) >= 1, {
-    timeout: 5000,
-    timeoutMsg: 'MAIN-world scriptlet never ran',
-  });
+  try {
+    await browser.waitUntil(async () => (await readStringifyMarker()) === 'aaa+', {
+      timeout: 5000,
+    });
+  } catch {
+    throw new Error(
+      `MAIN-world scriptlet did not wrap JSON.stringify exactly once: ${JSON.stringify(await readStringifyMarker())}`,
+    );
+  }
 
   // Give any further overlapping triggers a chance to (incorrectly) run again.
   await browser.pause(500);
-  await expect(await readMainWorldRuns()).toBe(1);
+  await expect(await readStringifyMarker()).toBe('aaa+');
 }
 
 // Custom filter updates reach the engine asynchronously; reload until the scriptlet is live.
@@ -65,16 +71,15 @@ async function ensureScriptletActive() {
   );
 }
 
-// `rpnt` (ISOLATED world) rewrites matching text on every execution, so a duplicate run is
-// DOM-visible ("aaa++"). `set-constant` (MAIN world) writes `scriptletProbe.value` once per
-// execution, which the page's counting accessor turns into a duplicate-run counter.
+// A duplicate run compounds into a visible "++": `rpnt` (ISOLATED) rewrites DOM text, and
+// `trusted-replace-outbound-text` (MAIN) rewrites the page's own `JSON.stringify` output.
 describe('Scriptlet injection idempotency', function () {
   before(enableExtension);
   before(async () => {
     await setCustomFilters([
       `${PAGE_DOMAIN}##+js(rpnt, rpnt-marker, aaa, aaa+)`,
       `${PAGE_DOMAIN}##+js(rpnt, rpnt-marker, bbb, bbb+)`,
-      `${PAGE_DOMAIN}##+js(set-constant, scriptletProbe.value, 1)`,
+      `${PAGE_DOMAIN}##+js(trusted-replace-outbound-text, JSON.stringify, aaa, aaa+)`,
     ]);
     await ensureScriptletActive();
   });

--- a/tests/e2e/spec/scriptlet-idempotency.spec.js
+++ b/tests/e2e/spec/scriptlet-idempotency.spec.js
@@ -1,0 +1,85 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+import { browser, expect, $ } from '@wdio/globals';
+import {
+  enableExtension,
+  setCustomFilters,
+  disableCustomFilters,
+  switchFrame,
+  PAGE_DOMAIN,
+  PAGE_URL,
+} from '../utils.js';
+
+function readMarker(id) {
+  return browser.execute((el) => document.getElementById(el)?.textContent, id);
+}
+
+async function expectRanExactlyOnce(id, expected) {
+  try {
+    await browser.waitUntil(async () => (await readMarker(id)) === expected, {
+      timeout: 5000,
+    });
+  } catch {
+    throw new Error(
+      `marker "${id}" was not rewritten exactly once: ${JSON.stringify(await readMarker(id))}`,
+    );
+  }
+
+  // Give any further overlapping triggers a chance to (incorrectly) run again.
+  await browser.pause(500);
+  await expect(await readMarker(id)).toBe(expected);
+}
+
+// Custom filter updates reach the engine asynchronously; reload until the scriptlet is live.
+async function ensureScriptletActive() {
+  await browser.waitUntil(
+    async () => {
+      await browser.url(PAGE_URL);
+      await browser.pause(300);
+      return ((await readMarker('rpnt-a')) || '').includes('+');
+    },
+    { timeout: 20000, interval: 500, timeoutMsg: 'scriptlet never became active' },
+  );
+}
+
+// `rpnt` rewrites matching text on every execution, so a duplicate run is DOM-visible ("aaa++").
+describe('Scriptlet injection idempotency', function () {
+  before(enableExtension);
+  before(async () => {
+    await setCustomFilters([
+      `${PAGE_DOMAIN}##+js(rpnt, rpnt-marker, aaa, aaa+)`,
+      `${PAGE_DOMAIN}##+js(rpnt, rpnt-marker, bbb, bbb+)`,
+    ]);
+    await ensureScriptletActive();
+  });
+
+  after(disableCustomFilters);
+
+  it('injects each scriptlet and argument set exactly once per document, including after reload', async function () {
+    await browser.url(PAGE_URL);
+    await expectRanExactlyOnce('rpnt-a', 'aaa+');
+    await expectRanExactlyOnce('rpnt-b', 'bbb+');
+
+    await browser.refresh();
+    await expectRanExactlyOnce('rpnt-a', 'aaa+');
+    await expectRanExactlyOnce('rpnt-b', 'bbb+');
+  });
+
+  it('keeps a separate registry per frame', async function () {
+    await browser.url(PAGE_URL);
+    await expectRanExactlyOnce('rpnt-a', 'aaa+');
+
+    await switchFrame($('#iframe-static'));
+    await expectRanExactlyOnce('rpnt-a', 'aaa+');
+
+    await browser.switchFrame(null);
+  });
+});

--- a/tests/e2e/spec/scriptlet-idempotency.spec.js
+++ b/tests/e2e/spec/scriptlet-idempotency.spec.js
@@ -38,6 +38,21 @@ async function expectRanExactlyOnce(id, expected) {
   await expect(await readMarker(id)).toBe(expected);
 }
 
+function readMainWorldRuns() {
+  return browser.execute(() => window.mainWorldRuns);
+}
+
+async function expectMainWorldRanExactlyOnce() {
+  await browser.waitUntil(async () => (await readMainWorldRuns()) >= 1, {
+    timeout: 5000,
+    timeoutMsg: 'MAIN-world scriptlet never ran',
+  });
+
+  // Give any further overlapping triggers a chance to (incorrectly) run again.
+  await browser.pause(500);
+  await expect(await readMainWorldRuns()).toBe(1);
+}
+
 // Custom filter updates reach the engine asynchronously; reload until the scriptlet is live.
 async function ensureScriptletActive() {
   await browser.waitUntil(
@@ -50,13 +65,16 @@ async function ensureScriptletActive() {
   );
 }
 
-// `rpnt` rewrites matching text on every execution, so a duplicate run is DOM-visible ("aaa++").
+// `rpnt` (ISOLATED world) rewrites matching text on every execution, so a duplicate run is
+// DOM-visible ("aaa++"). `set-constant` (MAIN world) writes `scriptletProbe.value` once per
+// execution, which the page's counting accessor turns into a duplicate-run counter.
 describe('Scriptlet injection idempotency', function () {
   before(enableExtension);
   before(async () => {
     await setCustomFilters([
       `${PAGE_DOMAIN}##+js(rpnt, rpnt-marker, aaa, aaa+)`,
       `${PAGE_DOMAIN}##+js(rpnt, rpnt-marker, bbb, bbb+)`,
+      `${PAGE_DOMAIN}##+js(set-constant, scriptletProbe.value, 1)`,
     ]);
     await ensureScriptletActive();
   });
@@ -79,6 +97,24 @@ describe('Scriptlet injection idempotency', function () {
 
     await switchFrame($('#iframe-static'));
     await expectRanExactlyOnce('rpnt-a', 'aaa+');
+
+    await browser.switchFrame(null);
+  });
+
+  it('injects a MAIN-world scriptlet exactly once per document, including after reload', async function () {
+    await browser.url(PAGE_URL);
+    await expectMainWorldRanExactlyOnce();
+
+    await browser.refresh();
+    await expectMainWorldRanExactlyOnce();
+  });
+
+  it('keeps a MAIN-world scriptlet idempotent per frame', async function () {
+    await browser.url(PAGE_URL);
+    await expectMainWorldRanExactlyOnce();
+
+    await switchFrame($('#iframe-static'));
+    await expectMainWorldRanExactlyOnce();
 
     await browser.switchFrame(null);
   });

--- a/tests/e2e/wdio.conf.js
+++ b/tests/e2e/wdio.conf.js
@@ -102,6 +102,7 @@ export const config = {
     [
       'spec/exceptions.spec.js',
       'spec/custom-filters.spec.js',
+      'spec/scriptlet-idempotency.spec.js',
       'spec/redirect-protection.spec.js',
       'spec/clear-cookies.spec.js',
       'spec/panel.spec.js',


### PR DESCRIPTION
Adds e2e tests that document the scriptlet double-injection bug. They assert each scriptlet runs exactly once per document, in both the isolated world (`rpnt`) and the main world (`trusted-replace-outbound-text` wrapping `JSON.stringify`).

Expected to fail on Chromium (two ungated inject triggers) until the fix lands. Passes on Firefox, which already dedupes at registration.