### PR TITLE
chore(xcode): add debug schemes for running the extension

### DIFF
--- a/xcode/Ghostery.xcodeproj/project.pbxproj
+++ b/xcode/Ghostery.xcodeproj/project.pbxproj
@@ -1019,6 +1019,71 @@
 			};
 			name = Release;
 		};
+		B4DEB0010000000000000001 /* Debug (Extension) */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 165;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = T3NRR7XMGG;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				GHOSTERY_DEBUG = 1;
+				MARKETING_VERSION = 10.5.56;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = "Debug (Extension)";
+		};
 		468E42CC2701F84A008B5792 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1079,6 +1144,36 @@
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
+		};
+		B4DEB0010000000000000002 /* Debug (Extension) */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "iOS (Extension)/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Ghostery AdBlocker for Privacy Extension";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = "$(MARKETING_VERSION)";
+				OTHER_LDFLAGS = (
+					"-framework",
+					SafariServices,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.ghostery.extension.debug.safari;
+				PRODUCT_NAME = "Ghostery AdBlocker for Privacy Extension";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Debug (Extension)";
 		};
 		468E42D02701F84A008B5792 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -1153,6 +1248,42 @@
 			};
 			name = Release;
 		};
+		B4DEB0010000000000000003 /* Debug (Extension) */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "iOS (App)/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = Ghostery;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.7;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = "$(MARKETING_VERSION)";
+				OTHER_LDFLAGS = (
+					"-framework",
+					SafariServices,
+					"-framework",
+					WebKit,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.ghostery.extension.debug;
+				PRODUCT_NAME = "Ghostery AdBlocker for Privacy";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Debug (Extension)";
+		};
 		468E42D32701F84A008B5792 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1220,6 +1351,40 @@
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
+		};
+		B4DEB0010000000000000004 /* Debug (Extension) */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "macOS (Extension)/Ghostery AdBlocker for Privacy.entitlements";
+				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = "$(CURRENT_PROJECT_VERSION)";
+				DEAD_CODE_STRIPPING = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "macOS (Extension)/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Ghostery AdBlocker for Privacy Extension";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = "$(MARKETING_VERSION)";
+				OTHER_LDFLAGS = (
+					"-framework",
+					SafariServices,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.ghostery.extension.debug.safari;
+				PRODUCT_NAME = "Ghostery AdBlocker for Privacy Extension";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = "Debug (Extension)";
 		};
 		468E42D72701F84A008B5792 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -1297,6 +1462,44 @@
 			};
 			name = Release;
 		};
