### PR TITLE
fix(build): use new privacy policy URL to preserve embed parameter

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -163,7 +163,7 @@ if (!existsSync(licensesPath)) {
 // privacy-policy.html...
 if (argv.target !== 'firefox') {
   const policyPath = resolve(staticPath, 'privacy-policy.html');
-  const url = `https://www.${argv.debug ? 'ghosterystage' : 'ghostery'}.com/privacy-policy?embed=true`;
+  const url = `https://www.${argv.debug ? 'ghosterystage' : 'ghostery'}.com/privacy/policy?embed=true`;
 
   if (!existsSync(policyPath)) {
     const policy = await fetch(url);


### PR DESCRIPTION
The privacy policy URL on ghostery.com changed, but the Rails redirect from the old path does not preserve query parameters, so the `embed=true` flag was dropped and the fetched page rendered with the full site layout instead of the bare policy content.

This updates the build script to fetch the privacy policy directly from the new `privacy/policy?embed=true` URL, ensuring the `embed` parameter is honored and the embedded (layout-free) version of the page is bundled.