### PR TITLE
chore(deps): bump @whotracksme/reporting from 11.0.1 to 11.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@ghostery/urlfilter2dnr": "^2.0.4",
         "@github/relative-time-element": "^5.3.0",
         "@sentry/browser": "^10.66.0",
-        "@whotracksme/reporting": "^11.0.1",
+        "@whotracksme/reporting": "^11.0.2",
         "apexsankey": "github:ghostery/apexsankey",
         "bowser": "^2.14.1",
         "csv-stringify": "^6.8.1",
@@ -5456,9 +5456,9 @@
       }
     },
     "node_modules/@whotracksme/reporting": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@whotracksme/reporting/-/reporting-11.0.1.tgz",
-      "integrity": "sha512-ZdF178SP73Ws4uPJ1pyUDcDj4FZd8npT9QR9O0fCrMNEvk3sEPmXujovDy5qrQ6YRMBwBXAsi1A3TnvolXe3+Q==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@whotracksme/reporting/-/reporting-11.0.2.tgz",
+      "integrity": "sha512-eFTaNalaQPsjdtTDqUfrmiH/t9iGHlCelwBzPRK/FUacgJUiegAZBqJSOSHSxirfKBEBw/6VUtRB4Cka98Hz0A==",
       "license": "MPL-2.0",
       "workspaces": [
         "reporting",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@ghostery/urlfilter2dnr": "^2.0.4",
     "@github/relative-time-element": "^5.3.0",
     "@sentry/browser": "^10.66.0",
-    "@whotracksme/reporting": "^11.0.1",
+    "@whotracksme/reporting": "^11.0.2",
     "apexsankey": "github:ghostery/apexsankey",
     "bowser": "^2.14.1",
     "csv-stringify": "^6.8.1",


### PR DESCRIPTION
Keeps the anti-tracking and ad-blocking reporting engine up to date by upgrading the `@whotracksme/reporting` dependency to its latest patch release.

This bumps `@whotracksme/reporting` from 11.0.1 to 11.0.2 in `package.json` and updates `package-lock.json` accordingly to pull in the latest fixes and improvements from the package.