### PR TITLE
fix(trackers-preview): resolve result destinations on updated SERPs

### DIFF
--- a/src/background/serp.js
+++ b/src/background/serp.js
@@ -14,7 +14,7 @@ import { store } from 'hybrids';
 import trackersPreviewCSS from '/content_scripts/trackers-preview.css?raw';
 
 import Options, { isGloballyPaused } from '/store/options.js';
-import { isSafari } from '/utils/browser-info.js';
+import { isWebkit } from '/utils/browser-info.js';
 import * as OptionsObserver from '/utils/options-observer.js';
 import { getWTMStats } from '/utils/wtm-stats.js';
 import { parseWithCache } from '/utils/request.js';
@@ -83,11 +83,11 @@ const SERP_TRACKING_CONTENT_SCRIPT_ID = 'serp-tracking-prevention';
 // no navigation is reported for until it is shown. Registering the script
 // leaves that to the browser instead of racing it.
 //
-// Except on Safari, which wipes the content scripts declared in the manifest
+// Except on WebKit, which wipes the content scripts declared in the manifest
 // when a script is registered (FB12817504, the reason for the `executeScript`
-// approach in the first place - see #1278). Safari does not prerender, so
+// approach in the first place - see #1278). WebKit does not prerender, so
 // injecting on navigation stays sufficient there.
