### PR TITLE
fix(content_scripts): validate window message source in notification and element-picker bridges

### DIFF
--- a/src/content_scripts/element-picker.js
+++ b/src/content_scripts/element-picker.js
@@ -9,6 +9,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
+import { isFromExtensionFrame } from '/utils/messaging.js';
+
 const PICKER_STYLES = `
   position: absolute;
   overflow: hidden;
@@ -434,7 +436,7 @@ function getElementArea(element) {
   /* Message Event Listener from Popup */
 
   const messageEventListener = (event) => {
-    if (event.origin + '/' !== chrome.runtime.getURL('/').toLowerCase()) return;
+    if (!isFromExtensionFrame(event)) return;
 
     switch (event.data?.type) {
       case 'gh:element-picker:resize':

--- a/src/content_scripts/element-picker.js
+++ b/src/content_scripts/element-picker.js
@@ -434,6 +434,8 @@ function getElementArea(element) {
   /* Message Event Listener from Popup */
 
   const messageEventListener = (event) => {
+    if (event.source !== iframe.contentWindow) return;
+
     switch (event.data?.type) {
       case 'gh:element-picker:resize':
         container.style.height = `${event.data.height}px`;

--- a/src/content_scripts/element-picker.js
+++ b/src/content_scripts/element-picker.js
@@ -434,7 +434,7 @@ function getElementArea(element) {
   /* Message Event Listener from Popup */
 
   const messageEventListener = (event) => {
-    if (event.source !== iframe.contentWindow) return;
+    if (event.origin + '/' !== chrome.runtime.getURL('/').toLowerCase()) return;
 
     switch (event.data?.type) {
       case 'gh:element-picker:resize':

--- a/src/content_scripts/notifications.js
+++ b/src/content_scripts/notifications.js
@@ -110,6 +110,8 @@ function mount(url, position = 'right', debug = false) {
   const iframe = shadowRoot.querySelector('iframe');
 
   window.addEventListener('message', (e) => {
+    if (e.source !== iframe.contentWindow) return;
+
     const type = e.data?.type;
 
     if (type === notifications.RESIZE_WINDOW_EVENT) {

--- a/src/content_scripts/notifications.js
+++ b/src/content_scripts/notifications.js
@@ -10,6 +10,7 @@
  */
 
 import * as notifications from '/utils/notifications.js';
+import { isFromExtensionFrame } from '/utils/messaging.js';
 
 const WRAPPER_ELEMENT = 'ghostery-notification-wrapper';
 
@@ -110,7 +111,7 @@ function mount(url, position = 'right', debug = false) {
   const iframe = shadowRoot.querySelector('iframe');
 
   window.addEventListener('message', (e) => {
-    if (e.origin + '/' !== chrome.runtime.getURL('/').toLowerCase()) return;
+    if (!isFromExtensionFrame(e)) return;
 
     const type = e.data?.type;
 

--- a/src/content_scripts/notifications.js
+++ b/src/content_scripts/notifications.js
@@ -110,7 +110,7 @@ function mount(url, position = 'right', debug = false) {
   const iframe = shadowRoot.querySelector('iframe');
 
   window.addEventListener('message', (e) => {
-    if (e.source !== iframe.contentWindow) return;
+    if (e.origin + '/' !== chrome.runtime.getURL('/').toLowerCase()) return;
 
     const type = e.data?.type;
 

--- a/src/content_scripts/trackers-preview.js
+++ b/src/content_scripts/trackers-preview.js
@@ -10,6 +10,7 @@
  */
 
 import { drawWheel } from '/ui/wheel.js';
+import { isFromExtensionFrame } from '/utils/messaging.js';
 
 const WRAPPER_CLASS = 'wtm-popup-iframe-wrapper';
 
@@ -184,10 +185,7 @@ function setupTrackersPreview(popupUrl) {
 }
 
 window.addEventListener('message', (message) => {
-  if (
-    message.origin + '/' !== chrome.runtime.getURL('/').toLowerCase() ||
-    typeof message.data !== 'string'
-  ) {
+  if (!isFromExtensionFrame(message) || typeof message.data !== 'string') {
     return;
   }
 

--- a/src/utils/messaging.js
+++ b/src/utils/messaging.js
@@ -9,6 +9,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
+const EXTENSION_ORIGIN = chrome.runtime.getURL('/').toLowerCase().slice(0, -1);
+
 export function isFromExtensionFrame(event) {
-  return event.origin + '/' === chrome.runtime.getURL('/').toLowerCase();
+  return event.origin === EXTENSION_ORIGIN;
 }

--- a/src/utils/messaging.js
+++ b/src/utils/messaging.js
@@ -1,0 +1,14 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+export function isFromExtensionFrame(event) {
+  return event.origin + '/' === chrome.runtime.getURL('/').toLowerCase();
+}


### PR DESCRIPTION
Web pages could forge `window` messages to dismiss Ghostery notifications, resize the notification iframe, or hijack the element picker, because these content scripts didn't check the message sender.

They now reject messages that aren't from the extension's own frame, via a shared `isFromExtensionFrame` helper (also adopted by `trackers-preview.js`). Applies to all builds: Chrome, Edge, Brave, Opera, Firefox.

## Test plan
- Trigger a notification: still shows, resizes, and closes.
- Open the element picker: highlight, slider, "similar", hide, and close still work.
- Search results tracker wheel: still opens and its popup controls still work.