### PR TITLE
test(e2e): fix flaky 'applies a remote filter list' custom filters test

### DIFF
--- a/tests/e2e/spec/custom-filters.spec.js
+++ b/tests/e2e/spec/custom-filters.spec.js
@@ -16,6 +16,7 @@ import {
   setCustomFilters,
   disableCustomFilters,
   waitForIdleBackgroundTasks,
+  reloadUntilActive,
   switchFrame,
   PAGE_DOMAIN,
   PAGE_URL,
@@ -196,9 +197,13 @@ describe('Custom Filters', function () {
   });
 
   it('applies a remote filter list', async function () {
-    // The element is visible before the filter list is applied
-    await browser.url(PAGE_URL);
-    await expect($('#filter-list')).toBeDisplayed();
+    // The element is visible before the filter list is applied. The previous
+    // test's filter update can still be settling in the engine, so retry the
+    // navigation instead of asserting on the first load.
+    await reloadUntilActive(
+      () => $('#filter-list').isDisplayed(),
+      '#filter-list was not displayed before applying the remote filter list',
+    );
 
     // Add the filter list served by the local test server
     await addCustomFilterList(`${PAGE_URL}filter-list.txt`);


### PR DESCRIPTION
## Problem
`Custom Filters applies a remote filter list` in `tests/e2e/spec/custom-filters.spec.js` has been intermittently failing e2e-chrome CI on unrelated PRs (#3593, #3594, #3589, #3601), always on the same first assertion:

\`\`\`
Expect \$(\`#filter-list\`) to be displayed
Expected: "displayed"
Received: "not displayed"
\`\`\`

This happens right after the preceding test replaces the custom filter set, before the engine has fully settled on the following navigation.

## Fix
Use the existing \`reloadUntilActive\` helper (already used elsewhere for the same class of "custom filter updates reach the engine asynchronously" flakiness) to retry the navigation until \`#filter-list\` is displayed, instead of asserting on the very first page load.