-if (isSafari()) {
+if (isWebkit()) {
   chrome.webNavigation.onCommitted.addListener(async (details) => {
     if (!details.url.match(SERP_URL_REGEXP)) return;
 

--- a/src/background/serp.js
+++ b/src/background/serp.js
@@ -14,7 +14,8 @@ import { store } from 'hybrids';
 import trackersPreviewCSS from '/content_scripts/trackers-preview.css?raw';
 
 import Options, { isGloballyPaused } from '/store/options.js';
-import { addListener } from '/utils/options-observer.js';
+import { isSafari } from '/utils/browser-info.js';
+import * as OptionsObserver from '/utils/options-observer.js';
 import { getWTMStats } from '/utils/wtm-stats.js';
 import { parseWithCache } from '/utils/request.js';
 
@@ -81,39 +82,70 @@ const SERP_TRACKING_CONTENT_SCRIPT_ID = 'serp-tracking-prevention';
 // it loads - in a frame, or in a document the browser is prerendering, which
 // no navigation is reported for until it is shown. Registering the script
 // leaves that to the browser instead of racing it.
-addListener(async function serpTrackingPrevention(options, lastOptions) {
-  const enabled = options.serpTrackingPrevention && !isGloballyPaused(options);
+//
+// Except on Safari, which wipes the content scripts declared in the manifest
+// when a script is registered (FB12817504, the reason for the `executeScript`
+// approach in the first place - see #1278). Safari does not prerender, so
+// injecting on navigation stays sufficient there.
+if (isSafari()) {
+  chrome.webNavigation.onCommitted.addListener(async (details) => {
+    if (!details.url.match(SERP_URL_REGEXP)) return;
 
-  if (lastOptions) {
-    const wasEnabled = lastOptions.serpTrackingPrevention && !isGloballyPaused(lastOptions);
-    if (enabled === wasEnabled) return;
-  }
+    const options = await store.resolve(Options);
+    if (!options.serpTrackingPrevention || isGloballyPaused(options)) return;
 
-  const registered = (
-    await chrome.scripting.getRegisteredContentScripts({
-      ids: [SERP_TRACKING_CONTENT_SCRIPT_ID],
-    })
-  ).length;
-
-  if (registered) {
-    await chrome.scripting.unregisterContentScripts({
-      ids: [SERP_TRACKING_CONTENT_SCRIPT_ID],
-    });
-  }
-
-  if (enabled) {
-    await chrome.scripting.registerContentScripts([
+    chrome.scripting.executeScript(
       {
-        id: SERP_TRACKING_CONTENT_SCRIPT_ID,
-        js: ['/content_scripts/prevent-serp-tracking.js'],
-        // Result pages are served from a domain per country, and a match
-        // pattern cannot wildcard a top level domain. What they do share is
-        // `/search` in the path; the domain itself is checked in the script.
-        matches: ['*://*/search*', '*://*/*/search*'],
-        allFrames: true,
-        runAt: 'document_start',
-        persistAcrossSessions: true,
+        injectImmediately: true,
+        world: chrome.scripting.ExecutionWorld?.ISOLATED ?? 'ISOLATED',
+        target: {
+          tabId: details.tabId,
+          frameIds: [details.frameId],
+        },
+        files: ['/content_scripts/prevent-serp-tracking.js'],
       },
-    ]);
-  }
-});
+      () => {
+        if (chrome.runtime.lastError) {
+          console.error(chrome.runtime.lastError);
+        }
+      },
+    );
+  });
+} else {
+  OptionsObserver.addListener(async function serpTrackingPrevention(options, lastOptions) {
+    const enabled = options.serpTrackingPrevention && !isGloballyPaused(options);
+
+    if (lastOptions) {
+      const wasEnabled = lastOptions.serpTrackingPrevention && !isGloballyPaused(lastOptions);
+      if (enabled === wasEnabled) return;
+    }
+
+    const registered = (
+      await chrome.scripting.getRegisteredContentScripts({
+        ids: [SERP_TRACKING_CONTENT_SCRIPT_ID],
+      })
+    ).length;
+
+    if (registered) {
+      await chrome.scripting.unregisterContentScripts({
+        ids: [SERP_TRACKING_CONTENT_SCRIPT_ID],
+      });
+    }
+
+    if (enabled) {
+      await chrome.scripting.registerContentScripts([
+        {
+          id: SERP_TRACKING_CONTENT_SCRIPT_ID,
+          js: ['/content_scripts/prevent-serp-tracking.js'],
+          // Result pages are served from a domain per country, and a match
+          // pattern cannot wildcard a top level domain. What they do share is
+          // `/search` in the path; the domain itself is checked in the script.
+          matches: ['*://*/search*', '*://*/*/search*'],
+          allFrames: true,
+          runAt: 'document_start',
+          persistAcrossSessions: true,
+        },
+      ]);
+    }
+  });
+}

--- a/src/background/serp.js
+++ b/src/background/serp.js
@@ -14,7 +14,6 @@ import { store } from 'hybrids';
 import trackersPreviewCSS from '/content_scripts/trackers-preview.css?raw';
 
 import Options, { isGloballyPaused } from '/store/options.js';
-import { isWebkit } from '/utils/browser-info.js';
 import * as OptionsObserver from '/utils/options-observer.js';
 import { getWTMStats } from '/utils/wtm-stats.js';
 import { parseWithCache } from '/utils/request.js';
@@ -83,69 +82,42 @@ const SERP_TRACKING_CONTENT_SCRIPT_ID = 'serp-tracking-prevention';
 // no navigation is reported for until it is shown. Registering the script
 // leaves that to the browser instead of racing it.
 //
-// Except on WebKit, which wipes the content scripts declared in the manifest
-// when a script is registered (FB12817504, the reason for the `executeScript`
-// approach in the first place - see #1278). WebKit does not prerender, so
-// injecting on navigation stays sufficient there.
-if (isWebkit()) {
-  chrome.webNavigation.onCommitted.addListener(async (details) => {
-    if (!details.url.match(SERP_URL_REGEXP)) return;
+// Registering once wiped Safari's manifest-declared content scripts
+// (FB12817504, the reason for the `executeScript` approach in #1278);
+// verified fixed on Safari 18.6, the minimum supported version.
+OptionsObserver.addListener(async function serpTrackingPrevention(options, lastOptions) {
+  const enabled = options.serpTrackingPrevention && !isGloballyPaused(options);
 
-    const options = await store.resolve(Options);
-    if (!options.serpTrackingPrevention || isGloballyPaused(options)) return;
+  if (lastOptions) {
+    const wasEnabled = lastOptions.serpTrackingPrevention && !isGloballyPaused(lastOptions);
+    if (enabled === wasEnabled) return;
+  }
 
-    chrome.scripting.executeScript(
+  const registered = (
+    await chrome.scripting.getRegisteredContentScripts({
+      ids: [SERP_TRACKING_CONTENT_SCRIPT_ID],
+    })
+  ).length;
+
+  if (registered) {
+    await chrome.scripting.unregisterContentScripts({
+      ids: [SERP_TRACKING_CONTENT_SCRIPT_ID],
+    });
+  }
+
+  if (enabled) {
+    await chrome.scripting.registerContentScripts([
       {
-        injectImmediately: true,
-        world: chrome.scripting.ExecutionWorld?.ISOLATED ?? 'ISOLATED',
-        target: {
-          tabId: details.tabId,
-          frameIds: [details.frameId],
-        },
-        files: ['/content_scripts/prevent-serp-tracking.js'],
+        id: SERP_TRACKING_CONTENT_SCRIPT_ID,
+        js: ['/content_scripts/prevent-serp-tracking.js'],
+        // Result pages are served from a domain per country, and a match
+        // pattern cannot wildcard a top level domain. What they do share is
+        // `/search` in the path; the domain itself is checked in the script.
+        matches: ['*://*/search*', '*://*/*/search*'],
+        allFrames: true,
+        runAt: 'document_start',
+        persistAcrossSessions: true,
       },
-      () => {
-        if (chrome.runtime.lastError) {
-          console.error(chrome.runtime.lastError);
-        }
-      },
-    );
-  });
-} else {
-  OptionsObserver.addListener(async function serpTrackingPrevention(options, lastOptions) {
-    const enabled = options.serpTrackingPrevention && !isGloballyPaused(options);
-
-    if (lastOptions) {
-      const wasEnabled = lastOptions.serpTrackingPrevention && !isGloballyPaused(lastOptions);
-      if (enabled === wasEnabled) return;
-    }
-
-    const registered = (
-      await chrome.scripting.getRegisteredContentScripts({
-        ids: [SERP_TRACKING_CONTENT_SCRIPT_ID],
-      })
-    ).length;
-
-    if (registered) {
-      await chrome.scripting.unregisterContentScripts({
-        ids: [SERP_TRACKING_CONTENT_SCRIPT_ID],
-      });
-    }
-
-    if (enabled) {
-      await chrome.scripting.registerContentScripts([
-        {
-          id: SERP_TRACKING_CONTENT_SCRIPT_ID,
-          js: ['/content_scripts/prevent-serp-tracking.js'],
-          // Result pages are served from a domain per country, and a match
-          // pattern cannot wildcard a top level domain. What they do share is
-          // `/search` in the path; the domain itself is checked in the script.
-          matches: ['*://*/search*', '*://*/*/search*'],
-          allFrames: true,
-          runAt: 'document_start',
-          persistAcrossSessions: true,
-        },
-      ]);
-    }
-  });
-}
+    ]);
+  }
+});

--- a/src/background/serp.js
+++ b/src/background/serp.js
@@ -14,6 +14,7 @@ import { store } from 'hybrids';
 import trackersPreviewCSS from '/content_scripts/trackers-preview.css?raw';
 
 import Options, { isGloballyPaused } from '/store/options.js';
+import { addListener } from '/utils/options-observer.js';
 import { getWTMStats } from '/utils/wtm-stats.js';
 import { parseWithCache } from '/utils/request.js';
 
@@ -42,7 +43,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 export const SERP_URL_REGEXP =
   /^https?:[/][/][^/]*[.](google|bing)[.][a-z]+([.][a-z]+)?([/][a-z]+)*[/]search/;
 
-// SERP tracking prevention and trackers preview content scripts
+// Trackers preview content script
 chrome.webNavigation.onCommitted.addListener(async (details) => {
   if (details.url.match(SERP_URL_REGEXP)) {
     const options = await store.resolve(Options);
@@ -54,20 +55,6 @@ chrome.webNavigation.onCommitted.addListener(async (details) => {
         },
         css: trackersPreviewCSS,
       });
-    }
-
-    if (options.wtmSerpReport || options.serpTrackingPrevention) {
-      const files = [];
-
-      if (options.wtmSerpReport) {
-        files.push('/content_scripts/trackers-preview.js');
-      }
-
-      if (!isGloballyPaused(options) && options.serpTrackingPrevention) {
-        files.push('/content_scripts/prevent-serp-tracking.js');
-      }
-
-      if (files.length === 0) return;
 
       chrome.scripting.executeScript(
         {
@@ -76,7 +63,7 @@ chrome.webNavigation.onCommitted.addListener(async (details) => {
           target: {
             tabId: details.tabId,
           },
-          files,
+          files: ['/content_scripts/trackers-preview.js'],
         },
         () => {
           if (chrome.runtime.lastError) {
@@ -85,5 +72,48 @@ chrome.webNavigation.onCommitted.addListener(async (details) => {
         },
       );
     }
+  }
+});
+
+const SERP_TRACKING_CONTENT_SCRIPT_ID = 'serp-tracking-prevention';
+
+// A result page has to be covered from the moment it starts loading, wherever
+// it loads - in a frame, or in a document the browser is prerendering, which
+// no navigation is reported for until it is shown. Registering the script
+// leaves that to the browser instead of racing it.
+addListener(async function serpTrackingPrevention(options, lastOptions) {
+  const enabled = options.serpTrackingPrevention && !isGloballyPaused(options);
+
+  if (lastOptions) {
+    const wasEnabled = lastOptions.serpTrackingPrevention && !isGloballyPaused(lastOptions);
+    if (enabled === wasEnabled) return;
+  }
+
+  const registered = (
+    await chrome.scripting.getRegisteredContentScripts({
+      ids: [SERP_TRACKING_CONTENT_SCRIPT_ID],
+    })
+  ).length;
+
+  if (registered) {
+    await chrome.scripting.unregisterContentScripts({
+      ids: [SERP_TRACKING_CONTENT_SCRIPT_ID],
+    });
+  }
+
+  if (enabled) {
+    await chrome.scripting.registerContentScripts([
+      {
+        id: SERP_TRACKING_CONTENT_SCRIPT_ID,
+        js: ['/content_scripts/prevent-serp-tracking.js'],
+        // Result pages are served from a domain per country, and a match
+        // pattern cannot wildcard a top level domain. What they do share is
+        // `/search` in the path; the domain itself is checked in the script.
+        matches: ['*://*/search*', '*://*/*/search*'],
+        allFrames: true,
+        runAt: 'document_start',
+        persistAcrossSessions: true,
+      },
+    ]);
   }
 });

--- a/src/content_scripts/prevent-serp-tracking.js
+++ b/src/content_scripts/prevent-serp-tracking.js
@@ -9,38 +9,77 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
+import debounce from '/utils/debounce.js';
+import { isResultPage, scanDocumentLinkData } from '/utils/link-destinations.js';
+
+// Only one of the result pages swaps a link for its wrapper, so only its
+// links are rewritten up front - elsewhere the click handler is enough.
+const WRAPPED_LINKS = 'a[href^="/goto?url="], a[href*="/aclk?"], a[data-rw], a[data-agdh="arwt"]';
+
+// `data-rw` holds the replacement outright; `data-agdh` names a hidden twin
+// that holds it. Either way, a link that points at its destination keeps it.
+function dropSwap(el) {
+  el.removeAttribute('data-rw');
+
+  if (el.dataset.agdh === 'arwt') el.removeAttribute('data-agdh');
+}
+
+function rewriteLinks() {
+  // A ping reports the click to the page it came from, and is sent for every
+  // way of following a link - including ones that raise no click event, like
+  // a middle click or opening in a new tab from the context menu.
+  for (const el of document.querySelectorAll('a[ping]')) {
+    el.removeAttribute('ping');
+  }
+
+  const getDestination = scanDocumentLinkData();
+
+  for (const el of document.querySelectorAll(WRAPPED_LINKS)) {
+    const destination = getDestination(el);
+
+    if (destination) {
+      el.href = destination;
+      dropSwap(el);
+    } else if (el.hostname !== window.location.hostname) {
+      // Shown with its real destination already - only the swap has to go
+      dropSwap(el);
+    }
+  }
+}
+
 function safeLinkClick(event) {
   let el = event.target;
   while (el && !el.href) el = el.parentElement;
 
   if (!el) return;
-  // Google Search Engine Redirect Protection
-  el.removeAttribute('ping');
-  let targetUrl = null;
-  if (el.pathname === '/url') {
-    targetUrl = new URL(el.href).searchParams.get('url');
-  }
-  // Bing Search Engine Redirect Protection
-  else if (el.pathname == '/ck/a') {
-    const uParam = new URL(el.href).searchParams.get('u');
-    if (uParam) {
-      // Bing prefixes the Base64 string with 'a1'
-      const base64Str = uParam.slice(2);
-      try {
-        const decoded = atob(base64Str);
-        if (decoded) {
-          targetUrl = decoded;
-        }
-      } catch {
-        // If decoding fails, leave targetUrl null (no rewrite)
-      }
-    }
-  }
 
-  if (targetUrl) {
+  el.removeAttribute('ping');
+
+  // The link may have arrived after the last rewrite
+  const destination = scanDocumentLinkData()(el);
+
+  if (destination) {
     event.stopImmediatePropagation();
-    el.href = targetUrl;
+    el.href = destination;
   }
 }
 
-document.addEventListener('click', safeLinkClick, true);
+const rewriteLinksDebounced = debounce(rewriteLinks, { waitFor: 100, maxWait: 500 });
+
+// A match pattern cannot name the result pages more closely than the `/search`
+// in their path, so most of the pages this runs on are not one of them.
+if (isResultPage()) {
+  document.addEventListener('click', safeLinkClick, true);
+
+  rewriteLinks();
+
+  // Results are rewritten as they stream in, and ads keep their place in the
+  // DOM and fill their attributes in later. `document` is observed rather than
+  // its element, which is not there yet when the page has only just started.
+  new MutationObserver(rewriteLinksDebounced).observe(document, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['ping', 'href', 'data-rw', 'data-agdh'],
+  });
+}

--- a/src/content_scripts/trackers-preview.js
+++ b/src/content_scripts/trackers-preview.js
@@ -11,6 +11,7 @@
 
 import { drawWheel } from '/ui/wheel.js';
 import { isFromExtensionFrame } from '/utils/messaging.js';
+import { scanDocumentLinkData } from '/utils/link-destinations.js';
 
 const WRAPPER_CLASS = 'wtm-popup-iframe-wrapper';
 
@@ -101,29 +102,12 @@ function setupTrackersPreview(popupUrl) {
   const elements = [...window.document.querySelectorAll(SELECTORS)].filter((el) => !el.dataset.wtm);
 
   if (elements.length) {
+    const getDestination = scanDocumentLinkData();
+
     const links = elements.map((el) => {
       el.dataset.wtm = 1;
 
-      if (el.hostname === window.location.hostname) {
-        const url = new URL(el.href);
-
-        // Google
-        if (url.pathname === '/url') {
-          return url.searchParams.get('url') || url.searchParams.get('q');
-        }
-
-        // Bing
-        if (url.pathname === '/ck/a' && url.searchParams.has('u')) {
-          try {
-            const base64Str = url.searchParams.get('u').slice(2);
-            return atob(base64Str) || '';
-          } catch {
-            return '';
-          }
-        }
-      }
-
-      return el.href;
+      return getDestination(el) || el.href;
     });
 
     chrome.runtime.sendMessage({ action: 'getWTMReport', links }, (response) => {
@@ -210,6 +194,12 @@ window.addEventListener('message', (message) => {
   }
 });
 
-document.addEventListener('DOMContentLoaded', () => {
+function setup() {
   setupTrackersPreview(chrome.runtime.getURL('pages/trackers-preview/index.html'));
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', setup);
+} else {
+  setup();
+}

--- a/src/utils/link-destinations.js
+++ b/src/utils/link-destinations.js
@@ -175,7 +175,7 @@ function bingDestinations() {
 
     try {
       // Two leading characters mark the encoding, they are not part of it
-      return atob(param.slice(2)) || null;
+      return httpUrl(atob(param.slice(2)));
     } catch {
       return null;
     }

--- a/src/utils/link-destinations.js
+++ b/src/utils/link-destinations.js
@@ -12,9 +12,15 @@
 // Result pages route their links through themselves to record where visitors
 // go, and each hides the destination its own way. A page is only ever read by
 // the function named for it here.
+//
+// A country edition is served from google.<com|cat|cc> or google.co(m).<cc>;
+// subdomains other than www are other products (mail, docs), not result pages.
 const RESULT_PAGES = [
-  { host: /(^|\.)google\.[a-z]+(\.[a-z]+)?$/, linkDestinations: googleDestinations },
-  { host: /(^|\.)bing\.[a-z]+(\.[a-z]+)?$/, linkDestinations: bingDestinations },
+  {
+    host: /^(www\.)?google\.(com|cat|[a-z]{2}|com?\.[a-z]{2})$/,
+    linkDestinations: googleDestinations,
+  },
+  { host: /^(www|cn)\.bing\.com$/, linkDestinations: bingDestinations },
 ];
 
 export function scanDocumentLinkData(doc = document) {

--- a/src/utils/link-destinations.js
+++ b/src/utils/link-destinations.js
@@ -147,7 +147,7 @@ function googleDestinations(doc) {
 
     switch (pathname) {
       case '/url':
-        return searchParams.get('url') || searchParams.get('q');
+        return httpUrl(searchParams.get('url') || searchParams.get('q'));
 
       case '/goto': {
         const [, token] = search.match(TOKEN_REGEXP) || [];

--- a/src/utils/link-destinations.js
+++ b/src/utils/link-destinations.js
@@ -1,0 +1,177 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+// Result pages route their links through themselves to record where visitors
+// go, and each hides the destination its own way. A page is only ever read by
+// the function named for it here.
+const RESULT_PAGES = [
+  { host: /(^|\.)google\.[a-z]+(\.[a-z]+)?$/, linkDestinations: googleDestinations },
+  { host: /(^|\.)bing\.[a-z]+(\.[a-z]+)?$/, linkDestinations: bingDestinations },
+];
+
+export function scanDocumentLinkData(doc = document) {
+  const page = RESULT_PAGES.find(({ host }) => host.test(window.location.hostname));
+  const getDestination = page ? page.linkDestinations(doc) : () => null;
+
+  return (el) => (typeof el.href === 'string' ? getDestination(el) : null);
+}
+
+export function isResultPage(hostname = window.location.hostname) {
+  return RESULT_PAGES.some(({ host }) => host.test(hostname));
+}
+
+// --- Shared ---
+
+function sameOrigin(el) {
+  return el.hostname === window.location.hostname;
+}
+
+function httpUrl(value) {
+  try {
+    const { protocol, href } = new URL(value);
+    return protocol === 'https:' || protocol === 'http:' ? href : null;
+  } catch {
+    return null;
+  }
+}
+
+// --- Google ---
+
+// Some links spell the destination out in the query string; the rest carry an
+// opaque token, and only the order of the data the page renders its results
+// from ties the two together:
+//
+//   [..., "/goto?url=<token>"],["https://example.com/", "<title>", ...]
+const RENDER_DATA_REGEXP =
+  /\/goto\?url\\u003d([\w-]{20,})"(?:,(?:null|-?\d+))*\],\["(https?:[^"]+)"/g;
+
+// The same token turns up with different padding and parameters around it.
+const TOKEN_REGEXP = /[?&]url=([\w-]{20,})/;
+
+// Ads are wrapped differently again: their click tracker names the landing
+// page in `adurl` - on the link itself, or in `data-rw`, what the link becomes.
+const AD_CLICK_PATHNAME_REGEXP = /^(?:\/pagead)?\/aclk$/;
+
+const documentIndexes = new WeakMap();
+
+function unescapeJS(str) {
+  return str.replace(/\\(?:u([\da-fA-F]{4})|x([\da-fA-F]{2})|(.))/g, (_, u, x, char) =>
+    char !== undefined ? char : String.fromCharCode(parseInt(u || x, 16)),
+  );
+}
+
+function addDestination(destinations, token, url) {
+  // A result is described more than once per page, every copy the same way
+  if (destinations.has(token)) return;
+
+  const destination = httpUrl(url);
+  if (destination) destinations.set(token, destination);
+}
+
+// Results stream in as the page grows, so the index is built up over repeated
+// scans of the same document. A script still being filled in is read again
+// once it has grown, rather than being taken for everything it will hold.
+function indexRenderData(doc) {
+  let index = documentIndexes.get(doc);
+
+  if (!index) {
+    index = { readUpTo: new WeakMap(), destinations: new Map() };
+    documentIndexes.set(doc, index);
+  }
+
+  const { readUpTo, destinations } = index;
+
+  for (const script of doc.querySelectorAll('script:not([src])')) {
+    const text = script.textContent;
+    if (!text || readUpTo.get(script) === text.length) continue;
+
+    readUpTo.set(script, text.length);
+    if (!text.includes('/goto?url')) continue;
+
+    for (const [, token, url] of text.matchAll(RENDER_DATA_REGEXP)) {
+      addDestination(destinations, token, unescapeJS(url));
+    }
+  }
+
+  return destinations;
+}
+
+function getAdDestination(el) {
+  for (const clickUrl of [el.getAttribute('data-rw'), el.href]) {
+    if (!clickUrl) continue;
+
+    let landingPage;
+    try {
+      const url = new URL(clickUrl, window.location.href);
+      if (!AD_CLICK_PATHNAME_REGEXP.test(url.pathname)) continue;
+
+      landingPage = url.searchParams.get('adurl');
+    } catch {
+      continue;
+    }
+
+    // Often empty, leaving only the advertiser's domain - not the same page
+    const destination = landingPage && httpUrl(landingPage);
+    if (destination) return destination;
+  }
+
+  return null;
+}
+
+function googleDestinations(doc) {
+  const destinations = indexRenderData(doc);
+
+  return (el) => {
+    // An ad's own landing page beats the index, which is keyed by a token the
+    // page reuses - one can back both an ad and a result for the same site.
+    const landingPage = getAdDestination(el);
+    if (landingPage) return landingPage;
+
+    if (!sameOrigin(el)) return null;
+
+    const { pathname, search, searchParams } = new URL(el.href);
+
+    switch (pathname) {
+      case '/url':
+        return searchParams.get('url') || searchParams.get('q');
+
+      case '/goto': {
+        const [, token] = search.match(TOKEN_REGEXP) || [];
+        return (token && destinations.get(token)) || null;
+      }
+
+      default:
+        return null;
+    }
+  };
+}
+
+// --- Bing ---
+
+// The destination travels in the link itself, encoded.
+function bingDestinations() {
+  return (el) => {
+    if (!sameOrigin(el)) return null;
+
+    const { pathname, searchParams } = new URL(el.href);
+    if (pathname !== '/ck/a') return null;
+
+    const param = searchParams.get('u');
+    if (!param) return null;
+
+    try {
+      // Two leading characters mark the encoding, they are not part of it
+      return atob(param.slice(2)) || null;
+    } catch {
+      return null;
+    }
+  };
+}

--- a/tests/unit/link-destinations.test.js
+++ b/tests/unit/link-destinations.test.js
@@ -67,6 +67,13 @@ describe('link destinations', () => {
       }
     });
 
+    it('ignores a spelled-out destination that is not an http(s) URL', () => {
+      for (const param of ['url', 'q']) {
+        const target = encodeURIComponent('javascript:alert(1)');
+        assert.equal(resolve('', `https://${RENDER_DATA_PAGE}/url?${param}=${target}`), null);
+      }
+    });
+
     it('leaves links that already point at their destination alone', () => {
       assert.equal(resolve('', `https://${RENDER_DATA_PAGE}/search?q=a+query`), null);
       assert.equal(resolve(renderDataScript(), `https://example.com/goto?url=${TOKEN}`), null);
@@ -218,6 +225,10 @@ describe('link destinations', () => {
     it('leaves the link alone when it cannot be decoded', () => {
       assert.equal(resolve(`https://${ENCODED_LINK_PAGE}/ck/a?u=a1!!not-base64`), null);
       assert.equal(resolve(`https://${ENCODED_LINK_PAGE}/ck/a?other=1`), null);
+    });
+
+    it('ignores a decoded destination that is not an http(s) URL', () => {
+      assert.equal(resolve(encoded('javascript:alert(1)')), null);
     });
 
     it('leaves links that already point at their destination alone', () => {

--- a/tests/unit/link-destinations.test.js
+++ b/tests/unit/link-destinations.test.js
@@ -246,13 +246,36 @@ describe('link destinations', () => {
 
   describe('isResultPage()', () => {
     it('knows a result page by its host, whichever country it is served from', () => {
-      for (const hostname of ['www.google.com', 'google.pl', 'www.google.co.uk', 'www.bing.com']) {
+      for (const hostname of [
+        'www.google.com',
+        'google.pl',
+        'www.google.co.uk',
+        'www.google.com.au',
+        'www.google.cat',
+        'www.bing.com',
+        'cn.bing.com',
+      ]) {
         assert.equal(isResultPage(hostname), true, hostname);
       }
     });
 
     it('is not fooled by a host that merely carries the name', () => {
-      for (const hostname of ['github.com', 'notgoogle.com', 'google.com.example.net']) {
+      for (const hostname of [
+        'github.com',
+        'notgoogle.com',
+        'google.example.com',
+        'google.example.net',
+        'bing.example.com',
+        'bing.example.net',
+        'google.com.example.net',
+        'google.co.com',
+      ]) {
+        assert.equal(isResultPage(hostname), false, hostname);
+      }
+    });
+
+    it('does not take other products on a subdomain for result pages', () => {
+      for (const hostname of ['mail.google.com', 'docs.google.com', 'scholar.google.com']) {
         assert.equal(isResultPage(hostname), false, hostname);
       }
     });

--- a/tests/unit/link-destinations.test.js
+++ b/tests/unit/link-destinations.test.js
@@ -1,0 +1,268 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isResultPage, scanDocumentLinkData } from '../../src/utils/link-destinations.js';
+
+const RENDER_DATA_PAGE = 'www.google.com';
+const ENCODED_LINK_PAGE = 'www.bing.com';
+
+const TOKEN = 'aResultTokenLongEnoughToPass';
+const DESTINATION = 'https://example.com/a-result';
+
+const element = (href, attributes = {}) => ({
+  href,
+  hostname: new URL(href).hostname,
+  getAttribute: (name) => attributes[name] ?? null,
+});
+
+const documentWith = (...scripts) => ({
+  querySelectorAll: () => scripts.map((text) => ({ textContent: text })),
+});
+
+function onPage(hostname) {
+  global.window = { location: { hostname } };
+}
+
+function visit(hostname, ...scripts) {
+  onPage(hostname);
+
+  return scanDocumentLinkData(documentWith(...scripts));
+}
+
+const renderDataScript = (token = TOKEN, destination = DESTINATION, trailing = '') =>
+  `x,"/goto?url\\u003d${token}"${trailing}],["${destination}","a title"],y`;
+
+describe('link destinations', () => {
+  describe('a page that carries its results as data', () => {
+    const wrapped = `https://${RENDER_DATA_PAGE}/goto?url=${TOKEN}`;
+
+    const resolve = (scripts, href = wrapped) =>
+      visit(RENDER_DATA_PAGE, ...[scripts].flat())(element(href));
+
+    it('resolves a wrapped link through the render data', () => {
+      assert.equal(resolve(renderDataScript()), DESTINATION);
+    });
+
+    it('leaves a link alone when the page does not describe its token', () => {
+      assert.equal(resolve('nothing to index here'), null);
+    });
+
+    it('reads a destination spelled out in the query string', () => {
+      const target = 'https://example.com/spelled-out';
+
+      for (const param of ['url', 'q']) {
+        const href = `https://${RENDER_DATA_PAGE}/url?${param}=${encodeURIComponent(target)}`;
+        assert.equal(resolve('', href), target);
+      }
+    });
+
+    it('leaves links that already point at their destination alone', () => {
+      assert.equal(resolve('', `https://${RENDER_DATA_PAGE}/search?q=a+query`), null);
+      assert.equal(resolve(renderDataScript(), `https://example.com/goto?url=${TOKEN}`), null);
+    });
+
+    it('matches a token carrying padding or extra parameters', () => {
+      for (const suffix of ['', '=', '%3D', '&ved=abc', '%3D%3D&ved=abc']) {
+        assert.equal(
+          resolve(renderDataScript(), `${wrapped}${suffix}`),
+          DESTINATION,
+          `suffix: ${JSON.stringify(suffix)}`,
+        );
+      }
+    });
+
+    it('ignores tokens too short to be real', () => {
+      const short = 'tooShort';
+
+      assert.equal(
+        resolve(renderDataScript(short), `https://${RENDER_DATA_PAGE}/goto?url=${short}`),
+        null,
+      );
+    });
+
+    it('ignores a destination that is not an http(s) URL', () => {
+      assert.equal(resolve(renderDataScript(TOKEN, 'ftp://example.com/x')), null);
+      assert.equal(resolve(renderDataScript(TOKEN, 'https://not a url')), null);
+    });
+
+    it('unescapes a destination out of the render data', () => {
+      const escaped = 'https://example.com/a\\u003db\\u0026c\\u003dd';
+
+      assert.equal(resolve(renderDataScript(TOKEN, escaped)), 'https://example.com/a=b&c=d');
+    });
+
+    it('tolerates extra fields trailing the token', () => {
+      assert.equal(resolve(renderDataScript(TOKEN, DESTINATION, ',null,3')), DESTINATION);
+    });
+
+    describe('while the page is still streaming in', () => {
+      const OTHER_TOKEN = TOKEN.replace('aResult', 'bResult');
+      const OTHER_DESTINATION = 'https://example.com/b-result';
+      const otherWrapped = `https://${RENDER_DATA_PAGE}/goto?url=${OTHER_TOKEN}`;
+
+      const streaming = (textContent) => {
+        onPage(RENDER_DATA_PAGE);
+
+        const script = { textContent };
+        return [script, { querySelectorAll: () => [script] }];
+      };
+
+      it('reads a script that was still empty on an earlier pass', () => {
+        const [script, doc] = streaming('');
+
+        scanDocumentLinkData(doc);
+        script.textContent = renderDataScript();
+
+        assert.equal(scanDocumentLinkData(doc)(element(wrapped)), DESTINATION);
+      });
+
+      it('reads the rest of a script that has grown since', () => {
+        const [script, doc] = streaming(renderDataScript());
+
+        scanDocumentLinkData(doc);
+        script.textContent += renderDataScript(OTHER_TOKEN, OTHER_DESTINATION);
+
+        const getDestination = scanDocumentLinkData(doc);
+
+        assert.equal(getDestination(element(otherWrapped)), OTHER_DESTINATION);
+        assert.equal(getDestination(element(wrapped)), DESTINATION);
+      });
+
+      it('leaves a script alone once it stops growing', () => {
+        const [script, doc] = streaming(renderDataScript());
+
+        scanDocumentLinkData(doc);
+        script.textContent = renderDataScript(OTHER_TOKEN, OTHER_DESTINATION);
+
+        const getDestination = scanDocumentLinkData(doc);
+
+        assert.equal(getDestination(element(otherWrapped)), null);
+        assert.equal(getDestination(element(wrapped)), DESTINATION);
+      });
+    });
+
+    describe('ads', () => {
+      const LANDING_PAGE = 'https://advertiser.example/offer?utm_campaign=x';
+      const clickTracker = (adurl, path = '/aclk') =>
+        `https://ads.example${path}?ai=abc&gclid=xyz&adurl=${encodeURIComponent(adurl)}`;
+
+      const adLink = (attributes, href = wrapped) =>
+        visit(RENDER_DATA_PAGE)(element(href, attributes));
+
+      it('follows the click tracker the page swaps the link for', () => {
+        assert.equal(adLink({ 'data-rw': clickTracker(LANDING_PAGE) }), LANDING_PAGE);
+      });
+
+      it('follows a click tracker used as the link itself', () => {
+        assert.equal(adLink({}, clickTracker(LANDING_PAGE)), LANDING_PAGE);
+        assert.equal(adLink({}, clickTracker(LANDING_PAGE, '/pagead/aclk')), LANDING_PAGE);
+      });
+
+      it('leaves the link alone when the landing page is withheld', () => {
+        assert.equal(adLink({ 'data-rw': clickTracker('') }), null);
+        assert.equal(adLink({ 'data-rw': 'https://ads.example/aclk?ai=abc' }), null);
+        assert.equal(adLink({ 'data-rw': 'not a url' }), null);
+      });
+
+      it('ignores a landing page that is not an http(s) URL', () => {
+        assert.equal(adLink({ 'data-rw': clickTracker('javascript:alert(1)') }), null);
+      });
+
+      it('only follows an actual click tracker', () => {
+        // A destination that merely carries an "adurl" of its own is not one
+        const decoy = 'https://advertiser.example/landing?adurl=https://elsewhere.example/';
+
+        assert.equal(adLink({}, decoy), null);
+        assert.equal(adLink({ 'data-rw': decoy }), null);
+      });
+
+      it('prefers its landing page over a token the page reuses elsewhere', () => {
+        const getDestination = visit(RENDER_DATA_PAGE, renderDataScript());
+
+        const el = element(wrapped, { 'data-rw': clickTracker(LANDING_PAGE) });
+
+        assert.equal(getDestination(el), LANDING_PAGE);
+      });
+
+      it('falls back to the index when the landing page is withheld', () => {
+        const getDestination = visit(RENDER_DATA_PAGE, renderDataScript());
+
+        const el = element(wrapped, { 'data-rw': clickTracker('') });
+
+        assert.equal(getDestination(el), DESTINATION);
+      });
+    });
+  });
+
+  describe('a page that encodes the destination into the link', () => {
+    const encoded = (value = DESTINATION) =>
+      `https://${ENCODED_LINK_PAGE}/ck/a?u=a1${Buffer.from(value).toString('base64')}`;
+
+    const resolve = (href) => visit(ENCODED_LINK_PAGE)(element(href));
+
+    it('decodes the destination', () => {
+      assert.equal(resolve(encoded()), DESTINATION);
+    });
+
+    it('leaves the link alone when it cannot be decoded', () => {
+      assert.equal(resolve(`https://${ENCODED_LINK_PAGE}/ck/a?u=a1!!not-base64`), null);
+      assert.equal(resolve(`https://${ENCODED_LINK_PAGE}/ck/a?other=1`), null);
+    });
+
+    it('leaves links that already point at their destination alone', () => {
+      assert.equal(resolve(`https://${ENCODED_LINK_PAGE}/search?q=a+query`), null);
+      assert.equal(resolve(`https://example.com/ck/a?u=a1${btoa(DESTINATION)}`), null);
+    });
+  });
+
+  it('reads a page only the way that page is written', () => {
+    const onRenderData = visit(RENDER_DATA_PAGE, renderDataScript());
+    const encodedLink = `https://${RENDER_DATA_PAGE}/ck/a?u=a1${btoa(DESTINATION)}`;
+
+    assert.equal(onRenderData(element(encodedLink)), null);
+
+    const onEncodedLink = visit(ENCODED_LINK_PAGE, renderDataScript());
+    const wrappedLink = `https://${ENCODED_LINK_PAGE}/goto?url=${TOKEN}`;
+
+    assert.equal(onEncodedLink(element(wrappedLink)), null);
+  });
+
+  it('resolves nothing on a page it does not know', () => {
+    const getDestination = visit('search.example', renderDataScript());
+
+    assert.equal(getDestination(element(`https://search.example/goto?url=${TOKEN}`)), null);
+  });
+
+  describe('isResultPage()', () => {
+    it('knows a result page by its host, whichever country it is served from', () => {
+      for (const hostname of ['www.google.com', 'google.pl', 'www.google.co.uk', 'www.bing.com']) {
+        assert.equal(isResultPage(hostname), true, hostname);
+      }
+    });
+
+    it('is not fooled by a host that merely carries the name', () => {
+      for (const hostname of ['github.com', 'notgoogle.com', 'google.com.example.net']) {
+        assert.equal(isResultPage(hostname), false, hostname);
+      }
+    });
+  });
+
+  it('ignores elements without a string href', () => {
+    const getDestination = visit(RENDER_DATA_PAGE);
+
+    for (const href of [undefined, null, {}, { baseVal: '/goto?url=x' }]) {
+      assert.equal(getDestination({ href, getAttribute: () => null }), null);
+    }
+  });
+});


### PR DESCRIPTION
Search result links no longer point at their destination, so Trackers Preview was looking up stats for the search engine itself and rendered no wheels.

Destinations are now resolved from the data the results page carries, in a module shared with Prevent SERP Tracking.

Each result page is read on its own terms: a small table maps a page to the one function that knows how its links are written, and the two share nothing. A link shape is no longer read on a page it does not belong to — where a shape used to be decoded wherever it turned up, an unfamiliar one is now left alone.

Prevent SERP Tracking rewrites links up front only on the page that swaps them for a wrapper; elsewhere the click handler covers it.
