### PR TITLE
fix(adblocker): subframe scriptlet injection on Firefox

### DIFF
--- a/src/background/adblocker/ancestors.js
+++ b/src/background/adblocker/ancestors.js
@@ -230,7 +230,8 @@ export class FramesHierarchy {
       this.unregister(tabId, 0);
     });
 
-    chrome.tabs.onReplaced.addListener((addedTabId, removedTabId) => {
+    // onReplaced is Chromium-only; guard so Firefox doesn't throw now the hierarchy runs there.
+    chrome.tabs.onReplaced?.addListener((addedTabId, removedTabId) => {
       this.replace(addedTabId, removedTabId);
     });
   }

--- a/src/background/adblocker/content-scripts.js
+++ b/src/background/adblocker/content-scripts.js
@@ -15,7 +15,11 @@ export const contentScripts = (() => {
     async register(hostname, scriptletsByWorld) {
       this.unregister(hostname);
 
+      // Reserve synchronously so a concurrent onCommitted register() short-circuits on
+      // isRegistered() instead of registering the hostname again and injecting twice.
       const registered = [];
+      map.set(hostname, registered);
+
       try {
         for (const [world, code] of Object.entries(scriptletsByWorld)) {
           if (!code) continue;
@@ -24,7 +28,8 @@ export const contentScripts = (() => {
             await browser.contentScripts.register({
               js: [{ code }],
               allFrames: true,
-              matches: [`https://*.${hostname}/*`, `http://*.${hostname}/*`],
+              // Subdomain frames register their own scriptlets, so match only this exact hostname.
+              matches: [`https://${hostname}/*`, `http://${hostname}/*`],
               matchAboutBlank: true,
               matchOriginAsFallback: true,
               runAt: 'document_start',
@@ -34,14 +39,8 @@ export const contentScripts = (() => {
         }
       } catch (e) {
         console.warn(e);
-        for (const contentScript of registered) {
-          contentScript.unregister();
-        }
-        return;
+        this.unregister(hostname);
       }
-
-      // Cache the entry (even when empty) so isRegistered() short-circuits later navigations.
-      map.set(hostname, registered);
     },
     isRegistered(hostname) {
       return map.has(hostname);

--- a/src/background/adblocker/cosmetics.js
+++ b/src/background/adblocker/cosmetics.js
@@ -74,16 +74,6 @@ function rememberInjectedDocument(documentId) {
 }
 
 async function injectScriptlets(filters, hostname, details) {
-  if (__FIREFOX__) {
-    if (filters.length === 0) {
-      contentScripts.unregister(hostname);
-      return;
-    }
-    if (contentScripts.isRegistered(hostname)) {
-      return;
-    }
-  }
-
   if (__CHROMIUM__) {
     if (filters.length === 0) return;
     if (details.documentId) {
@@ -114,13 +104,10 @@ async function injectScriptlets(filters, hostname, details) {
     const args = [scriptletGlobals, ...parsed.args.map((arg) => decodeURIComponent(arg))];
     const declaredWorld = scriptlet.world === 'ISOLATED' ? 'ISOLATED' : 'MAIN';
 
-    if (__FIREFOX__) {
-      let code = '';
-      if (filter.hasSubframeConstraint()) {
-        code += `window.parent!==window&&`;
-      }
-      code += `(${func.toString()})(...${JSON.stringify(args)});\n`;
-      scriptletsByWorld[declaredWorld] += code;
+    // Firefox registers direct-domain scriptlets (document_start); a per-hostname registration
+    // can't reach a cross-origin child, so subframe-constrained ones inject per-frame below.
+    if (__FIREFOX__ && !filter.hasSubframeConstraint()) {
+      scriptletsByWorld[declaredWorld] += `(${func.toString()})(...${JSON.stringify(args)});\n`;
       continue;
     }
 
@@ -141,7 +128,13 @@ async function injectScriptlets(filters, hostname, details) {
   }
 
   if (__FIREFOX__) {
-    contentScripts.register(hostname, scriptletsByWorld);
+    if (scriptletsByWorld.MAIN || scriptletsByWorld.ISOLATED) {
+      if (!contentScripts.isRegistered(hostname)) {
+        contentScripts.register(hostname, scriptletsByWorld);
+      }
+    } else {
+      contentScripts.unregister(hostname);
+    }
     return;
   }
 
@@ -189,13 +182,9 @@ function injectStyles(styles, details) {
 
 const SUBFRAME_SCRIPTING = resolveFlag(FLAG_SUBFRAME_SCRIPTING);
 
-let framesHierarchy;
-if (__CHROMIUM__) {
-  framesHierarchy = new FramesHierarchy();
-
-  framesHierarchy.handleWebWorkerStart();
-  framesHierarchy.handleWebextensionEvents();
-}
+const framesHierarchy = new FramesHierarchy();
+framesHierarchy.handleWebWorkerStart();
+framesHierarchy.handleWebextensionEvents();
 
 /*
  * returns `false` if the injection should be blocked for the given hostname
@@ -243,21 +232,11 @@ async function injectCosmetics(details, config) {
   const extendedCSSEnabled = !debugReady || debug.cosmeticsExtendedCSS;
 
   let ancestors = undefined;
-  if (SUBFRAME_SCRIPTING.enabled && typeof parentFrameId === 'number') {
-    if (__FIREFOX__) {
-      // On Firefox with content scripts API, we need to collect
-      // every scriptlets will potentially run on the hostname.
-      // Putting same values to `ancestors` enables adblocker to
-      // find all possible cases. The subframe constraint is
-      // validated by the `window.parent` property upon a script
-      // is executed.
-      ancestors = [{ domain, hostname }];
-    } else {
-      ancestors = framesHierarchy.ancestors(
-        { tabId, frameId, parentFrameId, documentId },
-        { domain, hostname },
-      );
-    }
+  if (!scriptletsOnly && SUBFRAME_SCRIPTING.enabled && typeof parentFrameId === 'number') {
+    ancestors = framesHierarchy.ancestors(
+      { tabId, frameId, parentFrameId, documentId },
+      { domain, hostname },
+    );
   }
 
   // Domain specific cosmetic filters (scriptlets and styles)

--- a/tests/e2e/page/subframe-probe.html
+++ b/tests/e2e/page/subframe-probe.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Subframe Scriptlet Probe</title>
+  </head>
+  <body>
+    <script>
+      // Report state to the parent repeatedly, since a scriptlet can land after parse. Each
+      // JSON.stringify wrap appends "+", so a double injection shows "aaa++".
+      setInterval(function () {
+        parent.postMessage(
+          {
+            __subframeProbe: true,
+            subframeScriptlet: window.__ghostery_subframe__ === true,
+            marker: JSON.parse(JSON.stringify({ marker: 'aaa' })).marker,
+          },
+          '*',
+        );
+      }, 200);
+    </script>
+  </body>
+</html>

--- a/tests/e2e/spec/subframe-scripting.spec.js
+++ b/tests/e2e/spec/subframe-scripting.spec.js
@@ -1,0 +1,101 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+import { browser, expect } from '@wdio/globals';
+import {
+  enableExtension,
+  setCustomFilters,
+  disableCustomFilters,
+  reloadUntilActive,
+  PAGE_DOMAIN,
+  PAGE_PORT,
+  PAGE_URL,
+  SUBPAGE_URL,
+} from '../utils.js';
+
+const CROSS_ORIGIN_PROBE_URL = `${SUBPAGE_URL}subframe-probe.html`;
+const SAME_ORIGIN_PROBE_URL = `${PAGE_URL}subframe-probe.html`;
+const SUBDOMAIN_PROBE_URL = `http://sub.${PAGE_DOMAIN}:${PAGE_PORT}/subframe-probe.html`;
+
+function probeSubframe(src, windowMs = 3000) {
+  return browser.executeAsync(
+    (src, windowMs, done) => {
+      const markers = new Set();
+      let subframeScriptlet = false;
+
+      window.addEventListener('message', (event) => {
+        if (!event.data || event.data.__subframeProbe !== true) return;
+        if (event.data.subframeScriptlet) subframeScriptlet = true;
+        if (event.data.marker != null) markers.add(event.data.marker);
+      });
+
+      const iframe = document.createElement('iframe');
+      iframe.src = src;
+      document.body.appendChild(iframe);
+
+      setTimeout(() => done({ subframeScriptlet, markers: [...markers] }), windowMs);
+    },
+    src,
+    windowMs,
+  );
+}
+
+const ensureFiltersActive = () =>
+  reloadUntilActive(() =>
+    browser.execute(() => JSON.parse(JSON.stringify({ marker: 'aaa' })).marker === 'aaa+'),
+  );
+
+describe('Subframe scriptlet injection', function () {
+  before(enableExtension);
+  before(async () => {
+    await setCustomFilters([
+      `${PAGE_DOMAIN}>>##+js(set, __ghostery_subframe__, true)`,
+      `${PAGE_DOMAIN}##+js(trusted-replace-outbound-text, JSON.stringify, aaa, aaa+)`,
+    ]);
+    await ensureFiltersActive();
+  });
+
+  after(disableCustomFilters);
+
+  it('injects a subframe (>>) scriptlet into a cross-origin child frame', async function () {
+    await browser.url(PAGE_URL);
+
+    const report = await probeSubframe(CROSS_ORIGIN_PROBE_URL);
+
+    await expect(report.subframeScriptlet).toBe(true);
+  });
+
+  it('injects a subframe (>>) scriptlet into a same-origin child frame', async function () {
+    await browser.url(PAGE_URL);
+
+    const report = await probeSubframe(SAME_ORIGIN_PROBE_URL);
+
+    await expect(report.subframeScriptlet).toBe(true);
+  });
+
+  it('does not inject a subframe (>>) scriptlet into the top frame', async function () {
+    await browser.url(PAGE_URL);
+    // Give any (incorrect) top-frame injection a chance to land before asserting its absence.
+    await browser.pause(500);
+
+    const topInjected = await browser.execute(() => window.__ghostery_subframe__ === true);
+
+    await expect(topInjected).toBe(false);
+  });
+
+  it('injects a direct-domain scriptlet exactly once into a subdomain child frame', async function () {
+    await browser.url(PAGE_URL);
+
+    const report = await probeSubframe(SUBDOMAIN_PROBE_URL);
+
+    await expect(report.markers).toContain('aaa+');
+    await expect(report.markers.some((marker) => marker.includes('++'))).toBe(false);
+  });
+});

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -107,6 +107,18 @@ export async function reloadExtension() {
   await waitForIdleBackgroundTasks();
 }
 
+// Custom filter updates reach the engine asynchronously; reload PAGE_URL until `check` passes.
+export function reloadUntilActive(check, timeoutMsg = 'scriptlet never became active') {
+  return browser.waitUntil(
+    async () => {
+      await browser.url(PAGE_URL);
+      await browser.pause(300);
+      return check();
+    },
+    { timeout: 20000, interval: 500, timeoutMsg },
+  );
+}
+
 export async function setToggle(name, value) {
   const toggle = await getExtensionElement(`toggle:${name}`);
 

--- a/tests/e2e/wdio.conf.js
+++ b/tests/e2e/wdio.conf.js
@@ -103,6 +103,7 @@ export const config = {
       'spec/exceptions.spec.js',
       'spec/custom-filters.spec.js',
       'spec/scriptlet-idempotency.spec.js',
+      'spec/subframe-scripting.spec.js',
       'spec/redirect-protection.spec.js',
       'spec/clear-cookies.spec.js',
       'spec/panel.spec.js',


### PR DESCRIPTION
## What was wrong

On Firefox, subframe-targeting scriptlets (`domain>>##+js(...)`) were broken:

- They never ran in **cross-origin** child frames.
- Direct-domain scriptlets were injected **twice** into subdomain frames.

Both now behave correctly, matching Chromium. The Chromium path is unchanged.

## Test plan

With custom **trusted** scriptlet filters enabled, on Firefox:

- Add `page.localhost>>##+js(set, __probe__, true)` and open a page embedding a **cross-origin** iframe — the scriptlet runs inside the iframe and **not** on the top page.
- Confirm it also runs inside a **same-origin** iframe.
- Add `page.localhost##+js(set-constant, ...)` and open a page embedding a **subdomain** iframe (`sub.page.localhost`) — the scriptlet takes effect exactly once (no doubled effect).