### PR TITLE
fix(e2e): unblock WebDriver navigation to extension pages on Firefox 153+

### DIFF
--- a/tests/e2e/wdio.conf.js
+++ b/tests/e2e/wdio.conf.js
@@ -124,7 +124,11 @@ export const config = {
       browserVersion: 'stable',
       cacheDir: '.wdio',
       'moz:firefoxOptions': {
-        args: argv.debug ? [] : ['-headless', '--width=1024', '--height=768'],
+        // Firefox 153+ blocks WebDriver navigation to moz-extension:// and
+        // about:debugging pages unless system access is explicitly allowed.
+        args: ['--remote-allow-system-access'].concat(
+          argv.debug ? [] : ['-headless', '--width=1024', '--height=768'],
+        ),
         prefs: {
           'browser.cache.disk.enable': false,
           'browser.cache.memory.enable': false,


### PR DESCRIPTION
## Description

All Firefox e2e jobs have been failing since Firefox 153.0 rolled out to CI (July 22). Every session dies on the first navigation to an extension page with:

```
WebDriverError: Navigation to "moz-extension://.../pages/onboarding/index.html" is not allowed in this context
```

Firefox 153 restricts WebDriver navigation to a safe-list of schemes (`http`, `https`, `file`, `blob`, `about:blank`) unless the browser is started with system access enabled (`isWebdriverSafeNavigationURL` in Marionette). `moz-extension://` pages and `about:debugging` are outside that list, so the whole suite fails at setup.

This adds `--remote-allow-system-access` to the Firefox capabilities, restoring navigation to extension pages. The update config inherits the capability, so both `wdio` and `wdio:update` runs are covered.

## Test plan

- Run the Firefox e2e suite on Firefox 153: `npm run wdio -- --target=firefox` — the browser opens extension pages (onboarding, settings, panel) instead of failing on the first navigation, and the suite completes green.