### PR TITLE
GPC support: set "navigator.globalPrivacyControl" to true

### DIFF
--- a/src/content_scripts/gpc.js
+++ b/src/content_scripts/gpc.js
@@ -1,0 +1,30 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+// Ensures that `navigator.globalPrivacyControl` is truthy (GPC support):
+// https://w3c.github.io/gpc/#javascript-property-to-detect-preference
+//
+// Injected into the page's MAIN world at document_start (including all frames).
+(function () {
+  try {
+    if (!window.navigator.globalPrivacyControl) {
+      Object.defineProperty(navigator, 'globalPrivacyControl', {
+        get() {
+          return true;
+        },
+        configurable: true,
+        enumerable: true,
+      });
+    }
+  } catch {
+    // ignore
+  }
+})();

--- a/src/manifest.chromium.json
+++ b/src/manifest.chromium.json
@@ -88,6 +88,14 @@
       "all_frames": true
     },
     {
+      "js": ["content_scripts/gpc.js"],
+      "matches": ["http://*/*", "https://*/*"],
+      "run_at": "document_start",
+      "match_about_blank": true,
+      "all_frames": true,
+      "world": "MAIN"
+    },
+    {
       "js": ["content_scripts/notifications.js"],
       "matches": ["http://*/*", "https://*/*"],
       "run_at": "document_start"

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -61,6 +61,14 @@
       "all_frames": true
     },
     {
+      "js": ["content_scripts/gpc.js"],
+      "matches": ["http://*/*", "https://*/*"],
+      "run_at": "document_start",
+      "match_about_blank": true,
+      "all_frames": true,
+      "world": "MAIN"
+    },
+    {
       "js": ["content_scripts/notifications.js"],
       "matches": ["http://*/*", "https://*/*"],
       "run_at": "document_start"

--- a/tests/e2e/spec/main.spec.js
+++ b/tests/e2e/spec/main.spec.js
@@ -80,6 +80,18 @@ describe('Main Features', function () {
 
       await setPrivacyToggle('never-consent', true);
     });
+
+    it('sets navigator.globalPrivacyControl in the page main world', async function () {
+      await browser.url(PAGE_URL);
+
+      // Main frame
+      expect(await browser.execute(() => navigator.globalPrivacyControl)).toBe(true);
+
+      // Sub-frame — each frame has its own navigator, so injection must reach it
+      await switchFrame($('#iframe-static'));
+      expect(await browser.execute(() => navigator.globalPrivacyControl)).toBe(true);
+      await browser.switchFrame(null);
+    });
   });
 
   describe('Ad-Blocking', function () {


### PR DESCRIPTION
GPC support: set "navigator.globalPrivacyControl" on Firefox and Chromium

Background:
https://w3c.github.io/gpc/#javascript-property-to-detect-preference

We already set the Sec-GPC signal, but the spec requires also to have navigator.globalPrivacyControl be truthy before the page runs.

Test pages:
- https://globalprivacycontrol.org/
- https://browserleaks.com/donottrack