### PR TITLE
fix(settings): prevent link chevron from shrinking

### DIFF
--- a/src/pages/settings/components/link.js
+++ b/src/pages/settings/components/link.js
@@ -34,7 +34,7 @@ export default {
                 </ui-text>
                 <slot name="footer"></slot>
               </div>
-              <div id="chevron" layout="row center size:4">
+              <div id="chevron" layout="row center size:4 shrink:0">
                 <ui-icon name="chevron-right" color="onbrand" layout="size:2"></ui-icon>
               </div>
             </div>


### PR DESCRIPTION
In the settings link component, the chevron icon container could shrink when the accompanying text content was long, distorting the icon and its alignment.

This adds `shrink:0` to the chevron container's layout so it keeps its fixed size regardless of the sibling content length, ensuring the chevron always renders at its intended dimensions.