### PR TITLE
ci(test): add timeout to e2e jobs so hangs fail fast

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
   e2e-chrome:
     runs-on: ubuntu-latest
     needs: unit
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -50,6 +51,7 @@ jobs:
   e2e-chrome-update:
     runs-on: ubuntu-latest
     needs: unit
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -63,6 +65,7 @@ jobs:
   e2e-firefox:
     runs-on: ubuntu-latest
     needs: unit
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -76,6 +79,7 @@ jobs:
   e2e-firefox-update:
     runs-on: ubuntu-latest
     needs: unit
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5


### PR DESCRIPTION
The e2e jobs have no timeout, so a browser session that hangs (rather than erroring) runs until the GitHub Actions 6-hour default before the job is killed, wasting runner minutes and delaying feedback. A recent Node.js upgrade surfaced exactly this: the Chrome WebdriverIO session hung indefinitely instead of failing.

This adds timeout-minutes: 20 to all four e2e jobs (chrome, chrome-update, firefox, firefox-update). Normal runs finish in well under 8 minutes, so 20 leaves ample headroom while turning any future hang into a prompt, actionable failure.
