### PR TITLE
fix(telemetry): await setup before accessing runner

### DIFF
--- a/src/background/telemetry/index.js
+++ b/src/background/telemetry/index.js
@@ -69,6 +69,9 @@ OptionsObserver.addListener(async function telemetry({ terms, feedback }, lastOp
   // as the `terms` option can only by enabled once
   if (lastOptions && lastOptions.terms) return;
 
+  // Wait for setup to finish initializing the runner
+  setup.pending && (await setup.pending);
+
   if (runner.isJustInstalled()) {
     await runner.setUTMs(await detectAttribution());
   }
@@ -77,27 +80,19 @@ OptionsObserver.addListener(async function telemetry({ terms, feedback }, lastOp
   runner.setUninstallUrl();
 
   if (terms) {
-    setup.pending && (await setup.pending);
-
     if (runner.isJustInstalled()) runner.ping('install');
 
     if (feedback) runner.ping('active');
   }
 });
 
-chrome.runtime.onInstalled.addListener((details) => {
-  (async () => {
-    setup.pending && (await setup.pending);
-    if (!runner) return;
-
-    await runner.setInstallReason(details.reason);
-  })();
+chrome.runtime.onInstalled.addListener(async (details) => {
+  setup.pending && (await setup.pending);
+  await runner.setInstallReason(details.reason);
 });
 
 export async function recordSerpVisit() {
   setup.pending && (await setup.pending);
-  if (!runner) return;
-
   await runner.recordSerpVisit();
 }
 


### PR DESCRIPTION
On Safari and Firefox the telemetry options listener could run before `asyncSetup` finished, so `runner` was still `undefined` and calls like `runner.isJustInstalled()` threw. The `await setup.pending` guard was placed too late — inside the `terms` branch — leaving the earlier `isJustInstalled()` and `setUninstallUrl()` calls unprotected.

The await is now moved to the top of the listener, right after the early return, so every access to `runner` happens once setup has resolved. The redundant `if (!runner) return;` checks in the `onInstalled` handler and `recordSerpVisit()` were dropped since they are unreachable — a failed setup rejects `setup.pending` and throws before those lines — and the `onInstalled` handler was simplified to a plain async listener instead of wrapping an async IIFE.