### PR TITLE
chore(panel): update survey notification wording

### DIFF
--- a/src/pages/panel/store/notification.js
+++ b/src/pages/panel/store/notification.js
@@ -70,7 +70,7 @@ const NOTIFICATIONS = {
   survey: {
     img: callForSurveyImage,
     type: 'image',
-    text: 'Which parts of this panel do you actually use? Anonymous, about three minutes — it decides what we simplify next.',
+    text: 'Which parts of this panel do you actually use? It takes about three minutes - and decides what we simplify next.',
     url: 'https://blocksurvey.io/panel-user-feedback-l8ijSFaLTGuLCV2ZZSFzYg',
     action: 'Tell us',
   },


### PR DESCRIPTION
The panel survey notification text used an em dash and the word "Anonymous", which read a bit stiff for a casual in-product prompt. This updates the wording to a friendlier phrasing ("It takes about three minutes - and decides what we simplify next.") while keeping the same meaning.