### PR TITLE
fix(e2e): wait for adblocker setup before tests

### DIFF
--- a/src/background/helpers.js
+++ b/src/background/helpers.js
@@ -16,7 +16,7 @@ import Config from '/store/config.js';
 import * as OptionsObserver from '/utils/options-observer.js';
 import { hasWTMStats } from '/utils/wtm-stats';
 import { isUserScriptsRegisterSupported } from '/utils/user-scripts.js';
-import { updateEngines } from './adblocker/engines.js';
+import { setup as adblockerSetup, updateEngines } from './adblocker/engines.js';
 import { openElementPicker } from './element-picker.js';
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
@@ -69,8 +69,8 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 
     // Messages for e2e tests
 
-    case 'e2e:idleOptionsObservers':
-      OptionsObserver.waitForIdle().then(() => {
+    case 'e2e:idle':
+      Promise.all([OptionsObserver.waitForIdle(), adblockerSetup.pending]).then(() => {
         sendResponse('done');
         console.debug('[helpers] "idleOptionsObservers" finished');
       }, sendResponse);

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -66,7 +66,7 @@ export async function sendMessage(msg) {
 }
 
 export async function waitForIdleBackgroundTasks() {
-  await sendMessage({ action: 'e2e:idleOptionsObservers' });
+  await sendMessage({ action: 'e2e:idle' });
 }
 
 export async function reloadExtension() {


### PR DESCRIPTION
Chrome E2E jobs intermittently reached the second test suite before the adblocker main engine had completed its initial setup. This caused tracker, cosmetic, and scriptlet assertions to fail together, while reruns passed after startup completed.

The dedicated E2E idle handshake now waits for both option observers and the adblocker setup promise. The change was validated with Chrome 152.0.7977.42 across the adblocker, custom-filters, and exceptions suites: 50 tests passed.