### PR TITLE
fix(telemetry): SERP counting with page views

### DIFF
--- a/src/background/serp.js
+++ b/src/background/serp.js
@@ -16,7 +16,6 @@ import trackersPreviewCSS from '/content_scripts/trackers-preview.css?raw';
 import Options, { isGloballyPaused } from '/store/options.js';
 import { getWTMStats } from '/utils/wtm-stats.js';
 import { parseWithCache } from '/utils/request.js';
-import { recordSerpVisit } from './telemetry/index.js';
 
 // Trackers preview messages
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
@@ -40,14 +39,12 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   return false;
 });
 
-const SERP_URL_REGEXP =
+export const SERP_URL_REGEXP =
   /^https?:[/][/][^/]*[.](google|bing)[.][a-z]+([.][a-z]+)?([/][a-z]+)*[/]search/;
 
 // SERP tracking prevention and trackers preview content scripts
 chrome.webNavigation.onCommitted.addListener(async (details) => {
   if (details.url.match(SERP_URL_REGEXP)) {
-    recordSerpVisit();
-
     const options = await store.resolve(Options);
 
     if (options.wtmSerpReport) {

--- a/src/background/stats.js
+++ b/src/background/stats.js
@@ -25,7 +25,10 @@ import { getMetadata, getUnidentifiedTracker } from '/utils/trackerdb.js';
 import Request from '/utils/request.js';
 import { isOpera, isWebkit } from '/utils/browser-info.js';
 
+import { recordSerpVisit } from './telemetry/index.js';
+
 import * as logger from './logger.js';
+import { SERP_URL_REGEXP } from './serp.js';
 
 export const tabStats = new AutoSyncingMap({ storageKey: 'tabStats:v1' });
 
@@ -214,12 +217,6 @@ export async function updateTabStats(tabId, requests) {
   // as some of the requests are fired before the tab is created, tabId -1
   if (!stats) return;
 
-  // If the tab is in incognito mode, we set the flag to avoid storing the stats
-  if (stats.incognito === undefined) {
-    const tab = await chrome.tabs.get(tabId).catch(() => null);
-    stats.incognito = tab?.incognito ?? false;
-  }
-
   // Filter out requests that are not related to the current page
   // (e.g. requests on trailing edge when navigation to a new page is in progress)
   requests = requests.filter(
@@ -290,7 +287,10 @@ export async function updateTabStats(tabId, requests) {
 
 async function flushTabStatsToDailyStats(tabId) {
   const stats = tabStats.get(tabId);
-  if (!stats || !stats.trackers.length || stats.incognito) return;
+  if (!stats || stats.incognito) return;
+
+  // Count SERP visits with the page view so both share timing and incognito exclusion.
+  if (SERP_URL_REGEXP.test(stats.url)) recordSerpVisit();
 
   let trackersBlocked = 0;
   let trackersModified = 0;
@@ -337,9 +337,16 @@ function setupTabStats(details) {
 }
 
 // Setup stats for the tab when a user navigates to a new page
-chrome.webNavigation.onCommitted.addListener((details) => {
+chrome.webNavigation.onCommitted.addListener(async (details) => {
   if (details.tabId > -1 && details.parentFrameId === -1) {
     setupTabStats(details);
+
+    // Resolve incognito now; on tab close the tab can no longer be queried.
+    const stats = tabStats.get(details.tabId);
+    if (stats) {
+      const tab = await chrome.tabs.get(details.tabId).catch(() => null);
+      stats.incognito = tab?.incognito ?? false;
+    }
   }
 });
 


### PR DESCRIPTION
The `se` (SERP visits) and `pv` (page views) telemetry signals were counted through separate paths, so they could diverge within a day — SERP visits were bumped in `serp.js` on navigation regardless of incognito state, while page views were counted only when flushing tab stats.

- SERP visit counting is moved out of `serp.js` into the tab-stats flush (`flushTabStatsToDailyStats`) via the shared, now-exported `SERP_URL_REGEXP`, so `se` and `pv` share the same timing, UTC-day attribution, and incognito exclusion.
- Incognito state is resolved once in the `onCommitted` listener while the tab is still alive and cached on the stats object, so it is reliable even when flushing on tab close.
- Page views are now counted regardless of whether trackers were seen (the patterns list is only extended when there are trackers).