+		B4DEB0010000000000000005 /* Debug (Extension) */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "macOS (App)/Ghostery AdBlocker for Privacy.entitlements";
+				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 165;
+				DEAD_CODE_STRIPPING = YES;
+				ENABLE_HARDENED_RUNTIME = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "macOS (App)/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Ghostery AdBlocker for Privacy";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
+				INFOPLIST_KEY_NSMainStoryboardFile = Main;
+				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.6;
+				MARKETING_VERSION = "$(MARKETING_VERSION)";
+				OTHER_LDFLAGS = (
+					"-framework",
+					SafariServices,
+					"-framework",
+					WebKit,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.ghostery.extension.debug;
+				PRODUCT_NAME = "Ghostery AdBlocker for Privacy";
+				SDKROOT = macosx;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = "Debug (Extension)";
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1304,6 +1507,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				468E42C92701F84A008B5792 /* Debug */,
+				B4DEB0010000000000000001 /* Debug (Extension) */,
 				468E42CA2701F84A008B5792 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -1313,6 +1517,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				468E42CC2701F84A008B5792 /* Debug */,
+				B4DEB0010000000000000002 /* Debug (Extension) */,
 				468E42CD2701F84A008B5792 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -1322,6 +1527,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				468E42D02701F84A008B5792 /* Debug */,
+				B4DEB0010000000000000003 /* Debug (Extension) */,
 				468E42D12701F84A008B5792 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -1331,6 +1537,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				468E42D32701F84A008B5792 /* Debug */,
+				B4DEB0010000000000000004 /* Debug (Extension) */,
 				468E42D42701F84A008B5792 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -1340,6 +1547,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				468E42D72701F84A008B5792 /* Debug */,
+				B4DEB0010000000000000005 /* Debug (Extension) */,
 				468E42D82701F84A008B5792 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;

--- a/xcode/Ghostery.xcodeproj/xcshareddata/xcschemes/Ghostery AdBlocker for Privacy (iOS) Debug.xcscheme
+++ b/xcode/Ghostery.xcodeproj/xcshareddata/xcschemes/Ghostery AdBlocker for Privacy (iOS) Debug.xcscheme
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1640"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "468E428A2701F84A008B5792"
+               BuildableName = "Ghostery AdBlocker for Privacy.app"
+               BlueprintName = "iOS"
+               ReferencedContainer = "container:Ghostery.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug (Extension)"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug (Extension)"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "468E428A2701F84A008B5792"
+            BuildableName = "Ghostery AdBlocker for Privacy.app"
+            BlueprintName = "iOS"
+            ReferencedContainer = "container:Ghostery.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <StoreKitConfigurationFileReference
+         identifier = "../../Shared (App)/StoreHelper/Products.storekit">
+      </StoreKitConfigurationFileReference>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Debug (Extension)"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "468E428A2701F84A008B5792"
+            BuildableName = "Ghostery AdBlocker for Privacy.app"
+            BlueprintName = "iOS"
+            ReferencedContainer = "container:Ghostery.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug (Extension)">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Debug (Extension)"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/xcode/Ghostery.xcodeproj/xcshareddata/xcschemes/Ghostery AdBlocker for Privacy (macOS) Debug.xcscheme
+++ b/xcode/Ghostery.xcodeproj/xcshareddata/xcschemes/Ghostery AdBlocker for Privacy (macOS) Debug.xcscheme
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1640"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "468E429C2701F84A008B5792"
+               BuildableName = "Ghostery AdBlocker for Privacy.app"
+               BlueprintName = "macOS"
+               ReferencedContainer = "container:Ghostery.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug (Extension)"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug (Extension)"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "468E429C2701F84A008B5792"
+            BuildableName = "Ghostery AdBlocker for Privacy.app"
+            BlueprintName = "macOS"
+            ReferencedContainer = "container:Ghostery.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <StoreKitConfigurationFileReference
+         identifier = "../../Shared (App)/StoreHelper/Products.storekit">
+      </StoreKitConfigurationFileReference>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Debug (Extension)"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "468E429C2701F84A008B5792"
+            BuildableName = "Ghostery AdBlocker for Privacy.app"
+            BlueprintName = "macOS"
+            ReferencedContainer = "container:Ghostery.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug (Extension)">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Debug (Extension)"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/xcode/Shared (App)/views/screens/WelcomeWebView.swift
+++ b/xcode/Shared (App)/views/screens/WelcomeWebView.swift
@@ -15,7 +15,8 @@ import UIKit
 import Cocoa
 #endif
 
-let extensionBundleIdentifier = "com.ghostery.extension.safari"
+// The extension target's identifier is always the app's, suffixed with ".safari".
+let extensionBundleIdentifier = Bundle.main.bundleIdentifier! + ".safari"
 
 struct WelcomeWebView {
     var openInWebView: (URL) -> Void

--- a/xcode/ci_scripts/build.sh
+++ b/xcode/ci_scripts/build.sh
@@ -11,6 +11,14 @@ command -v npm >/dev/null 2>&1 || {
   exit 127
 }
 
-npm run build -- --clean
+# GHOSTERY_DEBUG is a build setting defined by the "Debug (Extension)" configuration.
+BUILD_ARGS="--clean"
+if [ "${GHOSTERY_DEBUG:-0}" = "1" ]; then
+  BUILD_ARGS="$BUILD_ARGS --debug"
+fi
+
+echo "Building extension: npm run build -- $BUILD_ARGS"
+
+npm run build -- $BUILD_ARGS
 
 sh scripts/patch-safari.sh


### PR DESCRIPTION
Running the Safari extension from Xcode always produced a production build, since `ci_scripts/build.sh` hardcoded `npm run build -- --clean`. Getting a `--debug` build (staging domains, dev tools, onboarding skipped) meant editing the script by hand and remembering to revert it.

This adds a `Debug (Extension)` build configuration and two shared schemes that select it, so a debug run is one pick in the Xcode toolbar's scheme dropdown:

- The configuration is a clone of `Debug` with a user-defined `GHOSTERY_DEBUG = 1` build setting. `ci_scripts/build.sh` reads it and appends `--debug`. Keying off a build setting rather than `$CONFIGURATION` keeps the web-extension debug build decoupled from the Swift `Debug` configuration, so `Debug` and `Release` behave exactly as before.
- New shared schemes `Ghostery AdBlocker for Privacy (iOS) Debug` and `(macOS) Debug` use it for Run/Test/Profile/Analyze/Archive.
- The configuration ships under separate bundle identifiers — `com.ghostery.extension.debug` for the apps and `com.ghostery.extension.debug.safari` for the extensions — so a debug archive is rejected by App Store Connect instead of shipping, and a debug build no longer replaces the regular install in Safari.
- `WelcomeWebView` hardcoded `com.ghostery.extension.safari` and passed it to `SFSafariExtensionManager.getStateOfSafariExtension` and `SFSafariApplication.showPreferencesForExtension`. Left alone, the debug app would have reported the release extension's state. It now derives from `Bundle.main.bundleIdentifier`.

Verified with `plutil -lint` on the project file, `xmllint` on all four schemes, and `xcodebuild -showBuildSettings` across all 4 targets × 3 configurations to confirm `GHOSTERY_DEBUG` reaches the run-script phase and the identifiers resolve as intended. Note the debug targets use automatic signing, so the first debug build will register `com.ghostery.extension.debug` with the team.