### PR TITLE
fix(build): avoid exposing chrome global to page scope on Firefox

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -239,7 +239,7 @@ const config = {
             generateBundle(_, bundle) {
               for (const chunk of Object.values(bundle)) {
                 if (chunk.type === 'chunk' && (chunk.isEntry || chunk.isDynamicEntry)) {
-                  chunk.code = 'globalThis.chrome = globalThis.browser;\n\n' + chunk.code;
+                  chunk.code = 'const chrome = globalThis.browser;\n\n' + chunk.code;
                 }
               }
             },

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -186,6 +186,10 @@ if (argv.target !== 'firefox') {
 
 // --- Base Vite Config ---
 
+// Firefox only exposes the promise-based `browser` namespace, so alias it to `chrome`.
+// It must stay a scoped binding - a global one leaks into pages for MAIN world scripts.
+const FIREFOX_API_ALIAS = 'const chrome = globalThis.browser;';
+
 const config = {
   logLevel: silent ? 'silent' : undefined,
   configFile: false,
@@ -232,14 +236,15 @@ const config = {
   plugins:
     argv.target === 'firefox'
       ? [
-          // Add Firefox polyfill banner to entry point files
+          // Add Firefox polyfill banner to entry point files. Safe for the ESM build only,
+          // as module top-level declarations are scoped to the module.
           {
             name: 'firefox-entry-banner',
             enforce: 'post',
             generateBundle(_, bundle) {
               for (const chunk of Object.values(bundle)) {
                 if (chunk.type === 'chunk' && (chunk.isEntry || chunk.isDynamicEntry)) {
-                  chunk.code = 'const chrome = globalThis.browser;\n\n' + chunk.code;
+                  chunk.code = `${FIREFOX_API_ALIAS}\n\n` + chunk.code;
                 }
               }
             },
@@ -678,6 +683,9 @@ for (const [id, path] of Object.entries(mapPaths(content_scripts))) {
     contentScriptBuilds.push(
       build({
         ...config,
+        // The banner plugin would prepend the alias outside of the IIFE wrapper, which puts it
+        // in the page's global lexical scope for MAIN world scripts. `intro` goes inside instead.
+        plugins: [],
         build: {
           ...config.build,
           target: 'esnext',
@@ -688,6 +696,7 @@ for (const [id, path] of Object.entries(mapPaths(content_scripts))) {
               format: 'iife',
               dir: options.outDir,
               entryFileNames: '[name].js',
+              ...(argv.target === 'firefox' && { intro: FIREFOX_API_ALIAS }),
             },
           },
         },

--- a/tests/unit/setup/init-chrome.js
+++ b/tests/unit/setup/init-chrome.js
@@ -1,5 +1,5 @@
 if (typeof globalThis.chrome === 'undefined') {
-  global.chrome = {
+  globalThis.chrome = {
     runtime: {
       getManifest() {
         return {};
@@ -17,7 +17,7 @@ if (typeof globalThis.chrome === 'undefined') {
 }
 
 // Mock navigator to simulate Chrome
-Object.defineProperty(global, 'navigator', {
+Object.defineProperty(globalThis, 'navigator', {
   value: {
     userAgent:
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36',
@@ -27,5 +27,5 @@ Object.defineProperty(global, 'navigator', {
   configurable: true,
 });
 
-global.__CHROMIUM__ = true;
-global.__FIREFOX__ = false;
+globalThis.__CHROMIUM__ = true;
+globalThis.__FIREFOX__ = false;


### PR DESCRIPTION
On Firefox we prepend a small snippet to every entry chunk so the codebase can use the `chrome` namespace uniformly across browsers. The snippet assigned to `globalThis.chrome`, which meant content scripts injected into the MAIN execution context leaked that artefact into the page scope, making the extension detectable and polluting the page global namespace.

The snippet is now a scoped `const chrome = globalThis.browser;` binding instead of a global assignment, so the unified API access stays inside the bundle without touching the page:

* For the main ESM build the declaration is still prepended by the `firefox-entry-banner` plugin, where module top-level scope keeps it private. With `preserveModules` every emitted chunk is an entry, so coverage is unchanged.
* For content scripts, which are bundled as IIFE, prepending would place the declaration in the page global lexical scope — still a leak, and a source of `Identifier 'chrome' has already been declared` errors for pages declaring their own top-level `chrome`. Those builds now pass the alias through `output.intro` so it lands inside the IIFE wrapper.
* The unit test setup was updated to use `globalThis` consistently instead of the Node-only `global` alias.