### PR TITLE
[DO NOT MERGE] diagnostic: Node 26 Chrome e2e hang trace

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
   e2e-chrome:
     runs-on: ubuntu-latest
     needs: unit
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -50,6 +51,7 @@ jobs:
   e2e-chrome-update:
     runs-on: ubuntu-latest
     needs: unit
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 25.9.0
+nodejs 26.5.1

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "engineStrict": true,
   "engines": {
-    "npm": ">=11.6.3"
+    "npm": ">=11.17.0"
   },
   "webExt": {
     "sourceDir": "./dist/"

--- a/tests/e2e/wdio.conf.js
+++ b/tests/e2e/wdio.conf.js
@@ -113,7 +113,7 @@ export const config = {
     ],
   ],
   reporters: [['spec', { showPreface: false, realtimeReporting: !process.env.GITHUB_ACTIONS }]],
-  logLevel: argv.debug ? 'error' : 'silent',
+  logLevel: 'trace',
   mochaOpts: {
     timeout: argv.debug ? 24 * 60 * 60 * 1000 : 60 * 1000,
     retries: 2,


### PR DESCRIPTION
Throwaway diagnostic branch off the Node 26.5.1 branch. Enables WDIO trace logging and an 8-minute timeout on the Chrome jobs to capture exactly where the Chrome WebDriver session stalls. Will be closed once logs are captured.