### PR TITLE
chore(deps): update Node.js to 26.5.1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 25.9.0
+nodejs 26.5.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "web-ext": "^10.5.0"
       },
       "engines": {
-        "npm": ">=11.6.3"
+        "npm": ">=11.17.0"
       }
     },
     "node_modules/@adguard/agtree": {
@@ -5895,19 +5895,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/addons-linter/node_modules/yauzl": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
-      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/addons-moz-compare": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/addons-moz-compare/-/addons-moz-compare-1.3.0.tgz",
@@ -5940,19 +5927,6 @@
         "safe-compare": {
           "optional": true
         }
-      }
-    },
-    "node_modules/addons-scanner-utils/node_modules/yauzl": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
-      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/adm-zip": {
@@ -9656,16 +9630,6 @@
       "optional": true,
       "dependencies": {
         "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/fdir": {
@@ -17128,24 +17092,16 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
-    "node_modules/yauzl/node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "license": "MIT",
+        "pend": "~1.2.0"
+      },
       "engines": {
-        "node": "*"
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "engineStrict": true,
   "engines": {
-    "npm": ">=11.6.3"
+    "npm": ">=11.17.0"
   },
   "webExt": {
     "sourceDir": "./dist/"

--- a/package.json
+++ b/package.json
@@ -64,6 +64,9 @@
     "plotly.js-basic-dist": "^3.7.0",
     "tldts-experimental": "^7.4.9"
   },
+  "overrides": {
+    "yauzl": "3.4.0"
+  },
   "dataDependencies": {
     "redirect-resources": "dcbabf1634ecee547b9ecdf5ff893a5096d98d9bcecbda74481dc845b4949b7b",
     "wtm-bloomfilter": "2026-07-27",


### PR DESCRIPTION
Node.js 26.5.1 (released 2026-07-28) is a security patch release that fixes two high-severity issues — CVE-2026-56848 (HTTP/2 use-after-free) and CVE-2026-58043 (Permission Model path traversal) — plus several medium and low severity CVEs. Keeping the toolchain pinned to the latest patch release ensures CI and local builds run on a supported, secure runtime.

This bumps .tool-versions from 25.9.0 to 26.5.1 and raises the npm engines constraint in package.json to >=11.17.0, the npm version bundled with Node 26.5.1. It is split out from the combined dependency update so the Node.js upgrade can be reviewed and its CI impact evaluated on its own.

It also adds a `yauzl` override pinned to 3.4.0, which is required for the Chrome e2e jobs to pass on Node 26. Those jobs pull `extract-zip@2.0.1` transitively through `@puppeteer/browsers` (via `@wdio/utils`); extract-zip pins `yauzl@^2.10.0`, and yauzl 2.x hangs while unpacking the downloaded Chrome-for-Testing `.zip` on Node 26 — an unsettled-async regression tracked in [extract-zip#154](https://github.com/max-mapper/extract-zip/issues/154). The fix landed in yauzl 3.3.1+, but extract-zip is unmaintained and still constrains the 2.x range, so the override forces the fixed 3.4.0 (already present in the tree via web-ext) into that path. The full Chrome e2e suite was verified passing locally on Node 26.5.1 with the override in place.
