### PR TITLE
chore(release): remove manual translation push/pull steps

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -25,11 +25,6 @@ node ./scripts/data-dependencies.js
 # Update xcode version
 node ./scripts/xcode-version.js
 
-# Compile, push and pull new translations
-npm run locales
-tx push
-tx pull -f
-
 # Get version from package.json
 version=$(node -p "require('./package.json').version")
 # Get build number from xcode


### PR DESCRIPTION
Translations are now handled automatically through the Transifex–GitHub integration, so pushing and pulling them manually during a release is no longer necessary and only adds friction to the release process.

This removes the `npm run locales`, `tx push`, and `tx pull -f` steps from `scripts/release.sh`, letting the integration keep translations in sync on its own.