### PR TITLE
fix(telemetry): keep sending pings when the insights database is unavailable

### DIFF
--- a/src/background/telemetry/index.js
+++ b/src/background/telemetry/index.js
@@ -42,7 +42,8 @@ const setup = asyncSetup('telemetry', [
         const [options, config, dailyStats] = await Promise.all([
           store.resolve(Options),
           store.resolve(Config),
-          store.resolve(DailyStats, yesterdayId),
+          // A failed `insights` DB read must not block the ping.
+          store.resolve(DailyStats, yesterdayId).catch(() => ({ pages: 0 })),
         ]);
 
         return {


### PR DESCRIPTION
## What

`getConf` (telemetry) turned yesterday's page-view bucket — the `pv` param added in #3331 — into a hard dependency of every ping by awaiting `store.resolve(DailyStats, …)` unguarded. When a profile's `insights` IndexedDB fails to open, that resolve rejects, propagates through `_buildMetricsUrl`, and is swallowed by the ping's `.catch`, so `active` and `engaged` pings are silently dropped and never retried.

This makes the `DailyStats` read non-fatal — on failure it falls back to `pages: 0` (→ `pv=0`) instead of rejecting `getConf`.

Fixes #3494.

## Impact

Restores telemetry pings for the affected profiles — primarily long-lived desktop-Firefox installs whose legacy `insights` DB hits a throwing branch in the v31 `upgrade()`. Tracker blocking is not affected.

## Test plan

- In Firefox, browse a few pages and confirm the telemetry ping to `d.ghostery.com` still fires (Network tab), now including the `pv` param.
- Force `store.resolve(DailyStats, …)` to reject (e.g. corrupt or close the `insights` DB): confirm `active` / `engaged` pings are still sent with `pv=0` rather than being dropped.
