### PR TITLE
fix(custom-filters): refine copy and localize settings strings

### DIFF
--- a/src/pages/settings/store/hostname.js
+++ b/src/pages/settings/store/hostname.js
@@ -8,7 +8,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
-import { store } from 'hybrids';
+import { store, msg } from 'hybrids';
 import { parse } from 'tldts-experimental';
 
 export default {
@@ -19,7 +19,7 @@ export default {
     set: (id, model) => {
       const parsed = parse(model.value);
       if (!parsed.hostname && !parsed.isIp) {
-        throw 'The value must be a valid hostname or IP address.';
+        throw msg`The value must be a valid hostname or IP address.`;
       }
       return {
         ...model,

--- a/src/pages/settings/views/custom-filters.js
+++ b/src/pages/settings/views/custom-filters.js
@@ -104,9 +104,9 @@ export default {
           <div layout="column gap:2" slot="card-footer">
             <div layout="column gap:0.5">
               <ui-text color="tertiary">
-                Create your own filter rules to block specific content or bypass blocking on certain
-                sites. The syntax is the same as for regular filter lists, but only a subset of
-                supported rules is supported.
+                Create custom filter rules to block specific content or bypass blocking on certain
+                sites. The syntax is the same as for standard filter lists, but only a subset of
+                rules is supported.
               </ui-text>
             </div>
             <ui-input>
@@ -155,8 +155,8 @@ export default {
                 <ui-text type="body-s">Allow trusted scriptlets</ui-text>
                 <ui-tooltip autohide="0" wrap delay="0" position="bottom" focusable>
                   <div slot="content" layout="width::250px">
-                    Trusted scriptlets can use powerful rule modifiers — make sure you only use
-                    filter lists from trusted authors.
+                    Trusted scriptlets can use powerful rule modifiers. Only use filter lists from
+                    authors you trust.
                   </div>
                   <ui-icon name="warning" color="warning-primary" layout="size:2"></ui-icon>
                 </ui-tooltip>
@@ -170,7 +170,7 @@ export default {
           <div layout="column gap:2" slot="card-footer">
             <div layout="column gap:0.5">
               <ui-text color="tertiary">
-                Add URLs of filter lists to have them automatically updated and applied.
+                Add filter list URLs to have them automatically updated and applied.
               </ui-text>
             </div>
             ${__CHROMIUM__ &&
@@ -184,12 +184,8 @@ export default {
                 <div layout="row gap:0.5 items:center">
                   <ui-icon name="warning" color="warning-secondary" layout="size:2"></ui-icon>
                   <ui-text type="body-s" color="warning-secondary" underline>
-                    To use filter lists, enable "Allow user scripts" in your browser's
-                    <a
-                      href="${`chrome://extensions/?id=${chrome.runtime.id}`}"
-                      onclick="${openExtensionSettings}"
-                      >extension settings</a
-                    >.
+                    ${msg.html`To use filter lists, enable "Allow user scripts"
+                      in your browser's <a onclick="${openExtensionSettings}">extension settings</a>.`}
                   </ui-text>
                 </div>
               </div>
@@ -282,8 +278,8 @@ export default {
                                 <ui-text type="body-s">Allow trusted scriptlets</ui-text>
                                 <ui-tooltip autohide="0" wrap delay="0" position="bottom" focusable>
                                   <div slot="content" layout="width::250px">
-                                    Trusted scriptlets can use powerful rule modifiers — make sure
-                                    you only use filter lists from trusted authors.
+                                    Trusted scriptlets can use powerful rule modifiers. Only use
+                                    filter lists from authors you trust.
                                   </div>
                                   <ui-icon
                                     name="warning"


### PR DESCRIPTION
The custom filters settings UI introduced in #3441 contained wording that could be clearer and a few user-facing strings that were not localizable, including a validation error thrown as a plain string and inline HTML built without the `msg` helper.

This tightens the copy across the custom filters view (e.g. "Create custom filter rules…", "Add filter list URLs…", and clearer trusted scriptlet guidance) and wraps the remaining user-facing strings in hybrids' `msg`/`msg.html` so they can be translated. The hostname validation error is now thrown via `msg` as well.