### PR TITLE
fix(browser-info): detect iPadOS & add devtools navigator section

### DIFF
--- a/src/background/helpers.js
+++ b/src/background/helpers.js
@@ -67,6 +67,14 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       console.debug('[helpers] Received "keepAlive" message');
       break;
 
+    case 'devtools:navigator':
+      sendResponse({
+        userAgent: navigator.userAgent,
+        platform: navigator.platform,
+        maxTouchPoints: navigator.maxTouchPoints,
+      });
+      break;
+
     // Messages for e2e tests
 
     case 'e2e:idle':

--- a/src/background/report-issue.js
+++ b/src/background/report-issue.js
@@ -95,7 +95,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         const { csrf_token: csrfToken, csrf_param: csrfParam } = await csrfResponse.json();
 
         const formData = new FormData();
-        const browserInfo = await getBrowserInfo();
+        const browserInfo = getBrowserInfo();
         const { version } = chrome.runtime.getManifest();
 
         const email = msg.email || 'noreplay@ghostery.com';

--- a/src/background/telemetry/metrics.js
+++ b/src/background/telemetry/metrics.js
@@ -184,7 +184,7 @@ export default class Metrics {
     // Make sure that Globals._checkBrowserInfo() has resolved before we proceed,
     // so that we use the correct BROWSER_INFO values if we are in
     // the Ghostery Desktop or Ghostery Android browsers
-    const browserInfo = await getBrowserInfo();
+    const browserInfo = getBrowserInfo();
     const conf = await this.getConf();
 
     const frequencyString = type !== 'uninstall' ? `/${frequency}` : '';

--- a/src/pages/settings/components/devtools.js
+++ b/src/pages/settings/components/devtools.js
@@ -43,6 +43,10 @@ async function forceConfigSync(host, event) {
   await asyncAction(event, setConfig({ updatedAt: 0 }));
 }
 
+function getBackgroundNavigator() {
+  return chrome.runtime.sendMessage({ action: 'devtools:navigator' });
+}
+
 async function testConfigDomain() {
   const domain = window.prompt('Enter domain to test:', 'example.com');
   if (!domain) return;
@@ -307,6 +311,57 @@ export default {
                     `,
                   ),
                 )}
+                <div layout="column gap items:start" translate="no">
+                  <ui-text type="headline-s">Navigator</ui-text>
+                  <div layout="column gap">
+                    <div layout="column gap:0.5">
+                      <ui-text type="label-m">Page</ui-text>
+                      <ui-text type="body-s" color="secondary">
+                        <ui-text type="label-s">User agent:</ui-text>
+                        <span data-qa="text:navigator-user-agent-page">
+                          ${navigator.userAgent}
+                        </span>
+                      </ui-text>
+                      <ui-text type="body-s" color="secondary">
+                        <ui-text type="label-s">Platform:</ui-text>
+                        <span data-qa="text:navigator-platform-page">${navigator.platform}</span>
+                      </ui-text>
+                      <ui-text type="body-s" color="secondary">
+                        <ui-text type="label-s">Max touch points:</ui-text>
+                        <span data-qa="text:navigator-max-touch-points-page">
+                          ${navigator.maxTouchPoints}
+                        </span>
+                      </ui-text>
+                    </div>
+                    ${html.resolve(
+                      getBackgroundNavigator().then(
+                        (info) => html`
+                          <div layout="column gap:0.5">
+                            <ui-text type="label-m">Background</ui-text>
+                            <ui-text type="body-s" color="secondary">
+                              <ui-text type="label-s">User agent:</ui-text>
+                              <span data-qa="text:navigator-user-agent-background">
+                                ${info.userAgent}
+                              </span>
+                            </ui-text>
+                            <ui-text type="body-s" color="secondary">
+                              <ui-text type="label-s">Platform:</ui-text>
+                              <span data-qa="text:navigator-platform-background">
+                                ${info.platform}
+                              </span>
+                            </ui-text>
+                            <ui-text type="body-s" color="secondary">
+                              <ui-text type="label-s">Max touch points:</ui-text>
+                              <span data-qa="text:navigator-max-touch-points-background">
+                                ${info.maxTouchPoints}
+                              </span>
+                            </ui-text>
+                          </div>
+                        `,
+                      ),
+                    )}
+                  </div>
+                </div>
                 ${
                   __CHROMIUM__ &&
                   html`

--- a/src/utils/browser-info.js
+++ b/src/utils/browser-info.js
@@ -112,8 +112,8 @@ export function getOS() {
   const os = getUA().os?.name?.toLowerCase() || '';
 
   if (os.includes('mac')) {
-    // Safari on iPadOS spoofs a Mac desktop user-agent. Detect that before the macOS branch.
-    if (isSafari() && navigator.maxTouchPoints > 1) return 'ipados';
+    // All iOS/iPadOS browsers use WebKit and can spoof a Mac desktop user-agent on iPadOS.
+    if (navigator.maxTouchPoints > 1) return 'ipados';
     return 'mac';
   } else if (os.includes('win')) {
     return 'win';

--- a/src/utils/browser-info.js
+++ b/src/utils/browser-info.js
@@ -94,42 +94,47 @@ export function isOculus() {
 export function isWebkit() {
   if (__FIREFOX__) return false;
 
-  // Edge on iPadOS has OS detected as `ios`
-  if (isSafari() || getOS() === 'ios') return true;
+  // Safari on all platforms is WebKit
+  if (isSafari()) return true;
 
-  return false;
+  // All browsers on iOS/iPadOS are WebKit, so we can use the OS to identify them
+  const os = getOS();
+  return os === 'ios' || os === 'ipados';
+}
+
+export function isMobile() {
+  const os = getOS();
+  return os === 'android' || os === 'ios' || os === 'ipados';
 }
 
 export function getOS() {
   // Make sure that undefined operating systems don't mess with stuff like .includes()
-  const platform = getUA().os?.name?.toLowerCase() || '';
+  const os = getUA().os?.name?.toLowerCase() || '';
 
-  if (platform.includes('mac')) {
+  if (os.includes('mac')) {
+    // Safari on iPadOS spoofs a Mac desktop user-agent. Detect that before the macOS branch.
+    if (isSafari() && navigator.maxTouchPoints > 1) return 'ipados';
     return 'mac';
-  } else if (platform.includes('win')) {
+  } else if (os.includes('win')) {
     return 'win';
-  } else if (platform.includes('android')) {
+  } else if (os.includes('android')) {
     return 'android';
-  } else if (platform.includes('ios')) {
+  } else if (os.includes('ios')) {
+    if (navigator.platform?.toLocaleLowerCase() === 'ipad') return 'ipados';
     return 'ios';
-  } else if (platform.includes('chromium os')) {
+  } else if (os.includes('chromium os')) {
     return 'cros';
-  } else if (platform.includes('bsd')) {
+  } else if (os.includes('bsd')) {
     return 'openbsd';
-  } else if (platform.includes('linux')) {
+  } else if (os.includes('linux')) {
     return 'linux';
   }
 
   return 'other';
 }
 
-export function isMobile() {
-  const os = getOS();
-  return os === 'android' || os === 'ios';
-}
-
 let browserInfo = null;
-export default async function getBrowserInfo() {
+export default function getBrowserInfo() {
   if (browserInfo) return browserInfo;
 
   const ua = getUA();
@@ -142,15 +147,6 @@ export default async function getBrowserInfo() {
     os: getOS(),
     osVersion: ua.os.version || '',
   };
-
-  if (
-    __CHROMIUM__ &&
-    browserInfo.os === 'mac' &&
-    chrome.runtime.getPlatformInfo &&
-    (await chrome.runtime.getPlatformInfo()).os === 'ios'
-  ) {
-    browserInfo.os = 'ipados';
-  }
 
   return browserInfo;
 }

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -60,25 +60,21 @@ const config = {
 
 Sentry.init(config);
 
-getBrowserInfo().then(
-  ({ token, version, os, osVersion }) => {
-    // Sentry rejects tags with empty or NaN values ("expected a non-empty value"),
-    // which discards the whole tag, so only set tags that carry a usable value.
-    const setTag = (key, value) => {
-      if (value === '' || value == null || (typeof value === 'number' && Number.isNaN(value))) {
-        return;
-      }
-      Sentry.setTag(key, value);
-    };
+// Sentry rejects tags with empty or NaN values ("expected a non-empty value"),
+// which discards the whole tag, so only set tags that carry a usable value.
+function setTag(key, value) {
+  if (value === '' || value == null || (typeof value === 'number' && Number.isNaN(value))) {
+    return;
+  }
+  Sentry.setTag(key, value);
+}
 
-    setTag('ua', token);
-    setTag('uaVersion', version);
-    setTag('os', os);
-    setTag('osVersion', osVersion);
-  },
-  // empty error handled for tests
-  () => {},
-);
+const browserInfo = getBrowserInfo();
+
+setTag('ua', browserInfo.token);
+setTag('uaVersion', browserInfo.version);
+setTag('os', browserInfo.os);
+setTag('osVersion', browserInfo.osVersion);
 
 // Do not rename this to `captureException`/`captureMessage`. Sentry's stack
 // parser (STRIP_FRAME_REGEXP = /captureMessage|captureException/) drops the

--- a/src/utils/files.js
+++ b/src/utils/files.js
@@ -9,7 +9,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import getBrowserInfo from './browser-info.js';
+import { getOS } from './browser-info.js';
 
 export function saveAs(url, filename) {
   const a = document.createElement('a');
@@ -48,7 +48,7 @@ export async function download({
   // Safari on iOS does not support downloading blobs,
   // but it can handle data URLs, so we convert the blob to a data URL in that case.
   if (__CHROMIUM__) {
-    const { os } = await getBrowserInfo();
+    const os = getOS();
 
     if (os === 'ios' || os === 'ipados') {
       const fileReader = new FileReader();

--- a/tests/unit/browser-info.test.js
+++ b/tests/unit/browser-info.test.js
@@ -316,9 +316,21 @@ describe('iOS', () => {
       },
     ));
 
-  // TODO: Get the page data for Edge on iOS
-  test.skip('Edge in the page', () => {});
-
-  // TODO: Get the service worker data for Edge on iOS
-  test.skip('Edge in the service worker', () => {});
+  test('Edge in the page & service worker', () =>
+    assertBrowserInfo(
+      {
+        caseName: 'edge-ios-background',
+        userAgent:
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/152.0.4191.49',
+        platform: 'iPhone',
+        maxTouchPoints: 5,
+      },
+      {
+        os: 'ios',
+        isWebkit: true,
+        name: 'edge',
+        version: 152,
+        osVersion: '18.7',
+      },
+    ));
 });

--- a/tests/unit/browser-info.test.js
+++ b/tests/unit/browser-info.test.js
@@ -255,27 +255,24 @@ describe('iPad', () => {
       },
     ));
 
-  // TODO: Replace with real data from the extension
-  test('Edge in the page', () =>
+  // Edge on iPadOS spoofs a Mac desktop user-agent, and reports the same data in the page and the service worker
+  test('Edge in the page & service worker', () =>
     assertBrowserInfo(
       {
         caseName: 'edge-ipad',
         userAgent:
-          'Mozilla/5.0 (iPad; CPU OS 26_6_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/151.0.4129.96 Version/26.0 Mobile/15E148 Safari/604.1',
-        platform: 'iPad',
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/152.0.4191.49',
+        platform: 'MacIntel',
         maxTouchPoints: 5,
       },
       {
         os: 'ipados',
         isWebkit: true,
         name: 'edge',
-        version: 151,
-        osVersion: '26.6.0',
+        version: 152,
+        osVersion: '10.15.7',
       },
     ));
-
-  // TODO: Get the service worker data for Edge on iPadOS
-  test.skip('Edge in the service worker', () => {});
 
   // TODO: Replace with real data from the extension
   test('Chrome in the page', () =>

--- a/tests/unit/browser-info.test.js
+++ b/tests/unit/browser-info.test.js
@@ -1,0 +1,324 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+const originalNavigator = global.navigator;
+const originalFirefox = global.__FIREFOX__;
+const originalChromium = global.__CHROMIUM__;
+
+async function assertBrowserInfo(
+  { caseName, userAgent, platform, maxTouchPoints, firefox = false },
+  { os, isWebkit: expectedIsWebkit, name, version, osVersion },
+) {
+  Object.defineProperty(global, 'navigator', {
+    value: { userAgent, platform, maxTouchPoints, brave: undefined },
+    configurable: true,
+    writable: true,
+  });
+  global.__FIREFOX__ = firefox;
+  global.__CHROMIUM__ = !firefox;
+
+  const {
+    default: getBrowserInfo,
+    getBrowser,
+    getOS,
+    isMobile,
+    isWebkit,
+    // cache-bust the import so each test gets a fresh module (browser-info.js caches UA/os internally)
+  } = await import(`../../src/utils/browser-info.js?case=${caseName}`);
+
+  assert.equal(getOS(), os);
+  assert.equal(isWebkit(), expectedIsWebkit);
+  assert.equal(isMobile(), ['android', 'ios', 'ipados'].includes(os));
+  assert.equal(getBrowser().name, name);
+
+  const info = getBrowserInfo();
+  assert.equal(info.os, os);
+  assert.equal(info.name, name);
+  assert.equal(info.version, version);
+  assert.equal(info.osVersion, osVersion);
+
+  Object.defineProperty(global, 'navigator', {
+    value: originalNavigator,
+    configurable: true,
+    writable: true,
+  });
+  global.__FIREFOX__ = originalFirefox;
+  global.__CHROMIUM__ = originalChromium;
+}
+
+describe('Mac', () => {
+  test('Chrome in the page', () =>
+    assertBrowserInfo(
+      {
+        caseName: 'desktop-chrome-page',
+        userAgent:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36',
+        platform: 'MacIntel',
+        maxTouchPoints: 0,
+      },
+      {
+        os: 'mac',
+        isWebkit: false,
+        name: 'chrome',
+        version: 152,
+        osVersion: '10.15.7',
+      },
+    ));
+
+  test('Chrome in the background', () =>
+    assertBrowserInfo(
+      {
+        caseName: 'desktop-chrome-background',
+        userAgent:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36',
+        platform: 'MacIntel',
+        maxTouchPoints: undefined,
+      },
+      {
+        os: 'mac',
+        isWebkit: false,
+        name: 'chrome',
+        version: 152,
+        osVersion: '10.15.7',
+      },
+    ));
+
+  // Firefox reports the same navigator data in the page and the service worker
+  test('Firefox in the page & service worker', () =>
+    assertBrowserInfo(
+      {
+        caseName: 'firefox-mac',
+        firefox: true,
+        userAgent:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:154.0) Gecko/20100101 Firefox/154.0',
+        platform: 'MacIntel',
+        maxTouchPoints: 0, // undefined in service worker
+      },
+      {
+        os: 'mac',
+        isWebkit: false,
+        name: 'firefox',
+        version: 154,
+        osVersion: '10.15',
+      },
+    ));
+
+  // Opera reports the same navigator data in the page and the service worker
+  test('Opera in the page & service worker', () =>
+    assertBrowserInfo(
+      {
+        caseName: 'opera-mac',
+        userAgent:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36 OPR/132.0.0.0',
+        platform: 'MacIntel',
+        maxTouchPoints: 0, // undefined in service worker
+      },
+      {
+        os: 'mac',
+        isWebkit: false,
+        name: 'opera',
+        version: 132,
+        osVersion: '10.15.7',
+      },
+    ));
+
+  // Edge reports the same navigator data in the page and the service worker
+  test('Edge in the page & service worker', () =>
+    assertBrowserInfo(
+      {
+        caseName: 'edge-mac',
+        userAgent:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36 Edg/151.0.0.0',
+        platform: 'MacIntel',
+        maxTouchPoints: undefined,
+      },
+      {
+        os: 'mac',
+        isWebkit: false,
+        name: 'edge',
+        version: 151,
+        osVersion: '10.15.7',
+      },
+    ));
+});
+
+describe('Android', () => {
+  test('Firefox in the page', () =>
+    assertBrowserInfo(
+      {
+        caseName: 'firefox-android-page',
+        firefox: true,
+        userAgent: 'Mozilla/5.0 (Android 17; Mobile; rv:154.0) Gecko/154.0 Firefox/154.0',
+        platform: 'Linux armv81',
+        maxTouchPoints: 5,
+      },
+      {
+        os: 'android',
+        isWebkit: false,
+        name: 'firefox',
+        version: 154,
+        osVersion: '17',
+      },
+    ));
+
+  test('Firefox in the background', () =>
+    assertBrowserInfo(
+      {
+        caseName: 'firefox-android-background',
+        firefox: true,
+        userAgent: 'Mozilla/5.0 (Android 17; Mobile; rv:154.0) Gecko/154.0 Firefox/154.0',
+        platform: 'Linux armv81',
+        maxTouchPoints: 0,
+      },
+      {
+        os: 'android',
+        isWebkit: false,
+        name: 'firefox',
+        version: 154,
+        osVersion: '17',
+      },
+    ));
+
+  test('Edge in the page', () =>
+    assertBrowserInfo(
+      {
+        caseName: 'edge-android-page',
+        userAgent:
+          'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/154.0.0.0 Mobile Safari/537.36 EdgA/154.0.0.0',
+        platform: 'Linux armv81',
+        maxTouchPoints: 5,
+      },
+      {
+        os: 'android',
+        isWebkit: false,
+        name: 'edge',
+        version: 154,
+        osVersion: '10',
+      },
+    ));
+
+  test('Edge in the background', () =>
+    assertBrowserInfo(
+      {
+        caseName: 'edge-android-background',
+        userAgent:
+          'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/154.0.0.0 Mobile Safari/537.36 EdgA/154.0.0.0',
+        platform: 'Linux armv81',
+        maxTouchPoints: undefined,
+      },
+      {
+        os: 'android',
+        isWebkit: false,
+        name: 'edge',
+        version: 154,
+        osVersion: '10',
+      },
+    ));
+});
+
+describe('iPad', () => {
+  test('Safari in the page & page background process', () =>
+    assertBrowserInfo(
+      {
+        caseName: 'safari-ipados',
+        userAgent:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Safari/605.1.15',
+        platform: 'MacIntel',
+        maxTouchPoints: 5,
+      },
+      {
+        os: 'ipados',
+        isWebkit: true,
+        name: 'safari',
+        version: 26,
+        osVersion: '10.15.7',
+      },
+    ));
+
+  // NOTICE: We don't use service workers in Safari, but this test
+  // is here to ensure that if we do, the browser detection still works.
+  test('Safari in the service worker', () =>
+    assertBrowserInfo(
+      {
+        caseName: 'safari-ipados-sw',
+        userAgent:
+          'Mozilla/5.0 (iPad; CPU OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6 Mobile/15E148 Safari/604.1',
+        platform: 'iPad',
+        maxTouchPoints: undefined,
+      },
+      {
+        os: 'ipados',
+        isWebkit: true,
+        name: 'safari',
+        version: 26,
+        osVersion: '18.7',
+      },
+    ));
+
+  // TODO: Replace with real data from the extension
+  test('Edge in the page', () =>
+    assertBrowserInfo(
+      {
+        caseName: 'edge-ipad',
+        userAgent:
+          'Mozilla/5.0 (iPad; CPU OS 26_6_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/151.0.4129.96 Version/26.0 Mobile/15E148 Safari/604.1',
+        platform: 'iPad',
+        maxTouchPoints: 5,
+      },
+      {
+        os: 'ipados',
+        isWebkit: true,
+        name: 'edge',
+        version: 151,
+        osVersion: '26.6.0',
+      },
+    ));
+
+  // TODO: Get the service worker data for Edge on iPadOS
+  test.skip('Edge in the service worker', () => {});
+
+  // TODO: Replace with real data from the extension
+  test('Chrome in the page', () =>
+    assertBrowserInfo(
+      {
+        caseName: 'chrome-ipad',
+        userAgent:
+          'Mozilla/5.0 (iPad; CPU OS 26_6_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/152.0.7977.64 Mobile/15E148 Safari/604.1',
+        platform: 'iPad',
+        maxTouchPoints: 5,
+      },
+      {
+        os: 'ipados',
+        isWebkit: true,
+        name: 'chrome',
+        version: 152,
+        osVersion: '26.6.0',
+      },
+    ));
+});
+
+describe('iOS', () => {
+  test('Safari in the page & page background process', () =>
+    assertBrowserInfo(
+      {
+        caseName: 'safari-ios-page',
+        userAgent:
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.4 Mobile/15E148 Safari/604.1',
+        platform: 'iPhone',
+        maxTouchPoints: 5,
+      },
+      {
+        os: 'ios',
+        isWebkit: true,
+        name: 'safari',
+        version: 26,
+        osVersion: '18.7',
+      },
+    ));
+
+  // TODO: Get the page data for Edge on iOS
+  test.skip('Edge in the page', () => {});
+
+  // TODO: Get the service worker data for Edge on iOS
+  test.skip('Edge in the service worker', () => {});
+});


### PR DESCRIPTION
Safari on iPadOS spoofs a macOS desktop user agent, and the previous iPadOS detection relied on an async `chrome.runtime.getPlatformInfo()` call inside `getBrowserInfo()`, which made the function async everywhere it was used and only worked for `__CHROMIUM__` builds. `isMobile()` also missed `ipados` entirely.

- `getOS()` now detects `ipados` synchronously via `navigator.maxTouchPoints` (for spoofed Safari/Mac UAs) and `navigator.platform` (for iPad UAs reporting as iOS), so `getBrowserInfo()` is sync and no longer needs the `chrome.runtime.getPlatformInfo()` fallback.
- `isWebkit()` and `isMobile()` were updated to correctly account for the `ipados` OS value.
- Added a "Navigator" panel to the Settings devtools page (page + background `userAgent`/`platform`/`maxTouchPoints`) via a new `devtools:navigator` background message, to make it easier to inspect real navigator data across platforms.
- Added `tests/unit/browser-info.test.js` covering `getBrowserInfo()`/`getOS()`/`isWebkit()`/`isMobile()` against real UA strings for Safari/Chrome/Edge/Opera/Firefox on Mac, iPad, iOS, and Android.

Marking as draft: we're still missing real Edge-on-iPad (service worker) and Edge-on-iOS navigator data to fully prove out the `ipados`/`ios` detection changes for that browser.