### PR TITLE
fix(errors): restore Sentry stack traces for frameless errors

### DIFF
--- a/src/background/dnr.js
+++ b/src/background/dnr.js
@@ -24,7 +24,7 @@ import { isFilterConditionAccepted } from '/utils/engines.js';
 
 import { UPDATE_ENGINES_DELAY } from './adblocker/engines.js';
 import { updateRedirectProtectionRules } from './redirect-protection.js';
-import { captureException } from '/utils/errors.js';
+import { captureError } from '/utils/errors.js';
 
 if (__CHROMIUM__) {
   const DNR_RESOURCES = chrome.runtime
@@ -260,7 +260,7 @@ if (__CHROMIUM__) {
         }
       } catch (e) {
         console.error(`[dnr] Error while updating static rulesets:`, e);
-        captureException(e, { critical: true, once: true });
+        captureError(e, { critical: true, once: true });
       }
     }
   }

--- a/src/background/storage.js
+++ b/src/background/storage.js
@@ -10,8 +10,8 @@
  */
 
 import { checkSessionStorage } from '/utils/storage.js';
-import { captureException } from '/utils/errors.js';
+import { captureError } from '/utils/errors.js';
 
 checkSessionStorage().catch((e) => {
-  captureException(e, { critical: true, once: true });
+  captureError(e, { critical: true, once: true });
 });

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -62,16 +62,30 @@ Sentry.init(config);
 
 getBrowserInfo().then(
   ({ token, version, os, osVersion }) => {
-    Sentry.setTag('ua', token);
-    Sentry.setTag('uaVersion', version);
-    Sentry.setTag('os', os);
-    Sentry.setTag('osVersion', osVersion);
+    // Sentry rejects tags with empty or NaN values ("expected a non-empty value"),
+    // which discards the whole tag, so only set tags that carry a usable value.
+    const setTag = (key, value) => {
+      if (value === '' || value == null || (typeof value === 'number' && Number.isNaN(value))) {
+        return;
+      }
+      Sentry.setTag(key, value);
+    };
+
+    setTag('ua', token);
+    setTag('uaVersion', version);
+    setTag('os', os);
+    setTag('osVersion', osVersion);
   },
   // empty error handled for tests
   () => {},
 );
 
-export async function captureException(error, { critical = false, once = false } = {}) {
+// Do not rename this to `captureException`/`captureMessage`. Sentry's stack
+// parser (STRIP_FRAME_REGEXP = /captureMessage|captureException/) drops the
+// innermost stack frame whose function name matches, assuming it belongs to the
+// SDK. Our fallback stack below is captured inside this function, so such a name
+// would strip the only frame frameless errors have, leaving no stack trace.
+export async function captureError(error, { critical = false, once = false } = {}) {
   // Capture a fallback stack synchronously, before the first `await`,
   // so it still includes the caller frame when `error.stack` has no frames
   // (e.g. errors from chrome.* API rejections or serialized across contexts).
@@ -117,4 +131,4 @@ export async function captureException(error, { critical = false, once = false }
 }
 
 // Debug tools
-(globalThis.ghostery ??= {}).errors = { captureException };
+(globalThis.ghostery ??= {}).errors = { captureException: captureError };


### PR DESCRIPTION
Critical errors reported to Sentry (for example the DNR "The set of enabled rulesets exceeds the rule count limit" failure) were arriving with no stack trace, showing only the exception value and leaving them effectively undebuggable. The cause is a name collision: Sentry's stack parser strips the innermost frame whose function name matches `/captureMessage|captureException/`, assuming it belongs to the SDK, and our error wrapper was named `captureException` and captured its fallback stack inside itself — for frameless `chrome.*` rejections that wrapper frame is the only one, so the entire stack trace was removed.

- Renamed the wrapper `captureException` to `captureError` (and its callers in `dnr.js` and `storage.js`) so the fallback frame is no longer mistaken for an SDK frame and survives; added a comment so it is not renamed back.
- Guard Sentry tag values so empty or NaN values (such as `osVersion`) no longer make Sentry reject the entire tag set.