### PR TITLE
Full GPC support (set "navigator.globalPrivacyControl" on Firefox and Chromium)

### DIFF
--- a/src/background/never-consent/gpc.js
+++ b/src/background/never-consent/gpc.js
@@ -24,6 +24,58 @@ import {
 } from '/utils/dnr.js';
 import Request from '/utils/request.js';
 
+const GPC_CONTENT_SCRIPT_ID = 'gpc';
+
+// In addition to the Sec-GPC header, the GPC spec requires exposing
+// `navigator.globalPrivacyControl` before the page's scripts run:
+// https://w3c.github.io/gpc/#javascript-property-to-detect-preference
+//
+// The content script patches the DOM API in the MAIN world at document_start.
+// At that point, it is too late to read the settings; thus, the script is
+// registered (with persistAcrossSessions) while GPC is enabled and
+// unregistered while it is disabled.
+async function updateGPCContentScript(options) {
+  const enabled =
+    options.terms &&
+    options.blockAnnoyances &&
+    options.autoconsent.gpc &&
+    !isGloballyPaused(options);
+
+  const registered =
+    (
+      await chrome.scripting.getRegisteredContentScripts({
+        ids: [GPC_CONTENT_SCRIPT_ID],
+      })
+    ).length > 0;
+
+  if (enabled === registered) return;
+
+  if (enabled) {
+    await chrome.scripting.registerContentScripts([
+      {
+        id: GPC_CONTENT_SCRIPT_ID,
+        js: ['/content_scripts/gpc.js'],
+        matches: ['http://*/*', 'https://*/*'],
+        runAt: 'document_start',
+        matchOriginAsFallback: true,
+        allFrames: true,
+        world: 'MAIN',
+        persistAcrossSessions: true,
+      },
+    ]);
+
+    console.log('[autoconsent] GPC content script has been registered');
+  } else {
+    await chrome.scripting.unregisterContentScripts({
+      ids: [GPC_CONTENT_SCRIPT_ID],
+    });
+
+    console.log('[autoconsent] GPC content script has been unregistered');
+  }
+}
+
+OptionsObserver.addListener(updateGPCContentScript);
+
 if (__CHROMIUM__) {
   async function updateGPCRule(options) {
     // Disabled GPC

--- a/src/background/never-consent/gpc.js
+++ b/src/background/never-consent/gpc.js
@@ -15,7 +15,7 @@ import { ACTION_DISABLE_GPC } from '@ghostery/config';
 import Config from '/store/config.js';
 import Options, { getPausedDetails, isGloballyPaused } from '/store/options.js';
 
-import * as OptionsObserver from '/utils/options-observer.js';
+import { addListener, isOptionEqual } from '/utils/options-observer.js';
 import {
   GPC_RULE_ID,
   GPC_RULE_PRIORITY,
@@ -26,6 +26,15 @@ import Request from '/utils/request.js';
 
 const GPC_CONTENT_SCRIPT_ID = 'gpc';
 
+function shouldEnableGPC(options) {
+  return (
+    options.terms &&
+    options.blockAnnoyances &&
+    options.autoconsent.gpc &&
+    !isGloballyPaused(options)
+  );
+}
+
 // In addition to the Sec-GPC header, the GPC spec requires exposing
 // `navigator.globalPrivacyControl` before the page's scripts run:
 // https://w3c.github.io/gpc/#javascript-property-to-detect-preference
@@ -34,12 +43,13 @@ const GPC_CONTENT_SCRIPT_ID = 'gpc';
 // At that point, it is too late to read the settings; thus, the script is
 // registered (with persistAcrossSessions) while GPC is enabled and
 // unregistered while it is disabled.
-async function updateGPCContentScript(options) {
-  const enabled =
-    options.terms &&
-    options.blockAnnoyances &&
-    options.autoconsent.gpc &&
-    !isGloballyPaused(options);
+async function updateGPCContentScript(options, lastOptions) {
+  const enabledNow = shouldEnableGPC(options);
+
+  if (lastOptions) {
+    const wasEnabledBefore = shouldEnableGPC(lastOptions);
+    if (enabledNow === wasEnabledBefore) return;
+  }
 
   const registered =
     (
@@ -47,10 +57,9 @@ async function updateGPCContentScript(options) {
         ids: [GPC_CONTENT_SCRIPT_ID],
       })
     ).length > 0;
+  if (enabledNow === registered) return;
 
-  if (enabled === registered) return;
-
-  if (enabled) {
+  if (enabledNow) {
     await chrome.scripting.registerContentScripts([
       {
         id: GPC_CONTENT_SCRIPT_ID,
@@ -74,24 +83,27 @@ async function updateGPCContentScript(options) {
   }
 }
 
-OptionsObserver.addListener(updateGPCContentScript);
+addListener(updateGPCContentScript);
 
 if (__CHROMIUM__) {
-  async function updateGPCRule(options) {
-    // Disabled GPC
+  async function updateGPCRule(options, lastOptions) {
+    const enabledNow = shouldEnableGPC(options);
+
     if (
-      !options.terms ||
-      !options.blockAnnoyances ||
-      !options.autoconsent.gpc ||
-      isGloballyPaused(options)
+      lastOptions &&
+      enabledNow === shouldEnableGPC(lastOptions) &&
+      isOptionEqual(options.paused, lastOptions.paused)
     ) {
+      return;
+    }
+
+    // Disabled GPC: clear the GPC rule if it exists
+    if (!enabledNow) {
       const existingRules = await getDynamicRulesByIds([GPC_RULE_ID]);
-      // Clear the GPC rule if it exists
       if (existingRules.length) {
         await chrome.declarativeNetRequest.updateDynamicRules({
           removeRuleIds: [GPC_RULE_ID],
         });
-
         console.log('[autoconsent] GPC rule has been removed');
       }
 
@@ -149,7 +161,7 @@ if (__CHROMIUM__) {
   }
 
   // Re-evaluate when Options change
-  OptionsObserver.addListener(updateGPCRule);
+  addListener(updateGPCRule);
 
   // Re-evaluate when remote Config changes (e.g. ACTION_DISABLE_GPC domains)
   store.observe(Config, async (_, config, lastConfig) => {

--- a/src/background/never-consent/gpc.js
+++ b/src/background/never-consent/gpc.js
@@ -176,13 +176,7 @@ if (__FIREFOX__) {
   chrome.webRequest.onBeforeSendHeaders.addListener(
     (details) => {
       const options = store.get(Options);
-      if (
-        !store.ready(options) ||
-        !options.terms ||
-        !options.blockAnnoyances ||
-        !options.autoconsent.gpc ||
-        isGloballyPaused(options)
-      ) {
+      if (!store.ready(options) || !shouldEnableGPC(options)) {
         return;
       }
 

--- a/src/content_scripts/gpc.js
+++ b/src/content_scripts/gpc.js
@@ -1,0 +1,34 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+// Ensures that `navigator.globalPrivacyControl` is truthy (GPC support):
+// https://w3c.github.io/gpc/#javascript-property-to-detect-preference
+//
+// Injected into the page's MAIN world at document_start (including all frames).
+// It must not rely on message passing to read the current settings, since the
+// page must see the final value before any of its scripts run. Instead, the
+// background registers or unregisters this content script when the GPC option
+// changes (see background/never-consent/gpc.js).
+(function () {
+  try {
+    if (!window.navigator.globalPrivacyControl) {
+      Object.defineProperty(navigator, 'globalPrivacyControl', {
+        get() {
+          return true;
+        },
+        configurable: true,
+        enumerable: true,
+      });
+    }
+  } catch {
+    // ignore
+  }
+})();

--- a/src/content_scripts/gpc.js
+++ b/src/content_scripts/gpc.js
@@ -11,12 +11,6 @@
 
 // Ensures that `navigator.globalPrivacyControl` is truthy (GPC support):
 // https://w3c.github.io/gpc/#javascript-property-to-detect-preference
-//
-// Injected into the page's MAIN world at document_start (including all frames).
-// It must not rely on message passing to read the current settings, since the
-// page must see the final value before any of its scripts run. Instead, the
-// background registers or unregisters this content script when the GPC option
-// changes (see background/never-consent/gpc.js).
 (function () {
   try {
     if (!window.navigator.globalPrivacyControl) {

--- a/src/manifest.chromium.json
+++ b/src/manifest.chromium.json
@@ -108,6 +108,10 @@
       "run_at": "document_start"
     },
     {
+      "js": ["content_scripts/gpc.js"],
+      "run_at": "background_execute_script"
+    },
+    {
       "js": ["content_scripts/trackers-preview.js"],
       "run_at": "background_execute_script"
     },

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -76,6 +76,10 @@
       "run_at": "document_start"
     },
     {
+      "js": ["content_scripts/gpc.js"],
+      "run_at": "background_execute_script"
+    },
+    {
       "js": ["content_scripts/trackers-preview.js"],
       "run_at": "background_execute_script"
     },

--- a/tests/e2e/spec/main.spec.js
+++ b/tests/e2e/spec/main.spec.js
@@ -80,6 +80,28 @@ describe('Main Features', function () {
 
       await setPrivacyToggle('never-consent', true);
     });
+
+    it('sets navigator.globalPrivacyControl in the page main world', async function () {
+      await browser.url(PAGE_URL);
+
+      // Main frame
+      expect(await browser.execute(() => navigator.globalPrivacyControl)).toBe(true);
+
+      // Sub-frame — each frame has its own navigator, so injection must reach it
+      await switchFrame($('#iframe-static'));
+      expect(await browser.execute(() => navigator.globalPrivacyControl)).toBe(true);
+      await browser.switchFrame(null);
+
+      // Disabling never-consent must unregister the content script,
+      // so pages loaded afterwards no longer see the patched value
+      await setPrivacyToggle('never-consent', false);
+
+      await browser.url(PAGE_URL);
+
+      expect(await browser.execute(() => !!navigator.globalPrivacyControl)).toBe(false);
+
+      await setPrivacyToggle('never-consent', true);
+    });
   });
 
   describe('Ad-Blocking', function () {


### PR DESCRIPTION
Background:
https://w3c.github.io/gpc/#javascript-property-to-detect-preference

We already set the Sec-GPC signal, but the spec requires also to have navigator.globalPrivacyControl be truthy before the page runs.

Test pages:
- https://globalprivacycontrol.org/
- https://browserleaks.com/donottrack

---

Note: this is a follow-up of https://github.com/ghostery/ghostery-extension/pull/3490

The patching logic is the same, but it integrates now with the existing UI toggle (part of Never-Consent).