### PR TITLE
fix(telemetry): keep pings alive when insights DB is unavailable

### DIFF
--- a/src/background/telemetry/index.js
+++ b/src/background/telemetry/index.js
@@ -42,7 +42,7 @@ const setup = asyncSetup('telemetry', [
         const [options, config, dailyStats] = await Promise.all([
           store.resolve(Options),
           store.resolve(Config),
-          store.resolve(DailyStats, yesterdayId),
+          store.resolve(DailyStats, yesterdayId).catch(() => undefined),
         ]);
 
         return {
@@ -50,7 +50,7 @@ const setup = asyncSetup('telemetry', [
           config,
           // Use the previous full UTC day so the bucket doesn't depend on
           // the time-of-day at which the ping fires.
-          yesterdayPages: dailyStats.pages,
+          yesterdayPages: dailyStats?.pages,
           userSettings: __CHROMIUM__ ? await chrome.action?.getUserSettings?.() : undefined,
           isAllowedIncognitoAccess: await chrome.extension.isAllowedIncognitoAccess(),
         };

--- a/src/background/telemetry/metrics.js
+++ b/src/background/telemetry/metrics.js
@@ -238,9 +238,9 @@ export default class Metrics {
         buildQueryPair('sm', conf.options.blockAnnoyances ? '1' : '0') +
         // Antitracking state
         buildQueryPair('at', conf.options.blockTrackers ? '1' : '0') +
-        // Page views yesterday (0=none, 1=<10, 2=>=10)
+        // Page views yesterday (-1=undefined, 0=none, 1=<10, 2=>=10)
         // prettier-ignore
-        buildQueryPair('pv', conf.yesterdayPages >= 10 ? '2' : conf.yesterdayPages > 0 ? '1' : '0') +
+        buildQueryPair('pv', conf.yesterdayPages === undefined ? '-1' : conf.yesterdayPages >= 10 ? '2' : conf.yesterdayPages > 0 ? '1' : '0') +
         // SERP visits yesterday (0=none, 1=<10, 2=>=10)
         buildQueryPair('se', this._getSearchSignal()) +
         // Recency, days since last active daily ping


### PR DESCRIPTION
The telemetry daily ping resolves the previous day's DailyStats to compute the page-views bucket (`pv`). When the insights database is unavailable, `store.resolve(DailyStats, ...)` throws and rejects the setup promise, which aborts the entire ping — so the extension stops sending daily telemetry whenever that store read fails.

This guards the DailyStats read with `.catch(() => undefined)` and reads `dailyStats?.pages` optionally, so a failing insights DB no longer blocks the ping. The `pv` query pair now emits `-1` when the value is unknown, keeping it distinct from `0` (genuinely no page views) so the yesterday-pages signal stays accurate.