### PR TITLE
fix(element-picker): slider overflow caused by transient scrollbar

### DIFF
--- a/src/pages/element-picker/styles.css
+++ b/src/pages/element-picker/styles.css
@@ -1,6 +1,7 @@
 html {
   --background-brand-strong: var(--background-wtm-solid);
   --border-brand-solid: var(--background-wtm-solid);
+  overflow: hidden;
 }
 
 body {


### PR DESCRIPTION
On Windows Chromium browsers (Chrome, Edge, Opera), the Distraction Eraser slider overflowed its bar because a scrollbar briefly appeared when the element picker container changed state, leaving the range component with an incorrect `clientWidth`. Firefox and macOS were unaffected since their overlay scrollbars don't reserve layout space.

This sets `overflow: hidden` on the `html` element in the element picker styles, preventing the transient scrollbar so the range component always measures the correct width.

Fixes #3466