### PR TITLE
chore(dependabot): update schedule time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,9 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-      day: 'friday'
-      time: '07:00'
+      day: 'monday'
+      time: '08:00'
+      timezone: 'Europe/Warsaw'
     open-pull-requests-limit: 99
     groups:
       adblocker:


### PR DESCRIPTION
Releases moved from being pushed on Mondays (prepared on Fridays) to mid-week, so the previous Monday dependency update schedule no longer aligns with the release cycle. This updates the Dependabot schedule to run at the beginning of the week, giving time to review and merge dependency updates before the mid-week release. The schedule now runs Mondays at 08:00 in the Europe/Warsaw timezone instead of the default UTC.