### PR TITLE
fix(devtools): avoid translating navigator technical values

### DIFF
--- a/src/pages/settings/components/devtools.js
+++ b/src/pages/settings/components/devtools.js
@@ -311,7 +311,7 @@ export default {
                     `,
                   ),
                 )}
-                <div layout="column gap items:start" translate="no">
+                <div layout="column gap items:start">
                   <ui-text type="headline-s">Navigator</ui-text>
                   <div layout="column gap">
                     <div layout="column gap:0.5">
@@ -336,7 +336,7 @@ export default {
                     ${html.resolve(
                       getBackgroundNavigator().then(
                         (info) => html`
-                          <div layout="column gap:0.5">
+                          <div layout="column gap:0.5" translate="no">
                             <ui-text type="label-m">Background</ui-text>
                             <ui-text type="body-s" color="secondary">
                               <ui-text type="label-s">User agent:</ui-text>


### PR DESCRIPTION
The recently added Navigator section in devtools wrapped its whole container in `translate="no"`, which also suppressed translation of the "Navigator" heading and its "Page"/"Background" sub-labels, not just the raw technical values. Moved `translate="no"` off the outer container and onto the Background subsection so only the browser-reported values stay untranslated while the surrounding labels remain translatable.