### PR TITLE
fix(e2e): avoid locale-dependent custom filters save check

### DIFF
--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -182,15 +182,11 @@ export async function setCustomFilters(filters) {
   const input = await getExtensionElement('input:custom-filters');
   await input.setValue(filters.join('\n'));
 
-  await getExtensionElement('button:custom-filters:save').click();
+  const saveButton = await getExtensionElement('button:custom-filters:save');
+  await saveButton.click();
 
-  // The save button label is updated with a success message only after the
-  // background round-trip completes (rebuilding the custom engine and reloading
-  // the main engine). Waiting for it ensures the filters are applied before the
-  // test navigates, otherwise cosmetic/scriptlet injection may run too early.
-  await expect(getExtensionElement('button:custom-filters:save')).toHaveText(
-    'Filter rules have been updated',
-  );
+  await expect(saveButton).toHaveElementProperty('disabled', true);
+  await expect(saveButton).toHaveElementProperty('disabled', false, { wait: 15000 });
 
   await waitForIdleBackgroundTasks();
 }


### PR DESCRIPTION
Chrome e2e custom-filters tests were brittle on machines where the extension UI is not in English, because the `setCustomFilters` helper waited for a hardcoded English success label after saving custom rules, causing local failures whenever the UI text was translated.

This removes the locale-dependent text assertion and instead keeps synchronization locale-agnostic by waiting for the background idle signal and then verifying the Save button returns to its enabled state once the update cycle completes. These checks preserve the original intent of waiting for the save to finish without depending on any localized labels, and were verified by running the Chrome custom-filters spec and linting the updated helper file.
