### PR TITLE
fix(adblocker): reliably inject subframe scriptlets into cross-origin frames on Firefox

### DIFF
--- a/src/background/adblocker/ancestors.js
+++ b/src/background/adblocker/ancestors.js
@@ -21,7 +21,7 @@ export class FramesHierarchy {
     return this.tabs.findIndex((tab) => tab.id === tabId);
   }
 
-  track(target, details) {
+  updateAncestry(target, details) {
     const { tabId, frameId, parentFrameId, documentId = '' } = target;
     const tabIndex = this.#findTab(tabId);
 

--- a/src/background/adblocker/ancestors.js
+++ b/src/background/adblocker/ancestors.js
@@ -21,12 +21,10 @@ export class FramesHierarchy {
     return this.tabs.findIndex((tab) => tab.id === tabId);
   }
 
-  ancestors(target, details) {
-    let { tabId, frameId, parentFrameId, documentId = '' } = target;
+  track(target, details) {
+    const { tabId, frameId, parentFrameId, documentId = '' } = target;
     const tabIndex = this.#findTab(tabId);
 
-    // If the tab is just registered, we can skip retrieving
-    // the ancestor chain as there's no details stored.
     if (tabIndex === -1) {
       // Only build the list from the main frame.
       if (parentFrameId === -1) {
@@ -35,11 +33,10 @@ export class FramesHierarchy {
           frames: [{ id: frameId, parent: parentFrameId, documentId, details }],
         });
       }
-      return [];
+      return;
     }
 
     const frames = this.tabs[tabIndex].frames;
-    const chain = [];
 
     // Handle frame updates and replacements
     let frameIndex = frames.length;
@@ -77,31 +74,21 @@ export class FramesHierarchy {
       });
     }
 
-    // If no parent, return empty chain
-    if (parentFrameId === -1) {
-      return [];
-    }
-
-    // Build the ancestor chain
-    frameIndex = 0;
-    while (frameIndex !== -1) {
-      frameIndex = frames.length;
-      while (--frameIndex >= 0) {
-        if (frames[frameIndex].id === parentFrameId) {
-          chain.push(frames[frameIndex].details);
-          parentFrameId = frames[frameIndex].parent;
-          if (parentFrameId === -1) {
-            // top-most frame reached
-            return chain;
-          }
-          break;
-        }
-      }
-    }
-
     // If hierarchy is incomplete, remove the tab
-    this.tabs.splice(tabIndex, 1);
-    return [];
+    if (parentFrameId !== -1 && !this.#isComplete(frames, parentFrameId)) {
+      this.tabs.splice(tabIndex, 1);
+    }
+  }
+
+  #isComplete(frames, parentFrameId) {
+    while (parentFrameId !== -1) {
+      const parent = frames.find((frame) => frame.id === parentFrameId);
+      if (!parent) {
+        return false;
+      }
+      parentFrameId = parent.parent;
+    }
+    return true;
   }
 
   ancestorsOf(tabId, frameId) {

--- a/src/background/adblocker/ancestors.js
+++ b/src/background/adblocker/ancestors.js
@@ -104,6 +104,27 @@ export class FramesHierarchy {
     return [];
   }
 
+  ancestorsOf(tabId, frameId) {
+    const tabIndex = this.#findTab(tabId);
+    if (tabIndex === -1) {
+      return [];
+    }
+
+    const frames = this.tabs[tabIndex].frames;
+    const chain = [];
+
+    let frame = frames.find((f) => f.id === frameId);
+    while (frame && frame.parent !== -1) {
+      frame = frames.find((f) => f.id === frame.parent);
+      if (!frame) {
+        return [];
+      }
+      chain.push(frame.details);
+    }
+
+    return chain;
+  }
+
   #handleFrameReplacement(frames, frameIndex, frameId, parentFrameId, details, tabId) {
     const targetFrame = frames[frameIndex];
     targetFrame.parent = -1;

--- a/src/background/adblocker/cosmetics.js
+++ b/src/background/adblocker/cosmetics.js
@@ -73,7 +73,7 @@ function rememberInjectedDocument(documentId) {
   chrome.storage.session.set({ [INJECTED_DOCUMENTS_KEY]: [...injectedDocuments] }).catch(() => {});
 }
 
-async function injectScriptlets(filters, hostname, details, frameReady = false) {
+async function injectScriptlets(filters, hostname, details) {
   if (__CHROMIUM__) {
     if (filters.length === 0) return;
     if (details.documentId) {
@@ -111,15 +111,6 @@ async function injectScriptlets(filters, hostname, details, frameReady = false) 
       continue;
     }
 
-    // On Firefox, injecting a subframe-constrained (>>) scriptlet at webNavigation.onCommitted is
-    // unreliable for out-of-process (cross-origin) child frames: the committed document is still
-    // provisional and gets replaced, so executeScript resolves but its effect is discarded. We
-    // defer these injections to the content script's bootstrap message, which runs inside the
-    // frame's final document (frameReady), guaranteeing the scriptlet lands.
-    if (__FIREFOX__ && !frameReady) {
-      continue;
-    }
-
     injections.push(
       chrome.scripting
         .executeScript({
@@ -137,17 +128,12 @@ async function injectScriptlets(filters, hostname, details, frameReady = false) 
   }
 
   if (__FIREFOX__) {
-    // Content-script registration for direct-domain scriptlets is handled at onCommitted
-    // (document_start). The frameReady path only performs the deferred subframe executeScript
-    // above, so it must not touch the per-hostname registration state.
-    if (!frameReady) {
-      if (scriptletsByWorld.MAIN || scriptletsByWorld.ISOLATED) {
-        if (!contentScripts.isRegistered(hostname)) {
-          contentScripts.register(hostname, scriptletsByWorld);
-        }
-      } else {
-        contentScripts.unregister(hostname);
+    if (scriptletsByWorld.MAIN || scriptletsByWorld.ISOLATED) {
+      if (!contentScripts.isRegistered(hostname)) {
+        contentScripts.register(hostname, scriptletsByWorld);
       }
+    } else {
+      contentScripts.unregister(hostname);
     }
     return;
   }
@@ -206,7 +192,7 @@ framesHierarchy.handleWebextensionEvents();
  * (like registering content scripts for scriptlet filters on Firefox)
  */
 async function injectCosmetics(details, config) {
-  const { bootstrap: isBootstrap = false, scriptletsOnly, frameReady = false } = config;
+  const { bootstrap: isBootstrap = false, scriptletsOnly } = config;
 
   try {
     setup.pending && (await setup.pending);
@@ -245,12 +231,17 @@ async function injectCosmetics(details, config) {
   const scriptletsEnabled = !debugReady || debug.cosmeticsScriptlets;
   const extendedCSSEnabled = !debugReady || debug.cosmeticsExtendedCSS;
 
-  let ancestors = undefined;
+  let ancestors = details.ancestors;
   if (!scriptletsOnly && SUBFRAME_SCRIPTING.enabled && typeof parentFrameId === 'number') {
-    ancestors = framesHierarchy.ancestors(
+    const chain = framesHierarchy.ancestors(
       { tabId, frameId, parentFrameId, documentId },
       { domain, hostname },
     );
+
+    // On Firefox the chain is consumed by the bootstrap-message pass instead (see ancestorsOf).
+    if (!__FIREFOX__) {
+      ancestors = chain;
+    }
   }
 
   // Domain specific cosmetic filters (scriptlets and styles)
@@ -295,7 +286,7 @@ async function injectCosmetics(details, config) {
     }
 
     if (isBootstrap) {
-      injectScriptlets(scriptletsEnabled ? scriptFilters : [], hostname, details, frameReady);
+      injectScriptlets(scriptletsEnabled ? scriptFilters : [], hostname, details);
     }
 
     if (scriptletsOnly) {
@@ -368,23 +359,11 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       documentId: sender.documentId,
     };
 
-    // On Firefox, subframe-constrained (>>) scriptlets can't be reliably injected at
-    // webNavigation.onCommitted for out-of-process (cross-origin) child frames, because the
-    // committed document is provisional and gets replaced. The content script's bootstrap message
-    // runs inside the frame's final document, so we resolve the parent frame to evaluate the
-    // ancestor chain and inject the subframe scriptlet here, where the frame is ready.
-    if (__FIREFOX__ && msg.bootstrap && sender.frameId !== 0) {
-      chrome.webNavigation
-        .getFrame({ tabId: sender.tab.id, frameId: sender.frameId })
-        .then((frame) => {
-          if (frame && typeof frame.parentFrameId === 'number') {
-            details.parentFrameId = frame.parentFrameId;
-          }
-          return injectCosmetics(details, { ...msg, frameReady: true });
-        })
-        .then(sendResponse, () => sendResponse());
-
-      return true;
+    // On Firefox, subframe (>>) filters are evaluated only here: the bootstrap message comes from
+    // the frame's final document, while at onCommitted an out-of-process frame's document is still
+    // provisional, so an executeScript into it is discarded along with that document.
+    if (__FIREFOX__ && SUBFRAME_SCRIPTING.enabled && msg.bootstrap && sender.frameId !== 0) {
+      details.ancestors = framesHierarchy.ancestorsOf(sender.tab.id, sender.frameId);
     }
 
     injectCosmetics(details, msg).then(sendResponse);

--- a/src/background/adblocker/cosmetics.js
+++ b/src/background/adblocker/cosmetics.js
@@ -73,7 +73,7 @@ function rememberInjectedDocument(documentId) {
   chrome.storage.session.set({ [INJECTED_DOCUMENTS_KEY]: [...injectedDocuments] }).catch(() => {});
 }
 
-async function injectScriptlets(filters, hostname, details) {
+async function injectScriptlets(filters, hostname, details, frameReady = false) {
   if (__CHROMIUM__) {
     if (filters.length === 0) return;
     if (details.documentId) {
@@ -111,6 +111,15 @@ async function injectScriptlets(filters, hostname, details) {
       continue;
     }
 
+    // On Firefox, injecting a subframe-constrained (>>) scriptlet at webNavigation.onCommitted is
+    // unreliable for out-of-process (cross-origin) child frames: the committed document is still
+    // provisional and gets replaced, so executeScript resolves but its effect is discarded. We
+    // defer these injections to the content script's bootstrap message, which runs inside the
+    // frame's final document (frameReady), guaranteeing the scriptlet lands.
+    if (__FIREFOX__ && !frameReady) {
+      continue;
+    }
+
     injections.push(
       chrome.scripting
         .executeScript({
@@ -128,12 +137,17 @@ async function injectScriptlets(filters, hostname, details) {
   }
 
   if (__FIREFOX__) {
-    if (scriptletsByWorld.MAIN || scriptletsByWorld.ISOLATED) {
-      if (!contentScripts.isRegistered(hostname)) {
-        contentScripts.register(hostname, scriptletsByWorld);
+    // Content-script registration for direct-domain scriptlets is handled at onCommitted
+    // (document_start). The frameReady path only performs the deferred subframe executeScript
+    // above, so it must not touch the per-hostname registration state.
+    if (!frameReady) {
+      if (scriptletsByWorld.MAIN || scriptletsByWorld.ISOLATED) {
+        if (!contentScripts.isRegistered(hostname)) {
+          contentScripts.register(hostname, scriptletsByWorld);
+        }
+      } else {
+        contentScripts.unregister(hostname);
       }
-    } else {
-      contentScripts.unregister(hostname);
     }
     return;
   }
@@ -192,7 +206,7 @@ framesHierarchy.handleWebextensionEvents();
  * (like registering content scripts for scriptlet filters on Firefox)
  */
 async function injectCosmetics(details, config) {
-  const { bootstrap: isBootstrap = false, scriptletsOnly } = config;
+  const { bootstrap: isBootstrap = false, scriptletsOnly, frameReady = false } = config;
 
   try {
     setup.pending && (await setup.pending);
@@ -281,7 +295,7 @@ async function injectCosmetics(details, config) {
     }
 
     if (isBootstrap) {
-      injectScriptlets(scriptletsEnabled ? scriptFilters : [], hostname, details);
+      injectScriptlets(scriptletsEnabled ? scriptFilters : [], hostname, details, frameReady);
     }
 
     if (scriptletsOnly) {
@@ -353,6 +367,25 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       frameId: sender.frameId,
       documentId: sender.documentId,
     };
+
+    // On Firefox, subframe-constrained (>>) scriptlets can't be reliably injected at
+    // webNavigation.onCommitted for out-of-process (cross-origin) child frames, because the
+    // committed document is provisional and gets replaced. The content script's bootstrap message
+    // runs inside the frame's final document, so we resolve the parent frame to evaluate the
+    // ancestor chain and inject the subframe scriptlet here, where the frame is ready.
+    if (__FIREFOX__ && msg.bootstrap && sender.frameId !== 0) {
+      chrome.webNavigation
+        .getFrame({ tabId: sender.tab.id, frameId: sender.frameId })
+        .then((frame) => {
+          if (frame && typeof frame.parentFrameId === 'number') {
+            details.parentFrameId = frame.parentFrameId;
+          }
+          return injectCosmetics(details, { ...msg, frameReady: true });
+        })
+        .then(sendResponse, () => sendResponse());
+
+      return true;
+    }
 
     injectCosmetics(details, msg).then(sendResponse);
 

--- a/src/background/adblocker/cosmetics.js
+++ b/src/background/adblocker/cosmetics.js
@@ -231,14 +231,18 @@ async function injectCosmetics(details, config) {
   const scriptletsEnabled = !debugReady || debug.cosmeticsScriptlets;
   const extendedCSSEnabled = !debugReady || debug.cosmeticsExtendedCSS;
 
-  let ancestors = details.ancestors;
+  let ancestors;
+  if (__FIREFOX__) {
+    // Resolved upfront in the bootstrap handler via ancestorsOf(); see where details.ancestors is set.
+    ancestors = details.ancestors;
+  }
   if (!scriptletsOnly && SUBFRAME_SCRIPTING.enabled && typeof parentFrameId === 'number') {
+    // Also updates the frames hierarchy — the side effect Firefox reads back via ancestorsOf() — so the call runs on both platforms.
     const chain = framesHierarchy.ancestors(
       { tabId, frameId, parentFrameId, documentId },
       { domain, hostname },
     );
 
-    // On Firefox the chain is consumed by the bootstrap-message pass instead (see ancestorsOf).
     if (!__FIREFOX__) {
       ancestors = chain;
     }

--- a/src/background/adblocker/cosmetics.js
+++ b/src/background/adblocker/cosmetics.js
@@ -234,7 +234,10 @@ async function injectCosmetics(details, config) {
   let ancestors;
   if (SUBFRAME_SCRIPTING.enabled && !scriptletsOnly) {
     if (typeof parentFrameId === 'number') {
-      framesHierarchy.track({ tabId, frameId, parentFrameId, documentId }, { domain, hostname });
+      framesHierarchy.updateAncestry(
+        { tabId, frameId, parentFrameId, documentId },
+        { domain, hostname },
+      );
 
       if (!__FIREFOX__) {
         ancestors = framesHierarchy.ancestorsOf(tabId, frameId);

--- a/src/background/adblocker/cosmetics.js
+++ b/src/background/adblocker/cosmetics.js
@@ -231,20 +231,20 @@ async function injectCosmetics(details, config) {
   const scriptletsEnabled = !debugReady || debug.cosmeticsScriptlets;
   const extendedCSSEnabled = !debugReady || debug.cosmeticsExtendedCSS;
 
-  const subframesTracked =
-    !scriptletsOnly && SUBFRAME_SCRIPTING.enabled && typeof parentFrameId === 'number';
-
-  if (subframesTracked) {
-    // On Firefox the hierarchy is read back later, via ancestorsOf() in the message handler.
-    framesHierarchy.track({ tabId, frameId, parentFrameId, documentId }, { domain, hostname });
-  }
-
   let ancestors;
-  if (__FIREFOX__) {
-    // Resolved in the bootstrap message handler via ancestorsOf(); see where details.ancestors is set.
-    ancestors = details.ancestors;
-  } else if (subframesTracked) {
-    ancestors = framesHierarchy.ancestorsOf(tabId, frameId);
+  if (SUBFRAME_SCRIPTING.enabled && !scriptletsOnly) {
+    if (typeof parentFrameId === 'number') {
+      framesHierarchy.track({ tabId, frameId, parentFrameId, documentId }, { domain, hostname });
+
+      if (!__FIREFOX__) {
+        ancestors = framesHierarchy.ancestorsOf(tabId, frameId);
+      }
+    } else if (__FIREFOX__ && isBootstrap) {
+      // On Firefox, subframe (>>) filters are evaluated only at the bootstrap message: it comes
+      // from the frame's final document, while at onCommitted an out-of-process frame's document
+      // is still provisional, so an executeScript into it is discarded along with that document.
+      ancestors = framesHierarchy.ancestorsOf(tabId, frameId);
+    }
   }
 
   // Domain specific cosmetic filters (scriptlets and styles)
@@ -361,13 +361,6 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       frameId: sender.frameId,
       documentId: sender.documentId,
     };
-
-    // On Firefox, subframe (>>) filters are evaluated only here: the bootstrap message comes from
-    // the frame's final document, while at onCommitted an out-of-process frame's document is still
-    // provisional, so an executeScript into it is discarded along with that document.
-    if (__FIREFOX__ && SUBFRAME_SCRIPTING.enabled && msg.bootstrap && sender.frameId !== 0) {
-      details.ancestors = framesHierarchy.ancestorsOf(sender.tab.id, sender.frameId);
-    }
 
     injectCosmetics(details, msg).then(sendResponse);
 

--- a/src/background/adblocker/cosmetics.js
+++ b/src/background/adblocker/cosmetics.js
@@ -231,21 +231,20 @@ async function injectCosmetics(details, config) {
   const scriptletsEnabled = !debugReady || debug.cosmeticsScriptlets;
   const extendedCSSEnabled = !debugReady || debug.cosmeticsExtendedCSS;
 
+  const subframesTracked =
+    !scriptletsOnly && SUBFRAME_SCRIPTING.enabled && typeof parentFrameId === 'number';
+
+  if (subframesTracked) {
+    // On Firefox the hierarchy is read back later, via ancestorsOf() in the message handler.
+    framesHierarchy.track({ tabId, frameId, parentFrameId, documentId }, { domain, hostname });
+  }
+
   let ancestors;
   if (__FIREFOX__) {
-    // Resolved upfront in the bootstrap handler via ancestorsOf(); see where details.ancestors is set.
+    // Resolved in the bootstrap message handler via ancestorsOf(); see where details.ancestors is set.
     ancestors = details.ancestors;
-  }
-  if (!scriptletsOnly && SUBFRAME_SCRIPTING.enabled && typeof parentFrameId === 'number') {
-    // Also updates the frames hierarchy — the side effect Firefox reads back via ancestorsOf() — so the call runs on both platforms.
-    const chain = framesHierarchy.ancestors(
-      { tabId, frameId, parentFrameId, documentId },
-      { domain, hostname },
-    );
-
-    if (!__FIREFOX__) {
-      ancestors = chain;
-    }
+  } else if (subframesTracked) {
+    ancestors = framesHierarchy.ancestorsOf(tabId, frameId);
   }
 
   // Domain specific cosmetic filters (scriptlets and styles)

--- a/tests/e2e/spec/subframe-scripting.spec.js
+++ b/tests/e2e/spec/subframe-scripting.spec.js
@@ -24,26 +24,51 @@ const CROSS_ORIGIN_PROBE_URL = `${SUBPAGE_URL}subframe-probe.html`;
 const SAME_ORIGIN_PROBE_URL = `${PAGE_URL}subframe-probe.html`;
 const SUBDOMAIN_PROBE_URL = `http://sub.${PAGE_DOMAIN}:${PAGE_PORT}/subframe-probe.html`;
 
-function probeSubframe(src, windowMs = 3000) {
+function probeSubframe(src, { expectScriptlet = true, expectMarker = null, quietMs = 1000 } = {}) {
   return browser.executeAsync(
-    (src, windowMs, done) => {
+    (src, expectScriptlet, expectMarker, quietMs, done) => {
       const markers = new Set();
       let subframeScriptlet = false;
+      let settled = false;
+      let quietTimer = null;
+
+      const conditionMet = () =>
+        (!expectScriptlet || subframeScriptlet) &&
+        (expectMarker == null || markers.has(expectMarker));
+
+      const settle = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(quietTimer);
+        done({ subframeScriptlet, markers: [...markers] });
+      };
 
       window.addEventListener('message', (event) => {
         if (!event.data || event.data.__subframeProbe !== true) return;
-        if (event.data.subframeScriptlet) subframeScriptlet = true;
-        if (event.data.marker != null) markers.add(event.data.marker);
+        let changed = false;
+        if (event.data.subframeScriptlet && !subframeScriptlet) {
+          subframeScriptlet = true;
+          changed = true;
+        }
+        if (event.data.marker != null && !markers.has(event.data.marker)) {
+          markers.add(event.data.marker);
+          changed = true;
+        }
+        // Restart the quiet window on genuinely new state so a late double injection extends it.
+        if (changed && conditionMet()) {
+          clearTimeout(quietTimer);
+          quietTimer = setTimeout(settle, quietMs);
+        }
       });
 
       const iframe = document.createElement('iframe');
       iframe.src = src;
       document.body.appendChild(iframe);
-
-      setTimeout(() => done({ subframeScriptlet, markers: [...markers] }), windowMs);
     },
     src,
-    windowMs,
+    expectScriptlet,
+    expectMarker,
+    quietMs,
   );
 }
 
@@ -93,7 +118,10 @@ describe('Subframe scriptlet injection', function () {
   it('injects a direct-domain scriptlet exactly once into a subdomain child frame', async function () {
     await browser.url(PAGE_URL);
 
-    const report = await probeSubframe(SUBDOMAIN_PROBE_URL);
+    const report = await probeSubframe(SUBDOMAIN_PROBE_URL, {
+      expectScriptlet: false,
+      expectMarker: 'aaa+',
+    });
 
     await expect(report.markers).toContain('aaa+');
     await expect(report.markers.some((marker) => marker.includes('++'))).toBe(false);

--- a/tests/unit/ancestors.test.js
+++ b/tests/unit/ancestors.test.js
@@ -29,16 +29,16 @@ describe('#FramesHierarchy', () => {
      *    -> frame.bar.com (7)
      *      -> frameof.frame.bar.com (8)
      */
-    hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
+    hierarchy.updateAncestry({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
     assert.deepEqual(hierarchy.ancestorsOf(0, 0), []);
 
-    hierarchy.track({ tabId: 0, frameId: 1, parentFrameId: 0 }, 'frame.foo.com');
+    hierarchy.updateAncestry({ tabId: 0, frameId: 1, parentFrameId: 0 }, 'frame.foo.com');
     assert.deepEqual(hierarchy.ancestorsOf(0, 1), ['foo.com']);
 
-    hierarchy.track({ tabId: 0, frameId: 2, parentFrameId: 1 }, 'frameof.frame.foo.com');
+    hierarchy.updateAncestry({ tabId: 0, frameId: 2, parentFrameId: 1 }, 'frameof.frame.foo.com');
     assert.deepEqual(hierarchy.ancestorsOf(0, 2).reverse(), ['foo.com', 'frame.foo.com']);
 
-    hierarchy.track(
+    hierarchy.updateAncestry(
       { tabId: 0, frameId: 3, parentFrameId: 2 },
       'secondframeof.frameof.frame.foo.com',
     );
@@ -49,15 +49,15 @@ describe('#FramesHierarchy', () => {
     ]);
 
     // Create another branch of frames
-    hierarchy.track({ tabId: 0, frameId: 4, parentFrameId: 0 }, 'frame.foo.com');
+    hierarchy.updateAncestry({ tabId: 0, frameId: 4, parentFrameId: 0 }, 'frame.foo.com');
     assert.deepEqual(hierarchy.ancestorsOf(0, 4), ['foo.com']);
 
-    hierarchy.track({ tabId: 0, frameId: 5, parentFrameId: 4 }, 'frameof.frame.foo.com');
+    hierarchy.updateAncestry({ tabId: 0, frameId: 5, parentFrameId: 4 }, 'frameof.frame.foo.com');
     assert.deepEqual(hierarchy.ancestorsOf(0, 5).reverse(), ['foo.com', 'frame.foo.com']);
 
     // -- Returns same ancestor list for different branch but
     // same hostname
-    hierarchy.track(
+    hierarchy.updateAncestry(
       { tabId: 0, frameId: 3, parentFrameId: 2 },
       'secondframeof.frameof.frame.foo.com',
     );
@@ -68,13 +68,13 @@ describe('#FramesHierarchy', () => {
     ]);
 
     // Create another branch of frames
-    hierarchy.track({ tabId: 0, frameId: 6, parentFrameId: 0 }, 'bar.com');
+    hierarchy.updateAncestry({ tabId: 0, frameId: 6, parentFrameId: 0 }, 'bar.com');
     assert.deepEqual(hierarchy.ancestorsOf(0, 6), ['foo.com']);
 
-    hierarchy.track({ tabId: 0, frameId: 7, parentFrameId: 6 }, 'frame.bar.com');
+    hierarchy.updateAncestry({ tabId: 0, frameId: 7, parentFrameId: 6 }, 'frame.bar.com');
     assert.deepEqual(hierarchy.ancestorsOf(0, 7).reverse(), ['foo.com', 'bar.com']);
 
-    hierarchy.track({ tabId: 0, frameId: 8, parentFrameId: 7 }, 'frameof.frame.bar.com');
+    hierarchy.updateAncestry({ tabId: 0, frameId: 8, parentFrameId: 7 }, 'frameof.frame.bar.com');
     assert.deepEqual(hierarchy.ancestorsOf(0, 8).reverse(), [
       'foo.com',
       'bar.com',
@@ -260,11 +260,11 @@ describe('#FramesHierarchy', () => {
     const hierarchy = new FramesHierarchy();
 
     // Opens tab `foo.com`
-    hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
+    hierarchy.updateAncestry({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
     assert.deepEqual(hierarchy.ancestorsOf(0, 0), []);
 
     // Opens tab `bar.com`
-    hierarchy.track({ tabId: 1, frameId: 0, parentFrameId: -1 }, 'bar.com');
+    hierarchy.updateAncestry({ tabId: 1, frameId: 0, parentFrameId: -1 }, 'bar.com');
     assert.deepEqual(hierarchy.ancestorsOf(1, 0), []);
 
     assert.deepEqual(hierarchy.tabs, [
@@ -293,15 +293,15 @@ describe('#FramesHierarchy', () => {
     ]);
 
     // `foo.com` creates frame `proxy.foo.com`
-    hierarchy.track({ tabId: 0, frameId: 1, parentFrameId: 0 }, 'proxy.foo.com');
+    hierarchy.updateAncestry({ tabId: 0, frameId: 1, parentFrameId: 0 }, 'proxy.foo.com');
     assert.deepEqual(hierarchy.ancestorsOf(0, 1), ['foo.com']);
 
     // `bar.com` creates frame `proxy.bar.com`
-    hierarchy.track({ tabId: 1, frameId: 1, parentFrameId: 0 }, 'proxy.bar.com');
+    hierarchy.updateAncestry({ tabId: 1, frameId: 1, parentFrameId: 0 }, 'proxy.bar.com');
     assert.deepEqual(hierarchy.ancestorsOf(1, 1), ['bar.com']);
 
     // Opens tab `bar.com`
-    hierarchy.track({ tabId: 2, frameId: 0, parentFrameId: -1 }, 'baz.com');
+    hierarchy.updateAncestry({ tabId: 2, frameId: 0, parentFrameId: -1 }, 'baz.com');
     assert.deepEqual(hierarchy.ancestorsOf(2, 0), []);
 
     assert.deepEqual(hierarchy.tabs, [
@@ -366,14 +366,14 @@ describe('#FramesHierarchy', () => {
     const hierarchy = new FramesHierarchy();
 
     for (let i = 0; i < 100; i++) {
-      hierarchy.track({ tabId: i, frameId: 0, parentFrameId: -1 }, 'foo.com');
+      hierarchy.updateAncestry({ tabId: i, frameId: 0, parentFrameId: -1 }, 'foo.com');
       assert.deepEqual(hierarchy.ancestorsOf(i, 0), []);
     }
 
     for (let i = 0; i < 100; i++) {
       // Subframe ID should not start with 0.
       for (let k = 1; k < 200; k++) {
-        hierarchy.track({ tabId: i, frameId: k, parentFrameId: 0 }, 'frame.foo.com');
+        hierarchy.updateAncestry({ tabId: i, frameId: k, parentFrameId: 0 }, 'frame.foo.com');
         assert.deepEqual(hierarchy.ancestorsOf(i, k), ['foo.com']);
       }
     }
@@ -391,13 +391,13 @@ describe('#FramesHierarchy', () => {
     // Assume that the main frame tab information didn't reach.
     // We rather not to execute scripts when the chain is
     // incomplete, which might lead to the potential breakage.
-    hierarchy.track({ tabId: 0, frameId: 10, parentFrameId: 2 }, 'foo.com');
+    hierarchy.updateAncestry({ tabId: 0, frameId: 10, parentFrameId: 2 }, 'foo.com');
     assert.deepEqual(hierarchy.ancestorsOf(0, 10), []);
 
-    hierarchy.track({ tabId: 0, frameId: 10, parentFrameId: 5 }, 'foo.com');
+    hierarchy.updateAncestry({ tabId: 0, frameId: 10, parentFrameId: 5 }, 'foo.com');
     assert.deepEqual(hierarchy.ancestorsOf(0, 10), []);
 
-    hierarchy.track({ tabId: 0, frameId: 10, parentFrameId: 11 }, 'foo.com');
+    hierarchy.updateAncestry({ tabId: 0, frameId: 10, parentFrameId: 11 }, 'foo.com');
     assert.deepEqual(hierarchy.ancestorsOf(0, 10), []);
 
     assert.deepEqual(hierarchy.tabs, []);
@@ -406,8 +406,8 @@ describe('#FramesHierarchy', () => {
   it('drops the tab when a tracked frame points to an unknown ancestor', () => {
     const hierarchy = new FramesHierarchy();
 
-    hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
-    hierarchy.track({ tabId: 0, frameId: 2, parentFrameId: 1 }, 'orphan.foo.com');
+    hierarchy.updateAncestry({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
+    hierarchy.updateAncestry({ tabId: 0, frameId: 2, parentFrameId: 1 }, 'orphan.foo.com');
 
     assert.deepEqual(hierarchy.ancestorsOf(0, 2), []);
     assert.deepEqual(hierarchy.tabs, []);
@@ -418,15 +418,15 @@ describe('#FramesHierarchy', () => {
 
     // Assume that `frameId` is something unexpected, such as
     // omnibox prehit situation.
-    hierarchy.track({ tabId: 0, frameId: 10, parentFrameId: -1 }, 'about:blank');
+    hierarchy.updateAncestry({ tabId: 0, frameId: 10, parentFrameId: -1 }, 'about:blank');
     assert.deepEqual(hierarchy.ancestorsOf(0, 10), []);
 
     // Creates new main frame with `foo.com`.
-    hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
+    hierarchy.updateAncestry({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
     assert.deepEqual(hierarchy.ancestorsOf(0, 0), []);
 
     // Opens subframe.
-    hierarchy.track({ tabId: 0, frameId: 1, parentFrameId: 0 }, 'frame.foo.com');
+    hierarchy.updateAncestry({ tabId: 0, frameId: 1, parentFrameId: 0 }, 'frame.foo.com');
     assert.deepEqual(hierarchy.ancestorsOf(0, 1), ['foo.com']);
 
     assert.deepEqual(hierarchy.tabs, [
@@ -459,13 +459,13 @@ describe('#FramesHierarchy', () => {
   it('handles service worker restart', () => {
     const hierarchy = new FramesHierarchy();
 
-    hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
+    hierarchy.updateAncestry({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
     assert.deepEqual(hierarchy.ancestorsOf(0, 0), []);
 
-    hierarchy.track({ tabId: 0, frameId: 1, parentFrameId: 0 }, 'frame.foo.com');
+    hierarchy.updateAncestry({ tabId: 0, frameId: 1, parentFrameId: 0 }, 'frame.foo.com');
     assert.deepEqual(hierarchy.ancestorsOf(0, 1), ['foo.com']);
 
-    hierarchy.track({ tabId: 0, frameId: 2, parentFrameId: 1 }, 'bar.com');
+    hierarchy.updateAncestry({ tabId: 0, frameId: 2, parentFrameId: 1 }, 'bar.com');
     assert.deepEqual(hierarchy.ancestorsOf(0, 2).reverse(), ['foo.com', 'frame.foo.com']);
 
     const tabsBeforeClear = structuredClone(hierarchy.tabs);
@@ -499,26 +499,35 @@ describe('#FramesHierarchy', () => {
       const hierarchy = new FramesHierarchy();
 
       // Assume that a user opens a new tab.
-      hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1, documentId: 'A0' }, 'about:blank');
+      hierarchy.updateAncestry(
+        { tabId: 0, frameId: 0, parentFrameId: -1, documentId: 'A0' },
+        'about:blank',
+      );
       assert.deepEqual(hierarchy.ancestorsOf(0, 0), []);
 
       // Assume there's a pre-rendering frame as the user types
       // into the omnibox or the address bar.
-      hierarchy.track({ tabId: 0, frameId: 1_000, parentFrameId: 0, documentId: 'Z0' }, 'foo.com');
+      hierarchy.updateAncestry(
+        { tabId: 0, frameId: 1_000, parentFrameId: 0, documentId: 'Z0' },
+        'foo.com',
+      );
       assert.deepEqual(hierarchy.ancestorsOf(0, 1_000), ['about:blank']);
 
       // The pre-rendering frame calls another frame.
-      hierarchy.track(
+      hierarchy.updateAncestry(
         { tabId: 0, frameId: 1_001, parentFrameId: 1_000, documentId: 'Z1' },
         'frame.foo.com',
       );
       assert.deepEqual(hierarchy.ancestorsOf(0, 1_001).reverse(), ['about:blank', 'foo.com']);
 
       // The pre-rendered frame gets replaced into main frame.
-      hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1, documentId: 'Z0' }, 'foo.com');
+      hierarchy.updateAncestry(
+        { tabId: 0, frameId: 0, parentFrameId: -1, documentId: 'Z0' },
+        'foo.com',
+      );
       assert.deepEqual(hierarchy.ancestorsOf(0, 0), []);
 
-      hierarchy.track(
+      hierarchy.updateAncestry(
         { tabId: 0, frameId: 1_001, parentFrameId: 0, documentId: 'Z1' },
         'frame.foo.com',
       );
@@ -549,28 +558,37 @@ describe('#FramesHierarchy', () => {
       const hierarchy = new FramesHierarchy();
 
       // Assume that a user opens a new tab.
-      hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1, documentId: 'A0' }, 'about:blank');
+      hierarchy.updateAncestry(
+        { tabId: 0, frameId: 0, parentFrameId: -1, documentId: 'A0' },
+        'about:blank',
+      );
       assert.deepEqual(hierarchy.ancestorsOf(0, 0), []);
 
       // Assume that a user navigates the tab into the website.
-      hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1, documentId: 'B1' }, 'foo.com');
+      hierarchy.updateAncestry(
+        { tabId: 0, frameId: 0, parentFrameId: -1, documentId: 'B1' },
+        'foo.com',
+      );
       assert.deepEqual(hierarchy.ancestorsOf(0, 0), []);
 
       // Assume the page creates some frames.
-      hierarchy.track(
+      hierarchy.updateAncestry(
         { tabId: 0, frameId: 1, parentFrameId: 0, documentId: 'B2' },
         'oauth.foo.com',
       );
       assert.deepEqual(hierarchy.ancestorsOf(0, 1), ['foo.com']);
 
-      hierarchy.track(
+      hierarchy.updateAncestry(
         { tabId: 0, frameId: 2, parentFrameId: 0, documentId: 'B3' },
         'consent.foo.com',
       );
       assert.deepEqual(hierarchy.ancestorsOf(0, 2), ['foo.com']);
 
       // Assume user refreshes the page.
-      hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1, documentId: 'C1' }, 'foo.com');
+      hierarchy.updateAncestry(
+        { tabId: 0, frameId: 0, parentFrameId: -1, documentId: 'C1' },
+        'foo.com',
+      );
       assert.deepEqual(hierarchy.ancestorsOf(0, 0), []);
 
       assert.deepEqual(hierarchy.tabs, [
@@ -593,9 +611,9 @@ describe('#FramesHierarchy', () => {
     it('returns the tracked ancestor chain without mutating the hierarchy', () => {
       const hierarchy = new FramesHierarchy();
 
-      hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
-      hierarchy.track({ tabId: 0, frameId: 1, parentFrameId: 0 }, 'frame.foo.com');
-      hierarchy.track({ tabId: 0, frameId: 2, parentFrameId: 1 }, 'frameof.frame.foo.com');
+      hierarchy.updateAncestry({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
+      hierarchy.updateAncestry({ tabId: 0, frameId: 1, parentFrameId: 0 }, 'frame.foo.com');
+      hierarchy.updateAncestry({ tabId: 0, frameId: 2, parentFrameId: 1 }, 'frameof.frame.foo.com');
 
       const before = structuredClone(hierarchy.tabs);
 
@@ -611,7 +629,7 @@ describe('#FramesHierarchy', () => {
 
       assert.deepEqual(hierarchy.ancestorsOf(0, 1), []);
 
-      hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
+      hierarchy.updateAncestry({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
 
       assert.deepEqual(hierarchy.ancestorsOf(0, 1), []);
     });
@@ -619,7 +637,7 @@ describe('#FramesHierarchy', () => {
     it('returns an empty chain when the hierarchy is incomplete', () => {
       const hierarchy = new FramesHierarchy();
 
-      hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
+      hierarchy.updateAncestry({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
       hierarchy.tabs[0].frames.push({ id: 2, parent: 1, documentId: '', details: 'orphan.com' });
 
       assert.deepEqual(hierarchy.ancestorsOf(0, 2), []);

--- a/tests/unit/ancestors.test.js
+++ b/tests/unit/ancestors.test.js
@@ -29,68 +29,57 @@ describe('#FramesHierarchy', () => {
      *    -> frame.bar.com (7)
      *      -> frameof.frame.bar.com (8)
      */
-    assert.deepEqual(
-      hierarchy.ancestors({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com'),
-      [],
+    hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
+    assert.deepEqual(hierarchy.ancestorsOf(0, 0), []);
+
+    hierarchy.track({ tabId: 0, frameId: 1, parentFrameId: 0 }, 'frame.foo.com');
+    assert.deepEqual(hierarchy.ancestorsOf(0, 1), ['foo.com']);
+
+    hierarchy.track({ tabId: 0, frameId: 2, parentFrameId: 1 }, 'frameof.frame.foo.com');
+    assert.deepEqual(hierarchy.ancestorsOf(0, 2).reverse(), ['foo.com', 'frame.foo.com']);
+
+    hierarchy.track(
+      { tabId: 0, frameId: 3, parentFrameId: 2 },
+      'secondframeof.frameof.frame.foo.com',
     );
-    assert.deepEqual(
-      hierarchy.ancestors({ tabId: 0, frameId: 1, parentFrameId: 0 }, 'frame.foo.com'),
-      ['foo.com'],
-    );
-    assert.deepEqual(
-      hierarchy
-        .ancestors({ tabId: 0, frameId: 2, parentFrameId: 1 }, 'frameof.frame.foo.com')
-        .reverse(),
-      ['foo.com', 'frame.foo.com'],
-    );
-    assert.deepEqual(
-      hierarchy
-        .ancestors(
-          { tabId: 0, frameId: 3, parentFrameId: 2 },
-          'secondframeof.frameof.frame.foo.com',
-        )
-        .reverse(),
-      ['foo.com', 'frame.foo.com', 'frameof.frame.foo.com'],
-    );
+    assert.deepEqual(hierarchy.ancestorsOf(0, 3).reverse(), [
+      'foo.com',
+      'frame.foo.com',
+      'frameof.frame.foo.com',
+    ]);
 
     // Create another branch of frames
-    assert.deepEqual(
-      hierarchy.ancestors({ tabId: 0, frameId: 4, parentFrameId: 0 }, 'frame.foo.com'),
-      ['foo.com'],
-    );
-    assert.deepEqual(
-      hierarchy
-        .ancestors({ tabId: 0, frameId: 5, parentFrameId: 4 }, 'frameof.frame.foo.com')
-        .reverse(),
-      ['foo.com', 'frame.foo.com'],
-    );
+    hierarchy.track({ tabId: 0, frameId: 4, parentFrameId: 0 }, 'frame.foo.com');
+    assert.deepEqual(hierarchy.ancestorsOf(0, 4), ['foo.com']);
+
+    hierarchy.track({ tabId: 0, frameId: 5, parentFrameId: 4 }, 'frameof.frame.foo.com');
+    assert.deepEqual(hierarchy.ancestorsOf(0, 5).reverse(), ['foo.com', 'frame.foo.com']);
 
     // -- Returns same ancestor list for different branch but
     // same hostname
-    assert.deepEqual(
-      hierarchy
-        .ancestors(
-          { tabId: 0, frameId: 3, parentFrameId: 2 },
-          'secondframeof.frameof.frame.foo.com',
-        )
-        .reverse(),
-      ['foo.com', 'frame.foo.com', 'frameof.frame.foo.com'],
+    hierarchy.track(
+      { tabId: 0, frameId: 3, parentFrameId: 2 },
+      'secondframeof.frameof.frame.foo.com',
     );
+    assert.deepEqual(hierarchy.ancestorsOf(0, 3).reverse(), [
+      'foo.com',
+      'frame.foo.com',
+      'frameof.frame.foo.com',
+    ]);
 
     // Create another branch of frames
-    assert.deepEqual(hierarchy.ancestors({ tabId: 0, frameId: 6, parentFrameId: 0 }, 'bar.com'), [
+    hierarchy.track({ tabId: 0, frameId: 6, parentFrameId: 0 }, 'bar.com');
+    assert.deepEqual(hierarchy.ancestorsOf(0, 6), ['foo.com']);
+
+    hierarchy.track({ tabId: 0, frameId: 7, parentFrameId: 6 }, 'frame.bar.com');
+    assert.deepEqual(hierarchy.ancestorsOf(0, 7).reverse(), ['foo.com', 'bar.com']);
+
+    hierarchy.track({ tabId: 0, frameId: 8, parentFrameId: 7 }, 'frameof.frame.bar.com');
+    assert.deepEqual(hierarchy.ancestorsOf(0, 8).reverse(), [
       'foo.com',
+      'bar.com',
+      'frame.bar.com',
     ]);
-    assert.deepEqual(
-      hierarchy.ancestors({ tabId: 0, frameId: 7, parentFrameId: 6 }, 'frame.bar.com').reverse(),
-      ['foo.com', 'bar.com'],
-    );
-    assert.deepEqual(
-      hierarchy
-        .ancestors({ tabId: 0, frameId: 8, parentFrameId: 7 }, 'frameof.frame.bar.com')
-        .reverse(),
-      ['foo.com', 'bar.com', 'frame.bar.com'],
-    );
 
     // Validate the entire structure
     assert.deepEqual(hierarchy.tabs, [
@@ -271,15 +260,12 @@ describe('#FramesHierarchy', () => {
     const hierarchy = new FramesHierarchy();
 
     // Opens tab `foo.com`
-    assert.deepEqual(
-      hierarchy.ancestors({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com'),
-      [],
-    );
+    hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
+    assert.deepEqual(hierarchy.ancestorsOf(0, 0), []);
+
     // Opens tab `bar.com`
-    assert.deepEqual(
-      hierarchy.ancestors({ tabId: 1, frameId: 0, parentFrameId: -1 }, 'bar.com'),
-      [],
-    );
+    hierarchy.track({ tabId: 1, frameId: 0, parentFrameId: -1 }, 'bar.com');
+    assert.deepEqual(hierarchy.ancestorsOf(1, 0), []);
 
     assert.deepEqual(hierarchy.tabs, [
       {
@@ -307,21 +293,16 @@ describe('#FramesHierarchy', () => {
     ]);
 
     // `foo.com` creates frame `proxy.foo.com`
-    assert.deepEqual(
-      hierarchy.ancestors({ tabId: 0, frameId: 1, parentFrameId: 0 }, 'proxy.foo.com'),
-      ['foo.com'],
-    );
+    hierarchy.track({ tabId: 0, frameId: 1, parentFrameId: 0 }, 'proxy.foo.com');
+    assert.deepEqual(hierarchy.ancestorsOf(0, 1), ['foo.com']);
+
     // `bar.com` creates frame `proxy.bar.com`
-    assert.deepEqual(
-      hierarchy.ancestors({ tabId: 1, frameId: 1, parentFrameId: 0 }, 'proxy.bar.com'),
-      ['bar.com'],
-    );
+    hierarchy.track({ tabId: 1, frameId: 1, parentFrameId: 0 }, 'proxy.bar.com');
+    assert.deepEqual(hierarchy.ancestorsOf(1, 1), ['bar.com']);
 
     // Opens tab `bar.com`
-    assert.deepEqual(
-      hierarchy.ancestors({ tabId: 2, frameId: 0, parentFrameId: -1 }, 'baz.com'),
-      [],
-    );
+    hierarchy.track({ tabId: 2, frameId: 0, parentFrameId: -1 }, 'baz.com');
+    assert.deepEqual(hierarchy.ancestorsOf(2, 0), []);
 
     assert.deepEqual(hierarchy.tabs, [
       {
@@ -385,19 +366,15 @@ describe('#FramesHierarchy', () => {
     const hierarchy = new FramesHierarchy();
 
     for (let i = 0; i < 100; i++) {
-      assert.deepEqual(
-        hierarchy.ancestors({ tabId: i, frameId: 0, parentFrameId: -1 }, 'foo.com'),
-        [],
-      );
+      hierarchy.track({ tabId: i, frameId: 0, parentFrameId: -1 }, 'foo.com');
+      assert.deepEqual(hierarchy.ancestorsOf(i, 0), []);
     }
 
     for (let i = 0; i < 100; i++) {
       // Subframe ID should not start with 0.
       for (let k = 1; k < 200; k++) {
-        assert.deepEqual(
-          hierarchy.ancestors({ tabId: i, frameId: k, parentFrameId: 0 }, 'frame.foo.com'),
-          ['foo.com'],
-        );
+        hierarchy.track({ tabId: i, frameId: k, parentFrameId: 0 }, 'frame.foo.com');
+        assert.deepEqual(hierarchy.ancestorsOf(i, k), ['foo.com']);
       }
     }
 
@@ -414,19 +391,25 @@ describe('#FramesHierarchy', () => {
     // Assume that the main frame tab information didn't reach.
     // We rather not to execute scripts when the chain is
     // incomplete, which might lead to the potential breakage.
-    assert.deepEqual(
-      hierarchy.ancestors({ tabId: 0, frameId: 10, parentFrameId: 2 }, 'foo.com'),
-      [],
-    );
-    assert.deepEqual(
-      hierarchy.ancestors({ tabId: 0, frameId: 10, parentFrameId: 5 }, 'foo.com'),
-      [],
-    );
-    assert.deepEqual(
-      hierarchy.ancestors({ tabId: 0, frameId: 10, parentFrameId: 11 }, 'foo.com'),
-      [],
-    );
+    hierarchy.track({ tabId: 0, frameId: 10, parentFrameId: 2 }, 'foo.com');
+    assert.deepEqual(hierarchy.ancestorsOf(0, 10), []);
 
+    hierarchy.track({ tabId: 0, frameId: 10, parentFrameId: 5 }, 'foo.com');
+    assert.deepEqual(hierarchy.ancestorsOf(0, 10), []);
+
+    hierarchy.track({ tabId: 0, frameId: 10, parentFrameId: 11 }, 'foo.com');
+    assert.deepEqual(hierarchy.ancestorsOf(0, 10), []);
+
+    assert.deepEqual(hierarchy.tabs, []);
+  });
+
+  it('drops the tab when a tracked frame points to an unknown ancestor', () => {
+    const hierarchy = new FramesHierarchy();
+
+    hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
+    hierarchy.track({ tabId: 0, frameId: 2, parentFrameId: 1 }, 'orphan.foo.com');
+
+    assert.deepEqual(hierarchy.ancestorsOf(0, 2), []);
     assert.deepEqual(hierarchy.tabs, []);
   });
 
@@ -435,20 +418,16 @@ describe('#FramesHierarchy', () => {
 
     // Assume that `frameId` is something unexpected, such as
     // omnibox prehit situation.
-    assert.deepEqual(
-      hierarchy.ancestors({ tabId: 0, frameId: 10, parentFrameId: -1 }, 'about:blank'),
-      [],
-    );
+    hierarchy.track({ tabId: 0, frameId: 10, parentFrameId: -1 }, 'about:blank');
+    assert.deepEqual(hierarchy.ancestorsOf(0, 10), []);
+
     // Creates new main frame with `foo.com`.
-    assert.deepEqual(
-      hierarchy.ancestors({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com'),
-      [],
-    );
+    hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
+    assert.deepEqual(hierarchy.ancestorsOf(0, 0), []);
+
     // Opens subframe.
-    assert.deepEqual(
-      hierarchy.ancestors({ tabId: 0, frameId: 1, parentFrameId: 0 }, 'frame.foo.com'),
-      ['foo.com'],
-    );
+    hierarchy.track({ tabId: 0, frameId: 1, parentFrameId: 0 }, 'frame.foo.com');
+    assert.deepEqual(hierarchy.ancestorsOf(0, 1), ['foo.com']);
 
     assert.deepEqual(hierarchy.tabs, [
       {
@@ -480,18 +459,14 @@ describe('#FramesHierarchy', () => {
   it('handles service worker restart', () => {
     const hierarchy = new FramesHierarchy();
 
-    assert.deepEqual(
-      hierarchy.ancestors({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com'),
-      [],
-    );
-    assert.deepEqual(
-      hierarchy.ancestors({ tabId: 0, frameId: 1, parentFrameId: 0 }, 'frame.foo.com'),
-      ['foo.com'],
-    );
-    assert.deepEqual(
-      hierarchy.ancestors({ tabId: 0, frameId: 2, parentFrameId: 1 }, 'bar.com').reverse(),
-      ['foo.com', 'frame.foo.com'],
-    );
+    hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
+    assert.deepEqual(hierarchy.ancestorsOf(0, 0), []);
+
+    hierarchy.track({ tabId: 0, frameId: 1, parentFrameId: 0 }, 'frame.foo.com');
+    assert.deepEqual(hierarchy.ancestorsOf(0, 1), ['foo.com']);
+
+    hierarchy.track({ tabId: 0, frameId: 2, parentFrameId: 1 }, 'bar.com');
+    assert.deepEqual(hierarchy.ancestorsOf(0, 2).reverse(), ['foo.com', 'frame.foo.com']);
 
     const tabsBeforeClear = structuredClone(hierarchy.tabs);
 
@@ -524,52 +499,30 @@ describe('#FramesHierarchy', () => {
       const hierarchy = new FramesHierarchy();
 
       // Assume that a user opens a new tab.
-      assert.deepEqual(
-        hierarchy.ancestors(
-          { tabId: 0, frameId: 0, parentFrameId: -1, documentId: 'A0' },
-          'about:blank',
-        ),
-        [],
-      );
+      hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1, documentId: 'A0' }, 'about:blank');
+      assert.deepEqual(hierarchy.ancestorsOf(0, 0), []);
+
       // Assume there's a pre-rendering frame as the user types
       // into the omnibox or the address bar.
-      assert.deepEqual(
-        hierarchy.ancestors(
-          { tabId: 0, frameId: 1_000, parentFrameId: 0, documentId: 'Z0' },
-          'foo.com',
-        ),
-        ['about:blank'],
-      );
+      hierarchy.track({ tabId: 0, frameId: 1_000, parentFrameId: 0, documentId: 'Z0' }, 'foo.com');
+      assert.deepEqual(hierarchy.ancestorsOf(0, 1_000), ['about:blank']);
+
       // The pre-rendering frame calls another frame.
-      assert.deepEqual(
-        hierarchy
-          .ancestors(
-            {
-              tabId: 0,
-              frameId: 1_001,
-              parentFrameId: 1_000,
-              documentId: 'Z1',
-            },
-            'frame.foo.com',
-          )
-          .reverse(),
-        ['about:blank', 'foo.com'],
+      hierarchy.track(
+        { tabId: 0, frameId: 1_001, parentFrameId: 1_000, documentId: 'Z1' },
+        'frame.foo.com',
       );
+      assert.deepEqual(hierarchy.ancestorsOf(0, 1_001).reverse(), ['about:blank', 'foo.com']);
+
       // The pre-rendered frame gets replaced into main frame.
-      assert.deepEqual(
-        hierarchy.ancestors(
-          { tabId: 0, frameId: 0, parentFrameId: -1, documentId: 'Z0' },
-          'foo.com',
-        ),
-        [],
+      hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1, documentId: 'Z0' }, 'foo.com');
+      assert.deepEqual(hierarchy.ancestorsOf(0, 0), []);
+
+      hierarchy.track(
+        { tabId: 0, frameId: 1_001, parentFrameId: 0, documentId: 'Z1' },
+        'frame.foo.com',
       );
-      assert.deepEqual(
-        hierarchy.ancestors(
-          { tabId: 0, frameId: 1_001, parentFrameId: 0, documentId: 'Z1' },
-          'frame.foo.com',
-        ),
-        ['foo.com'],
-      );
+      assert.deepEqual(hierarchy.ancestorsOf(0, 1_001), ['foo.com']);
 
       assert.deepEqual(hierarchy.tabs, [
         {
@@ -596,45 +549,29 @@ describe('#FramesHierarchy', () => {
       const hierarchy = new FramesHierarchy();
 
       // Assume that a user opens a new tab.
-      assert.deepEqual(
-        hierarchy.ancestors(
-          { tabId: 0, frameId: 0, parentFrameId: -1, documentId: 'A0' },
-          'about:blank',
-        ),
-        [],
-      );
+      hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1, documentId: 'A0' }, 'about:blank');
+      assert.deepEqual(hierarchy.ancestorsOf(0, 0), []);
+
       // Assume that a user navigates the tab into the website.
-      assert.deepEqual(
-        hierarchy.ancestors(
-          { tabId: 0, frameId: 0, parentFrameId: -1, documentId: 'B1' },
-          'foo.com',
-        ),
-        [],
-      );
+      hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1, documentId: 'B1' }, 'foo.com');
+      assert.deepEqual(hierarchy.ancestorsOf(0, 0), []);
+
       // Assume the page creates some frames.
-      assert.deepEqual(
-        hierarchy.ancestors(
-          { tabId: 0, frameId: 1, parentFrameId: 0, documentId: 'B2' },
-          'oauth.foo.com',
-        ),
-        ['foo.com'],
+      hierarchy.track(
+        { tabId: 0, frameId: 1, parentFrameId: 0, documentId: 'B2' },
+        'oauth.foo.com',
       );
-      assert.deepEqual(
-        hierarchy.ancestors(
-          { tabId: 0, frameId: 2, parentFrameId: 0, documentId: 'B3' },
-          'consent.foo.com',
-        ),
-        ['foo.com'],
+      assert.deepEqual(hierarchy.ancestorsOf(0, 1), ['foo.com']);
+
+      hierarchy.track(
+        { tabId: 0, frameId: 2, parentFrameId: 0, documentId: 'B3' },
+        'consent.foo.com',
       );
+      assert.deepEqual(hierarchy.ancestorsOf(0, 2), ['foo.com']);
 
       // Assume user refreshes the page.
-      assert.deepEqual(
-        hierarchy.ancestors(
-          { tabId: 0, frameId: 0, parentFrameId: -1, documentId: 'C1' },
-          'foo.com',
-        ),
-        [],
-      );
+      hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1, documentId: 'C1' }, 'foo.com');
+      assert.deepEqual(hierarchy.ancestorsOf(0, 0), []);
 
       assert.deepEqual(hierarchy.tabs, [
         {
@@ -656,9 +593,9 @@ describe('#FramesHierarchy', () => {
     it('returns the tracked ancestor chain without mutating the hierarchy', () => {
       const hierarchy = new FramesHierarchy();
 
-      hierarchy.ancestors({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
-      hierarchy.ancestors({ tabId: 0, frameId: 1, parentFrameId: 0 }, 'frame.foo.com');
-      hierarchy.ancestors({ tabId: 0, frameId: 2, parentFrameId: 1 }, 'frameof.frame.foo.com');
+      hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
+      hierarchy.track({ tabId: 0, frameId: 1, parentFrameId: 0 }, 'frame.foo.com');
+      hierarchy.track({ tabId: 0, frameId: 2, parentFrameId: 1 }, 'frameof.frame.foo.com');
 
       const before = structuredClone(hierarchy.tabs);
 
@@ -674,7 +611,7 @@ describe('#FramesHierarchy', () => {
 
       assert.deepEqual(hierarchy.ancestorsOf(0, 1), []);
 
-      hierarchy.ancestors({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
+      hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
 
       assert.deepEqual(hierarchy.ancestorsOf(0, 1), []);
     });
@@ -682,7 +619,7 @@ describe('#FramesHierarchy', () => {
     it('returns an empty chain when the hierarchy is incomplete', () => {
       const hierarchy = new FramesHierarchy();
 
-      hierarchy.ancestors({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
+      hierarchy.track({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
       hierarchy.tabs[0].frames.push({ id: 2, parent: 1, documentId: '', details: 'orphan.com' });
 
       assert.deepEqual(hierarchy.ancestorsOf(0, 2), []);

--- a/tests/unit/ancestors.test.js
+++ b/tests/unit/ancestors.test.js
@@ -651,4 +651,41 @@ describe('#FramesHierarchy', () => {
       ]);
     });
   });
+
+  describe('ancestorsOf', () => {
+    it('returns the tracked ancestor chain without mutating the hierarchy', () => {
+      const hierarchy = new FramesHierarchy();
+
+      hierarchy.ancestors({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
+      hierarchy.ancestors({ tabId: 0, frameId: 1, parentFrameId: 0 }, 'frame.foo.com');
+      hierarchy.ancestors({ tabId: 0, frameId: 2, parentFrameId: 1 }, 'frameof.frame.foo.com');
+
+      const before = structuredClone(hierarchy.tabs);
+
+      assert.deepEqual(hierarchy.ancestorsOf(0, 2).reverse(), ['foo.com', 'frame.foo.com']);
+      assert.deepEqual(hierarchy.ancestorsOf(0, 1), ['foo.com']);
+      assert.deepEqual(hierarchy.ancestorsOf(0, 0), []);
+
+      assert.deepEqual(hierarchy.tabs, before);
+    });
+
+    it('returns an empty chain for unknown tabs and frames', () => {
+      const hierarchy = new FramesHierarchy();
+
+      assert.deepEqual(hierarchy.ancestorsOf(0, 1), []);
+
+      hierarchy.ancestors({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
+
+      assert.deepEqual(hierarchy.ancestorsOf(0, 1), []);
+    });
+
+    it('returns an empty chain when the hierarchy is incomplete', () => {
+      const hierarchy = new FramesHierarchy();
+
+      hierarchy.ancestors({ tabId: 0, frameId: 0, parentFrameId: -1 }, 'foo.com');
+      hierarchy.tabs[0].frames.push({ id: 2, parent: 1, documentId: '', details: 'orphan.com' });
+
+      assert.deepEqual(hierarchy.ancestorsOf(0, 2), []);
+    });
+  });
 });


### PR DESCRIPTION
A subframe scriptlet e2e test was flaky on Firefox CI: subframe-constrained (`>>`) scriptlets intermittently failed to inject into cross-origin child frames. On Firefox these frames are out-of-process (Fission), and the document present at `webNavigation.onCommitted` is provisional and gets replaced — so `chrome.scripting.executeScript` resolves successfully but the injected scriptlet is discarded with the throwaway document, permanently missing that frame.

This defers Firefox subframe (`>>`) scriptlet injection from `onCommitted` to the content script's `injectCosmetics` bootstrap message, which runs at `document_start` inside the frame's final document, so the injection reliably lands.

- On Firefox, scriptlets without a subframe constraint keep the direct-domain content-script registration; only `>>`-constrained ones are injected per-frame, and only once the bootstrap message arrives from the frame's final document.
- The bootstrap message sender carries no `parentFrameId`, so the `>>` constraint is evaluated against the frames hierarchy the background already tracks: on Firefox, `injectCosmetics` resolves the sender's ancestor chain with `ancestorsOf()` when the bootstrap message arrives.
- `FramesHierarchy` now separates writes from reads: `updateAncestry()` only maintains the hierarchy — replacing the previous `ancestors()` call that updated it and returned the chain in one step — and `ancestorsOf()` is the single way to resolve a chain on both platforms. The recovery behavior where a frame pointing at an unknown ancestor drops the whole tab is preserved and now covered by a unit test.
- Simplified the e2e probe back to a single iframe (removing the earlier retry/recreate workaround) now that first-frame injection is reliable.

Subframe filter evaluation stays behind the `SUBFRAME_SCRIPTING` flag and Chromium injection behavior is unchanged. Verified with 3 consecutive Firefox runs of the subframe-scripting spec — all 4 tests pass with 0 retries.

## Test plan

- On Firefox, open a page embedding a cross-origin iframe targeted by a `>>` scriptlet filter and confirm the scriptlet takes effect inside the iframe on first load.
- Reload the page several times and confirm the scriptlet keeps applying, with no intermittent misses.
- On Chromium, open the same page and confirm subframe scriptlets and styles behave as before.
