### PR TITLE
chore(npm): allow root git dependencies for npm 12

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+allow-git=root


### PR DESCRIPTION
npm 12 changed the default of the `allow-git` config to `none`, so `npm install` now fails with `npm error Fetching packages of type "git" have been disabled`. The project depends on two GitHub-hosted packages — `@ghostery/scriptlets` and `apexsankey` — which can no longer be fetched with the default configuration.

Adds a project-level `.npmrc` with `allow-git=root`, which re-enables git dependencies only for those declared in this repository's own `package.json`. Transitive git dependencies from other packages remain blocked, keeping the stricter npm 12 behaviour for everything we do not control. This restores a working `npm install` locally and in CI without touching the dependency list.