### PR TITLE
Ignore messages without "action" fields

### DIFF
--- a/src/background/telemetry/index.js
+++ b/src/background/telemetry/index.js
@@ -97,7 +97,7 @@ export async function recordSerpVisit() {
 }
 
 chrome.runtime.onMessage.addListener((msg) => {
-  if (enabled && msg.action.startsWith('telemetry:')) {
+  if (enabled && msg.action?.startsWith('telemetry:')) {
     (async () => {
       setup.pending && (await setup.pending);
 


### PR DESCRIPTION
Do not fail with errors when encountering urlReporting messages. They do not follow the convention of having an "action"  