### PR TITLE
fix(panel): don't fire engaged ping and sync on auto-opened recap

### DIFF
--- a/src/pages/panel/index.js
+++ b/src/pages/panel/index.js
@@ -27,6 +27,12 @@ if (isWhatsNew) {
   (chrome.action || chrome.browserAction).setPopup({
     popup: chrome.runtime.getURL('/pages/panel/index.html'),
   });
+} else {
+  // Ping telemetry 'engaged' signal on panel being opened by the user
+  chrome.runtime.sendMessage({ action: 'telemetry:ping', event: 'engaged' });
+
+  // Sync options with background
+  chrome.runtime.sendMessage({ action: 'syncOptions' });
 }
 
 // Mount the app
@@ -41,12 +47,6 @@ mount(document.body, {
     </template>
   `,
 });
-
-// Ping telemetry on panel open
-chrome.runtime.sendMessage({ action: 'telemetry:ping', event: 'engaged' });
-
-// Sync options with background
-chrome.runtime.sendMessage({ action: 'syncOptions' });
 
 // This code keeps the services worker alive while the panel is open to ensure that
 // pausing the website triggers an update keeping the old value of the option.


### PR DESCRIPTION
The "what's new" feature from #3554 auto-opens the panel to show the recap notification, but the panel entry point was firing the `engaged` telemetry ping and the `syncOptions` message unconditionally. That caused an auto-shown recap to be recorded as a user "engaged" session and to trigger an options sync, polluting telemetry and causing an unnecessary background sync.

The fix moves both `chrome.runtime.sendMessage` calls (the `telemetry:ping` engaged event and the `syncOptions` message) out of the unconditional block and into the `else` branch that runs only when the panel is not auto-opened for the recap. As a result these signals now fire only when the user manually opens the panel, so the auto-shown "what's new" recap no longer counts as engagement.
