### PR TITLE
fix(reporting): enable reporting when disableOnboarding managed config is set

### DIFF
--- a/src/background/reporting/index.js
+++ b/src/background/reporting/index.js
@@ -9,10 +9,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
+import { store } from 'hybrids';
 import { setLogLevel, describeLoggers } from '@whotracksme/reporting/reporting';
 
 import * as OptionsObserver from '/utils/options-observer.js';
-import { isFirefox } from '/utils/browser-info.js';
+
+import ManagedConfig from '/store/managed-config.js';
 
 import config from './config.js';
 import communication from './communication.js';
@@ -36,7 +38,7 @@ import webRequestReporter from './webrequest-reporter.js';
 })();
 
 OptionsObserver.addListener('terms', async function reporting(terms) {
-  if (terms && !isFirefox()) {
+  if (terms && (__CHROMIUM__ || (await store.resolve(ManagedConfig).disableOnboarding))) {
     if (webRequestReporter) {
       webRequestReporter.init().catch((e) => {
         console.warn(


### PR DESCRIPTION
Fixes ghostery/journal#760.

Enables the reporting module when the `disableOnboarding` managed config is set, in addition to chromium builds.

Note: using the `__CHROMIUM__` build-time environment variable doesn't change the built result, since the condition now contains another requirement. However, it simplifies the condition for Chromium, since previously we were checking `isFirefox()` every time, even on Chromium builds.