### PR TITLE
Cross-platform subframe scriptlet injection

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,7 +40,7 @@ export default [
     },
   },
   {
-    files: ['tests/**/*.spec.js'],
+    files: ['tests/**/*.spec.js', 'tests/e2e/utils.js'],
     languageOptions: {
       globals: {
         ...globals.mocha,

--- a/src/background/adblocker/ancestors.js
+++ b/src/background/adblocker/ancestors.js
@@ -230,8 +230,7 @@ export class FramesHierarchy {
       this.unregister(tabId, 0);
     });
 
-    // onReplaced only fires on Chromium (prerender/instant swaps); guard so a browser without it
-    // does not throw when the hierarchy is initialized.
+    // onReplaced is Chromium-only; guard so Firefox doesn't throw now the hierarchy runs there.
     chrome.tabs.onReplaced?.addListener((addedTabId, removedTabId) => {
       this.replace(addedTabId, removedTabId);
     });

--- a/src/background/adblocker/ancestors.js
+++ b/src/background/adblocker/ancestors.js
@@ -230,7 +230,9 @@ export class FramesHierarchy {
       this.unregister(tabId, 0);
     });
 
-    chrome.tabs.onReplaced.addListener((addedTabId, removedTabId) => {
+    // onReplaced only fires on Chromium (prerender/instant swaps); guard so a browser without it
+    // does not throw when the hierarchy is initialized.
+    chrome.tabs.onReplaced?.addListener((addedTabId, removedTabId) => {
       this.replace(addedTabId, removedTabId);
     });
   }

--- a/src/background/adblocker/content-scripts.js
+++ b/src/background/adblocker/content-scripts.js
@@ -24,7 +24,10 @@ const firefoxRegistry = (() => {
             await browser.contentScripts.register({
               js: [{ code }],
               allFrames: true,
-              matches: [`https://*.${hostname}/*`, `http://*.${hostname}/*`],
+              // Match the exact hostname (like the Chromium userScripts registry). A `*.` wildcard
+              // would also match subdomain frames, which self-register under their own hostname —
+              // the overlap injects the same scriptlet twice into a subdomain child.
+              matches: [`https://${hostname}/*`, `http://${hostname}/*`],
               matchAboutBlank: true,
               matchOriginAsFallback: true,
               runAt: 'document_start',

--- a/src/background/adblocker/content-scripts.js
+++ b/src/background/adblocker/content-scripts.js
@@ -24,9 +24,7 @@ const firefoxRegistry = (() => {
             await browser.contentScripts.register({
               js: [{ code }],
               allFrames: true,
-              // Match the exact hostname (like the Chromium userScripts registry). A `*.` wildcard
-              // would also match subdomain frames, which self-register under their own hostname —
-              // the overlap injects the same scriptlet twice into a subdomain child.
+              // Exact hostname: a `*.` wildcard would double-inject into subdomain frames that self-register.
               matches: [`https://${hostname}/*`, `http://${hostname}/*`],
               matchAboutBlank: true,
               matchOriginAsFallback: true,
@@ -63,15 +61,13 @@ const firefoxRegistry = (() => {
   };
 })();
 
-// Registrations persist across service-worker restarts, so register() upserts by a stable id
-// and unregisterAll() queries the browser to purge them (the map is empty after a restart).
+// userScripts registrations persist across restarts; upsert by a stable id, purge via getScripts().
 const USER_SCRIPTS_NAMESPACE = 'ghostery-scriptlet';
 
 function userScriptId(hostname, world) {
   return `${USER_SCRIPTS_NAMESPACE}:${world}:${hostname}`;
 }
 
-// __CHROMIUM__ guard so chrome.userScripts is tree-shaken from the Firefox build.
 const chromiumRegistry =
   __CHROMIUM__ &&
   (() => {
@@ -121,6 +117,4 @@ const chromiumRegistry =
     };
   })();
 
-// browser.contentScripts (Firefox) and chrome.userScripts (Chromium) fill the same role;
-// the rest of the adblocker treats whichever one this resolves to as "content scripts".
 export const contentScripts = __FIREFOX__ ? firefoxRegistry : chromiumRegistry;

--- a/src/background/adblocker/content-scripts.js
+++ b/src/background/adblocker/content-scripts.js
@@ -15,7 +15,13 @@ const firefoxRegistry = (() => {
     async register(hostname, scriptletsByWorld) {
       this.unregister(hostname);
 
+      // Reserve the hostname synchronously so the onCommitted pass short-circuits on
+      // isRegistered() before this async register resolves — otherwise both the
+      // onBeforeNavigate and onCommitted passes register the same hostname and leak
+      // two overlapping content scripts, injecting the scriptlet twice.
       const registered = [];
+      map.set(hostname, registered);
+
       try {
         for (const [world, code] of Object.entries(scriptletsByWorld)) {
           if (!code) continue;
@@ -35,14 +41,8 @@ const firefoxRegistry = (() => {
         }
       } catch (e) {
         console.warn(e);
-        for (const contentScript of registered) {
-          contentScript.unregister();
-        }
-        return;
+        this.unregister(hostname);
       }
-
-      // Cache the entry (even when empty) so isRegistered() short-circuits later navigations.
-      map.set(hostname, registered);
     },
     isRegistered(hostname) {
       return map.has(hostname);

--- a/src/background/adblocker/cosmetics.js
+++ b/src/background/adblocker/cosmetics.js
@@ -76,63 +76,79 @@ function rememberInjectedDocument(documentId) {
   chrome.storage.session.set({ [INJECTED_DOCUMENTS_KEY]: [...injectedDocuments] }).catch(() => {});
 }
 
-async function injectScriptlets(filters, hostname, details) {
-  if (__FIREFOX__ || USER_SCRIPTS) {
-    if (filters.length === 0) {
-      contentScripts.unregister(hostname);
-      return;
-    }
-    if (contentScripts.isRegistered(hostname)) {
-      return;
-    }
-  } else if (__CHROMIUM__) {
-    if (filters.length === 0) return;
-    if (details.documentId) {
-      if (injectedDocuments.has(details.documentId)) return;
-      injectedDocuments.add(details.documentId);
-    }
+function buildScriptletInjection(filter) {
+  const parsed = filter.parseScript();
+
+  if (!parsed) {
+    console.warn('[adblocker] could not inject script filter:', filter.toString());
+    return null;
+  }
+
+  const scriptletName = `${parsed.name}${parsed.name.endsWith('.js') ? '' : '.js'}`;
+  const scriptlet = scriptlets[scriptletName];
+
+  if (!scriptlet) {
+    console.warn('[adblocker] unknown scriptlet with name:', scriptletName);
+    return null;
+  }
+
+  return {
+    func: scriptlet.func,
+    args: [scriptletGlobals, ...parsed.args.map((arg) => decodeURIComponent(arg))],
+    world: scriptlet.world === 'ISOLATED' ? 'ISOLATED' : 'MAIN',
+  };
+}
+
+// Direct (non-subframe) scriptlets are delivered through the content-script registry so the
+// browser runs them at document_start. Registration is keyed by hostname and deduped there.
+function registerDirectScriptlets(filters, hostname) {
+  if (filters.length === 0) {
+    contentScripts.unregister(hostname);
+    return;
+  }
+
+  if (contentScripts.isRegistered(hostname)) {
+    return;
   }
 
   const scriptletsByWorld = { MAIN: '', ISOLATED: '' };
+  for (const filter of filters) {
+    const injection = buildScriptletInjection(filter);
+    if (!injection) continue;
+
+    scriptletsByWorld[injection.world] +=
+      `(${injection.func.toString()})(...${JSON.stringify(injection.args)});\n`;
+  }
+
+  contentScripts.register(hostname, scriptletsByWorld);
+}
+
+// A per-frame ancestor decision is the only way to reach a cross-origin child (a per-hostname
+// registration cannot), so subframe-constrained scriptlets go through executeScript on every
+// platform. The Chromium legacy path (no userScripts permission) sends every scriptlet here.
+async function executeScriptlets(filters, details) {
+  if (filters.length === 0) return;
+
+  // onCommitted and onResponseStarted both fire for the same document on Chromium, so skip a
+  // repeat. Firefox drives executeScript from onCommitted alone and needs no cross-trigger guard.
+  if (__CHROMIUM__ && details.documentId) {
+    if (injectedDocuments.has(details.documentId)) return;
+    injectedDocuments.add(details.documentId);
+  }
+
   const injections = [];
   for (const filter of filters) {
-    const parsed = filter.parseScript();
-
-    if (!parsed) {
-      console.warn('[adblocker] could not inject script filter:', filter.toString());
-      continue;
-    }
-
-    const scriptletName = `${parsed.name}${parsed.name.endsWith('.js') ? '' : '.js'}`;
-    const scriptlet = scriptlets[scriptletName];
-
-    if (!scriptlet) {
-      console.warn('[adblocker] unknown scriptlet with name:', scriptletName);
-      continue;
-    }
-
-    const func = scriptlet.func;
-    const args = [scriptletGlobals, ...parsed.args.map((arg) => decodeURIComponent(arg))];
-    const declaredWorld = scriptlet.world === 'ISOLATED' ? 'ISOLATED' : 'MAIN';
-
-    if (__FIREFOX__ || USER_SCRIPTS) {
-      let code = '';
-      if (filter.hasSubframeConstraint()) {
-        code += `window.parent!==window&&`;
-      }
-      code += `(${func.toString()})(...${JSON.stringify(args)});\n`;
-      scriptletsByWorld[declaredWorld] += code;
-      continue;
-    }
+    const injection = buildScriptletInjection(filter);
+    if (!injection) continue;
 
     injections.push(
       chrome.scripting
         .executeScript({
           injectImmediately: true,
-          world: declaredWorld,
+          world: injection.world,
           target: resolveInjectionTarget(details),
-          func,
-          args,
+          func: injection.func,
+          args: injection.args,
         })
         .catch((e) => {
           console.warn(e);
@@ -141,14 +157,12 @@ async function injectScriptlets(filters, hostname, details) {
     );
   }
 
-  if (__FIREFOX__ || USER_SCRIPTS) {
-    contentScripts.register(hostname, scriptletsByWorld);
-    return;
-  }
+  const results = await Promise.all(injections);
+
+  if (!__CHROMIUM__) return;
 
   // The documentId echoed back by executeScript proves the injection landed; persist it so
   // the dedup outlives a service-worker restart. If nothing landed, release the reservation.
-  const results = await Promise.all(injections);
   const injectedDocumentId = results.flat().find((result) => result?.documentId)?.documentId;
 
   if (injectedDocumentId) {
@@ -156,6 +170,28 @@ async function injectScriptlets(filters, hostname, details) {
   } else if (details.documentId) {
     injectedDocuments.delete(details.documentId);
   }
+}
+
+async function injectScriptlets(filters, hostname, details, scriptletsOnly) {
+  if (__FIREFOX__ || USER_SCRIPTS) {
+    const directFilters = [];
+    const subframeFilters = [];
+    for (const filter of filters) {
+      (filter.hasSubframeConstraint() ? subframeFilters : directFilters).push(filter);
+    }
+
+    registerDirectScriptlets(directFilters, hostname);
+
+    // The scriptletsOnly pass (onBeforeNavigate) runs before the document commits; its only job
+    // is to register document_start scripts. executeScript needs the committed document, so the
+    // subframe scriptlets wait for the full bootstrap on onCommitted.
+    if (scriptletsOnly) return;
+
+    await executeScriptlets(subframeFilters, details);
+    return;
+  }
+
+  await executeScriptlets(filters, details);
 }
 
 function injectStyles(styles, details) {
@@ -190,13 +226,11 @@ function injectStyles(styles, details) {
 
 const SUBFRAME_SCRIPTING = resolveFlag(FLAG_SUBFRAME_SCRIPTING);
 
-let framesHierarchy;
-if (__CHROMIUM__) {
-  framesHierarchy = new FramesHierarchy();
-
-  framesHierarchy.handleWebWorkerStart();
-  framesHierarchy.handleWebextensionEvents();
-}
+// Subframe scriptlets are injected per-frame on every platform (see executeScriptlets), and the
+// per-frame decision needs the real ancestor chain — so the hierarchy is tracked everywhere.
+const framesHierarchy = new FramesHierarchy();
+framesHierarchy.handleWebWorkerStart();
+framesHierarchy.handleWebextensionEvents();
 
 /*
  * returns `false` if the injection should be blocked for the given hostname
@@ -244,17 +278,11 @@ async function injectCosmetics(details, config) {
   const extendedCSSEnabled = !debugReady || debug.cosmeticsExtendedCSS;
 
   let ancestors = undefined;
-  if (SUBFRAME_SCRIPTING.enabled && typeof parentFrameId === 'number') {
-    if (__FIREFOX__ || USER_SCRIPTS) {
-      // The registration API is not per-frame, so surface every scriptlet that could run on
-      // the hostname; the subframe constraint is enforced by `window.parent` at runtime.
-      ancestors = [{ domain, hostname }];
-    } else {
-      ancestors = framesHierarchy.ancestors(
-        { tabId, frameId, parentFrameId, documentId },
-        { domain, hostname },
-      );
-    }
+  if (!scriptletsOnly && SUBFRAME_SCRIPTING.enabled && typeof parentFrameId === 'number') {
+    ancestors = framesHierarchy.ancestors(
+      { tabId, frameId, parentFrameId, documentId },
+      { domain, hostname },
+    );
   }
 
   // Domain specific cosmetic filters (scriptlets and styles)
@@ -299,7 +327,7 @@ async function injectCosmetics(details, config) {
     }
 
     if (isBootstrap) {
-      injectScriptlets(scriptletsEnabled ? scriptFilters : [], hostname, details);
+      injectScriptlets(scriptletsEnabled ? scriptFilters : [], hostname, details, scriptletsOnly);
     }
 
     if (scriptletsOnly) {

--- a/src/background/adblocker/cosmetics.js
+++ b/src/background/adblocker/cosmetics.js
@@ -51,30 +51,8 @@ const scriptletGlobals = {
 
 const USER_SCRIPTS = __CHROMIUM__ && isUserScriptsRegisterSupported();
 
-// On Chromium both webNavigation.onCommitted and webRequest.onResponseStarted fire for the
-// same document, so scriptlets would run twice. We remember the documentIds we have already
-// injected into (proved by executeScript's result) and skip a repeat. The in-memory set gives
-// a synchronous check that closes the race between the two triggers; session storage keeps it
-// across service-worker restarts.
-const INJECTED_DOCUMENTS_KEY = 'injectedScriptletDocuments';
+// Chromium fires onCommitted and onResponseStarted per document; dedup so executeScript runs once.
 const injectedDocuments = new Set();
-
-if (__CHROMIUM__) {
-  chrome.storage.session
-    .get(INJECTED_DOCUMENTS_KEY)
-    .then((stored) => {
-      for (const id of stored[INJECTED_DOCUMENTS_KEY] || []) injectedDocuments.add(id);
-    })
-    .catch(() => {});
-}
-
-function rememberInjectedDocument(documentId) {
-  injectedDocuments.add(documentId);
-  if (injectedDocuments.size > 1000) {
-    injectedDocuments.delete(injectedDocuments.values().next().value);
-  }
-  chrome.storage.session.set({ [INJECTED_DOCUMENTS_KEY]: [...injectedDocuments] }).catch(() => {});
-}
 
 function buildScriptletInjection(filter) {
   const parsed = filter.parseScript();
@@ -99,17 +77,14 @@ function buildScriptletInjection(filter) {
   };
 }
 
-// Direct (non-subframe) scriptlets are delivered through the content-script registry so the
-// browser runs them at document_start. Registration is keyed by hostname and deduped there.
+// Registered rather than executeScript'd so the browser runs them at document_start.
 function registerDirectScriptlets(filters, hostname) {
   if (filters.length === 0) {
     contentScripts.unregister(hostname);
     return;
   }
 
-  if (contentScripts.isRegistered(hostname)) {
-    return;
-  }
+  if (contentScripts.isRegistered(hostname)) return;
 
   const scriptletsByWorld = { MAIN: '', ISOLATED: '' };
   for (const filter of filters) {
@@ -123,26 +98,22 @@ function registerDirectScriptlets(filters, hostname) {
   contentScripts.register(hostname, scriptletsByWorld);
 }
 
-// A per-frame ancestor decision is the only way to reach a cross-origin child (a per-hostname
-// registration cannot), so subframe-constrained scriptlets go through executeScript on every
-// platform. The Chromium legacy path (no userScripts permission) sends every scriptlet here.
+// Per-frame injection reaches cross-origin children that a per-hostname registration cannot.
 async function executeScriptlets(filters, details) {
   if (filters.length === 0) return;
 
-  // onCommitted and onResponseStarted both fire for the same document on Chromium, so skip a
-  // repeat. Firefox drives executeScript from onCommitted alone and needs no cross-trigger guard.
-  if (__CHROMIUM__ && details.documentId) {
-    if (injectedDocuments.has(details.documentId)) return;
-    injectedDocuments.add(details.documentId);
+  const { documentId } = details;
+  if (__CHROMIUM__ && documentId) {
+    if (injectedDocuments.has(documentId)) return;
+    injectedDocuments.add(documentId);
   }
 
-  const injections = [];
-  for (const filter of filters) {
-    const injection = buildScriptletInjection(filter);
-    if (!injection) continue;
+  const results = await Promise.all(
+    filters.map((filter) => {
+      const injection = buildScriptletInjection(filter);
+      if (!injection) return null;
 
-    injections.push(
-      chrome.scripting
+      return chrome.scripting
         .executeScript({
           injectImmediately: true,
           world: injection.world,
@@ -153,22 +124,13 @@ async function executeScriptlets(filters, details) {
         .catch((e) => {
           console.warn(e);
           return null;
-        }),
-    );
-  }
+        });
+    }),
+  );
 
-  const results = await Promise.all(injections);
-
-  if (!__CHROMIUM__) return;
-
-  // The documentId echoed back by executeScript proves the injection landed; persist it so
-  // the dedup outlives a service-worker restart. If nothing landed, release the reservation.
-  const injectedDocumentId = results.flat().find((result) => result?.documentId)?.documentId;
-
-  if (injectedDocumentId) {
-    rememberInjectedDocument(injectedDocumentId);
-  } else if (details.documentId) {
-    injectedDocuments.delete(details.documentId);
+  // Nothing landed (e.g. the frame was gone) — release so the other trigger can retry.
+  if (__CHROMIUM__ && documentId && !results.some((r) => r?.length)) {
+    injectedDocuments.delete(documentId);
   }
 }
 
@@ -182,9 +144,7 @@ async function injectScriptlets(filters, hostname, details, scriptletsOnly) {
 
     registerDirectScriptlets(directFilters, hostname);
 
-    // The scriptletsOnly pass (onBeforeNavigate) runs before the document commits; its only job
-    // is to register document_start scripts. executeScript needs the committed document, so the
-    // subframe scriptlets wait for the full bootstrap on onCommitted.
+    // executeScript needs the committed document; the onBeforeNavigate pass only registers.
     if (scriptletsOnly) return;
 
     await executeScriptlets(subframeFilters, details);
@@ -226,8 +186,7 @@ function injectStyles(styles, details) {
 
 const SUBFRAME_SCRIPTING = resolveFlag(FLAG_SUBFRAME_SCRIPTING);
 
-// Subframe scriptlets are injected per-frame on every platform (see executeScriptlets), and the
-// per-frame decision needs the real ancestor chain — so the hierarchy is tracked everywhere.
+// Per-frame subframe injection needs the real ancestor chain on every platform.
 const framesHierarchy = new FramesHierarchy();
 framesHierarchy.handleWebWorkerStart();
 framesHierarchy.handleWebextensionEvents();
@@ -406,20 +365,20 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   }
 });
 
-if (__FIREFOX__) {
-  OptionsObserver.addListener('paused', function firefoxContentScriptScriptlets(paused) {
+if (__FIREFOX__ || USER_SCRIPTS) {
+  OptionsObserver.addListener('paused', (paused) => {
     for (const hostname of Object.keys(paused)) {
       contentScripts.unregister(hostname);
     }
   });
 
   chrome.webNavigation.onBeforeNavigate.addListener(
-    (details) => {
-      injectCosmetics(details, { bootstrap: true, scriptletsOnly: true });
-    },
+    (details) => injectCosmetics(details, { bootstrap: true, scriptletsOnly: true }),
     { url: [{ urlPrefix: 'http://' }, { urlPrefix: 'https://' }] },
   );
-} else {
+}
+
+if (__CHROMIUM__) {
   chrome.webRequest?.onResponseStarted.addListener(
     (details) => {
       if (details.tabId === -1) return;
@@ -433,19 +392,6 @@ if (__FIREFOX__) {
   );
 
   if (USER_SCRIPTS) {
-    OptionsObserver.addListener('paused', function chromiumUserScriptScriptlets(paused) {
-      for (const hostname of Object.keys(paused)) {
-        contentScripts.unregister(hostname);
-      }
-    });
-
-    chrome.webNavigation.onBeforeNavigate.addListener(
-      (details) => {
-        injectCosmetics(details, { bootstrap: true, scriptletsOnly: true });
-      },
-      { url: [{ urlPrefix: 'http://' }, { urlPrefix: 'https://' }] },
-    );
-
     // Registrations persist across restarts, so drop stale ones when the engine changes.
     const refresh = () => contentScripts.unregisterAll();
     chrome.runtime.onStartup.addListener(refresh);

--- a/src/utils/user-scripts.js
+++ b/src/utils/user-scripts.js
@@ -28,8 +28,7 @@ export function isUserScriptsSupported() {
   }
 }
 
-// Real capability probe (unlike isUserScriptsSupported, without the __DEBUG__/Safari
-// bypass) so a disabled "Allow user scripts" toggle falls back to the executeScript path.
+// Real capability probe (no __DEBUG__/Safari bypass) so a disabled toggle falls back to executeScript.
 export function isUserScriptsRegisterSupported() {
   try {
     chrome.userScripts.getScripts();

--- a/tests/e2e/page/subframe-probe.html
+++ b/tests/e2e/page/subframe-probe.html
@@ -5,15 +5,9 @@
     <title>Subframe Scriptlet Probe</title>
   </head>
   <body>
-    <!--
-      Loaded as a child frame (often cross-origin, so the parent cannot read this document
-      directly). It reports, via postMessage, whether the extension's scriptlets ran here:
-        - subframeScriptlet: a MAIN-world `set` from a `domain>>##+js(...)` subframe filter.
-        - stringifyMarker:   a MAIN-world `trusted-replace-outbound-text` wrapping JSON.stringify;
-                             each injection appends a `+`, so a double injection shows `aaa++`.
-      Scriptlets can land slightly after parse, so the probe reports repeatedly and the parent
-      keeps the latest values.
-    -->
+    <!-- Child frame (often cross-origin); postMessages to the parent whether the subframe scriptlet
+         (__ghostery_subframe__) and the JSON.stringify wrap ran. Each wrap appends "+", so a double
+         injection shows "aaa++". Posts repeatedly since scriptlets can land after parse. -->
     <script>
       function collect() {
         var stringifyMarker;

--- a/tests/e2e/page/subframe-probe.html
+++ b/tests/e2e/page/subframe-probe.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Subframe Scriptlet Probe</title>
+  </head>
+  <body>
+    <!--
+      Loaded as a child frame (often cross-origin, so the parent cannot read this document
+      directly). It reports, via postMessage, whether the extension's scriptlets ran here:
+        - subframeScriptlet: a MAIN-world `set` from a `domain>>##+js(...)` subframe filter.
+        - stringifyMarker:   a MAIN-world `trusted-replace-outbound-text` wrapping JSON.stringify;
+                             each injection appends a `+`, so a double injection shows `aaa++`.
+      Scriptlets can land slightly after parse, so the probe reports repeatedly and the parent
+      keeps the latest values.
+    -->
+    <script>
+      function collect() {
+        var stringifyMarker;
+        try {
+          stringifyMarker = JSON.parse(JSON.stringify({ marker: 'aaa' })).marker;
+        } catch (e) {
+          stringifyMarker = null;
+        }
+
+        return {
+          __subframeProbe: true,
+          subframeScriptlet: window.__ghostery_subframe__ === true,
+          stringifyMarker: stringifyMarker,
+        };
+      }
+
+      function report() {
+        try {
+          parent.postMessage(collect(), '*');
+        } catch (e) {
+          /* parent gone */
+        }
+      }
+
+      report();
+      document.addEventListener('DOMContentLoaded', report);
+      window.addEventListener('load', report);
+      for (var i = 1; i <= 8; i++) {
+        setTimeout(report, i * 250);
+      }
+    </script>
+  </body>
+</html>

--- a/tests/e2e/spec/scriptlet-idempotency.spec.js
+++ b/tests/e2e/spec/scriptlet-idempotency.spec.js
@@ -13,8 +13,8 @@ import {
   enableExtension,
   setCustomFilters,
   disableCustomFilters,
-  setUserScriptsAllowed,
-  isUserScriptsPathActive,
+  describeInjectionPaths,
+  reloadUntilActive,
   switchFrame,
   PAGE_DOMAIN,
   PAGE_URL,
@@ -61,20 +61,10 @@ async function expectMainWorldRanExactlyOnce() {
   await expect(await readStringifyMarker()).toBe('aaa+');
 }
 
-// Custom filter updates reach the engine asynchronously; reload until the scriptlet is live.
-async function ensureScriptletActive() {
-  await browser.waitUntil(
-    async () => {
-      await browser.url(PAGE_URL);
-      await browser.pause(300);
-      return ((await readMarker('rpnt-a')) || '').includes('+');
-    },
-    { timeout: 20000, interval: 500, timeoutMsg: 'scriptlet never became active' },
-  );
-}
+const ensureScriptletActive = () =>
+  reloadUntilActive(async () => ((await readMarker('rpnt-a')) || '').includes('+'));
 
-// A duplicate run compounds into a visible "++": `rpnt` (ISOLATED) rewrites DOM text, and
-// `trusted-replace-outbound-text` (MAIN) rewrites the page's own `JSON.stringify` output.
+// A duplicate run would compound into a visible "++", so these markers catch double injection.
 function idempotencyChecks() {
   it('injects each scriptlet and argument set exactly once per document, including after reload', async function () {
     await browser.url(PAGE_URL);
@@ -128,31 +118,5 @@ describe('Scriptlet injection idempotency', function () {
 
   after(disableCustomFilters);
 
-  describe('via the legacy injection path', function () {
-    before(async function () {
-      if (browser.isChromium) {
-        await setUserScriptsAllowed(false);
-        await ensureScriptletActive();
-        await expect(await isUserScriptsPathActive()).toBe(false);
-      }
-    });
-
-    idempotencyChecks();
-  });
-
-  describe('via chrome.userScripts', function () {
-    before(async function () {
-      if (!browser.isChromium) this.skip();
-
-      await setUserScriptsAllowed(true);
-      await ensureScriptletActive();
-      await expect(await isUserScriptsPathActive()).toBe(true);
-    });
-
-    after(async function () {
-      if (browser.isChromium) await setUserScriptsAllowed(false);
-    });
-
-    idempotencyChecks();
-  });
+  describeInjectionPaths(ensureScriptletActive, idempotencyChecks);
 });

--- a/tests/e2e/spec/subframe-scripting.spec.js
+++ b/tests/e2e/spec/subframe-scripting.spec.js
@@ -13,8 +13,8 @@ import {
   enableExtension,
   setCustomFilters,
   disableCustomFilters,
-  setUserScriptsAllowed,
-  isUserScriptsPathActive,
+  describeInjectionPaths,
+  reloadUntilActive,
   PAGE_DOMAIN,
   PAGE_PORT,
   PAGE_URL,
@@ -25,12 +25,10 @@ import {
 const CROSS_ORIGIN_PROBE_URL = `${SUBPAGE_URL}subframe-probe.html`;
 // Same origin as the top frame.
 const SAME_ORIGIN_PROBE_URL = `${PAGE_URL}subframe-probe.html`;
-// A subdomain of PAGE_DOMAIN (same registrable domain): both the parent-domain registration and
-// the subdomain's own registration match it, which is where the historical double-injection lived.
+// A subdomain of PAGE_DOMAIN — where parent-domain and subdomain registrations historically double-injected.
 const SUBDOMAIN_PROBE_URL = `http://sub.${PAGE_DOMAIN}:${PAGE_PORT}/subframe-probe.html`;
 
-// Embeds a child frame and returns what the probe reports back over postMessage. Scriptlets can
-// land a beat after the frame parses, so the probe posts repeatedly and we keep every value seen.
+// Embeds a child frame; the probe posts repeatedly (scriptlets can land after parse) and we keep every value.
 function probeSubframe(src, windowMs = 3500) {
   return browser.executeAsync(
     (src, windowMs, done) => {
@@ -65,18 +63,10 @@ function probeSubframe(src, windowMs = 3500) {
   );
 }
 
-// Custom filter updates reach the engine asynchronously; reload until the direct-domain scriptlet
-// (which runs on the top frame) is live before asserting on the subframe behavior.
-async function ensureFiltersActive() {
-  await browser.waitUntil(
-    async () => {
-      await browser.url(PAGE_URL);
-      await browser.pause(300);
-      return browser.execute(() => JSON.parse(JSON.stringify({ marker: 'aaa' })).marker === 'aaa+');
-    },
-    { timeout: 20000, interval: 500, timeoutMsg: 'scriptlet never became active' },
+const ensureFiltersActive = () =>
+  reloadUntilActive(() =>
+    browser.execute(() => JSON.parse(JSON.stringify({ marker: 'aaa' })).marker === 'aaa+'),
   );
-}
 
 function subframeChecks() {
   it('injects a subframe (>>) scriptlet into a cross-origin child frame', async function () {
@@ -129,31 +119,5 @@ describe('Subframe scriptlet injection', function () {
 
   after(disableCustomFilters);
 
-  describe('via the legacy injection path', function () {
-    before(async function () {
-      if (browser.isChromium) {
-        await setUserScriptsAllowed(false);
-        await ensureFiltersActive();
-        await expect(await isUserScriptsPathActive()).toBe(false);
-      }
-    });
-
-    subframeChecks();
-  });
-
-  describe('via chrome.userScripts', function () {
-    before(async function () {
-      if (!browser.isChromium) this.skip();
-
-      await setUserScriptsAllowed(true);
-      await ensureFiltersActive();
-      await expect(await isUserScriptsPathActive()).toBe(true);
-    });
-
-    after(async function () {
-      if (browser.isChromium) await setUserScriptsAllowed(false);
-    });
-
-    subframeChecks();
-  });
+  describeInjectionPaths(ensureFiltersActive, subframeChecks);
 });

--- a/tests/e2e/spec/subframe-scripting.spec.js
+++ b/tests/e2e/spec/subframe-scripting.spec.js
@@ -1,0 +1,159 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+import { browser, expect } from '@wdio/globals';
+import {
+  enableExtension,
+  setCustomFilters,
+  disableCustomFilters,
+  setUserScriptsAllowed,
+  isUserScriptsPathActive,
+  PAGE_DOMAIN,
+  PAGE_PORT,
+  PAGE_URL,
+  SUBPAGE_URL,
+} from '../utils.js';
+
+// A different registrable domain than PAGE_DOMAIN — a genuinely cross-origin, cross-site child.
+const CROSS_ORIGIN_PROBE_URL = `${SUBPAGE_URL}subframe-probe.html`;
+// Same origin as the top frame.
+const SAME_ORIGIN_PROBE_URL = `${PAGE_URL}subframe-probe.html`;
+// A subdomain of PAGE_DOMAIN (same registrable domain): both the parent-domain registration and
+// the subdomain's own registration match it, which is where the historical double-injection lived.
+const SUBDOMAIN_PROBE_URL = `http://sub.${PAGE_DOMAIN}:${PAGE_PORT}/subframe-probe.html`;
+
+// Embeds a child frame and returns what the probe reports back over postMessage. Scriptlets can
+// land a beat after the frame parses, so the probe posts repeatedly and we keep every value seen.
+function probeSubframe(src, windowMs = 3500) {
+  return browser.executeAsync(
+    (src, windowMs, done) => {
+      const result = { received: false, subframeScriptlet: false, markers: [] };
+
+      function onMessage(event) {
+        const data = event && event.data;
+        if (!data || data.__subframeProbe !== true) return;
+
+        result.received = true;
+        if (data.subframeScriptlet === true) result.subframeScriptlet = true;
+        if (data.stringifyMarker != null) result.markers.push(data.stringifyMarker);
+      }
+
+      window.addEventListener('message', onMessage);
+
+      const iframe = document.createElement('iframe');
+      iframe.style.width = '1px';
+      iframe.style.height = '1px';
+      iframe.style.opacity = '0';
+      iframe.src = src;
+      document.body.appendChild(iframe);
+
+      setTimeout(() => {
+        window.removeEventListener('message', onMessage);
+        iframe.remove();
+        done(result);
+      }, windowMs);
+    },
+    src,
+    windowMs,
+  );
+}
+
+// Custom filter updates reach the engine asynchronously; reload until the direct-domain scriptlet
+// (which runs on the top frame) is live before asserting on the subframe behavior.
+async function ensureFiltersActive() {
+  await browser.waitUntil(
+    async () => {
+      await browser.url(PAGE_URL);
+      await browser.pause(300);
+      return browser.execute(() => JSON.parse(JSON.stringify({ marker: 'aaa' })).marker === 'aaa+');
+    },
+    { timeout: 20000, interval: 500, timeoutMsg: 'scriptlet never became active' },
+  );
+}
+
+function subframeChecks() {
+  it('injects a subframe (>>) scriptlet into a cross-origin child frame', async function () {
+    await browser.url(PAGE_URL);
+
+    const report = await probeSubframe(CROSS_ORIGIN_PROBE_URL);
+
+    await expect(report.received).toBe(true);
+    await expect(report.subframeScriptlet).toBe(true);
+  });
+
+  it('injects a subframe (>>) scriptlet into a same-origin child frame', async function () {
+    await browser.url(PAGE_URL);
+
+    const report = await probeSubframe(SAME_ORIGIN_PROBE_URL);
+
+    await expect(report.subframeScriptlet).toBe(true);
+  });
+
+  it('does not inject a subframe (>>) scriptlet into the top frame', async function () {
+    await browser.url(PAGE_URL);
+    // Give any (incorrect) top-frame injection a chance to land before asserting its absence.
+    await browser.pause(500);
+
+    const topInjected = await browser.execute(() => window.__ghostery_subframe__ === true);
+
+    await expect(topInjected).toBe(false);
+  });
+
+  it('injects a direct-domain scriptlet exactly once into a subdomain child frame', async function () {
+    await browser.url(PAGE_URL);
+
+    const report = await probeSubframe(SUBDOMAIN_PROBE_URL);
+
+    // A single injection wraps JSON.stringify once ("aaa+"); a duplicate would show "aaa++".
+    await expect(report.markers).toContain('aaa+');
+    await expect(report.markers.some((marker) => (marker || '').includes('++'))).toBe(false);
+  });
+}
+
+describe('Subframe scriptlet injection', function () {
+  before(enableExtension);
+  before(async () => {
+    await setCustomFilters([
+      `${PAGE_DOMAIN}>>##+js(set, __ghostery_subframe__, true)`,
+      `${PAGE_DOMAIN}##+js(trusted-replace-outbound-text, JSON.stringify, aaa, aaa+)`,
+    ]);
+    await ensureFiltersActive();
+  });
+
+  after(disableCustomFilters);
+
+  describe('via the legacy injection path', function () {
+    before(async function () {
+      if (browser.isChromium) {
+        await setUserScriptsAllowed(false);
+        await ensureFiltersActive();
+        await expect(await isUserScriptsPathActive()).toBe(false);
+      }
+    });
+
+    subframeChecks();
+  });
+
+  describe('via chrome.userScripts', function () {
+    before(async function () {
+      if (!browser.isChromium) this.skip();
+
+      await setUserScriptsAllowed(true);
+      await ensureFiltersActive();
+      await expect(await isUserScriptsPathActive()).toBe(true);
+    });
+
+    after(async function () {
+      if (browser.isChromium) await setUserScriptsAllowed(false);
+    });
+
+    subframeChecks();
+  });
+});

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -149,6 +149,49 @@ export async function setUserScriptsAllowed(value) {
   await reloadExtension();
 }
 
+// Custom filter updates reach the engine asynchronously; reload PAGE_URL until `check` passes.
+export function reloadUntilActive(check, timeoutMsg = 'scriptlet never became active') {
+  return browser.waitUntil(
+    async () => {
+      await browser.url(PAGE_URL);
+      await browser.pause(300);
+      return check();
+    },
+    { timeout: 20000, interval: 500, timeoutMsg },
+  );
+}
+
+// Runs the same checks through both Chromium scriptlet paths (legacy executeScript and userScripts).
+export function describeInjectionPaths(ensureActive, runChecks) {
+  describe('via the legacy injection path', function () {
+    before(async function () {
+      if (browser.isChromium) {
+        await setUserScriptsAllowed(false);
+        await ensureActive();
+        await expect(await isUserScriptsPathActive()).toBe(false);
+      }
+    });
+
+    runChecks();
+  });
+
+  describe('via chrome.userScripts', function () {
+    before(async function () {
+      if (!browser.isChromium) this.skip();
+
+      await setUserScriptsAllowed(true);
+      await ensureActive();
+      await expect(await isUserScriptsPathActive()).toBe(true);
+    });
+
+    after(async function () {
+      if (browser.isChromium) await setUserScriptsAllowed(false);
+    });
+
+    runChecks();
+  });
+}
+
 export async function setToggle(name, value) {
   const toggle = await getExtensionElement(`toggle:${name}`);
 

--- a/tests/e2e/wdio.conf.js
+++ b/tests/e2e/wdio.conf.js
@@ -103,6 +103,7 @@ export const config = {
       'spec/exceptions.spec.js',
       'spec/custom-filters.spec.js',
       'spec/scriptlet-idempotency.spec.js',
+      'spec/subframe-scripting.spec.js',
       'spec/redirect-protection.spec.js',
       'spec/clear-cookies.spec.js',
       'spec/panel.spec.js',


### PR DESCRIPTION
## Goal

Make subframe-targeting scriptlets (`domain>>##+js(...)`) behave identically on Firefox and Chromium (both with and without the userScripts permission). Previously they only reached **cross-origin** child frames on Chromium's `executeScript` path — on Firefox and the Chromium userScripts path they silently never ran, which meant enabling **"Allow user scripts"** on Chrome dropped subframe-scripting support that the fallback path had.

## What changes

Subframe scriptlet delivery is now split by the decision it actually requires:

- **Direct-domain** scriptlets keep going through the content-script registry (Firefox `contentScripts` / Chromium `userScripts`), preserving `document_start` injection.
- **Subframe-constrained** scriptlets are injected per-frame from the real frame ancestor chain on **every** platform. Only a per-frame decision can inject into a cross-origin child because *its parent* matched — a per-hostname registration structurally cannot.

Alongside the main fix:

- **Mixed direct/subframe filters** (`a.com,b.com>>##+js(...)`) now also run on the top `a.com` frame, which the old per-frame `window.parent` guard wrongly suppressed.
- **Firefox registration** now matches the exact hostname instead of `*.hostname`. The wildcard also covered subdomain child frames, which register under their own hostname too, so the same scriptlet was injected twice into a subdomain frame.

## Behavior notes

- On Firefox, same-origin subframe scriptlets shift from registration to per-frame injection, so their timing moves from `document_start` to just after the child frame commits. This is the trade-off for correct, uniform cross-origin behavior; the affected feature is gated behind the subframe-scripting flag.

## Test plan

With custom **trusted** scriptlet filters enabled, on Firefox and on Chrome (both with and without **Allow user scripts**):

- Add `page.localhost>>##+js(set, __probe__, true)` and open a page that embeds a **cross-origin** iframe. Confirm the scriptlet ran inside the iframe and did **not** run on the top page.
- Confirm the same scriptlet also runs inside a **same-origin** iframe.
- Add a direct-domain scriptlet (e.g. `page.localhost##+js(set-constant, ...)`) and open a page that embeds a **subdomain** iframe (e.g. `sub.page.localhost`). Confirm the scriptlet takes effect exactly once in that iframe (no doubled effect).