### PR TITLE
chore(modes): Remove FLAG_MODES conditions

### DIFF
--- a/src/background/config.js
+++ b/src/background/config.js
@@ -86,32 +86,6 @@ export default async function syncConfig() {
   }
 }
 
-export function waitForConfigSync(timeout = 5000) {
-  return new Promise((resolve) => {
-    store.resolve(Config).then((config) => {
-      if (config.updatedAt > 0) {
-        resolve();
-        return;
-      }
-
-      let unobserve;
-
-      const timer = setTimeout(() => {
-        unobserve();
-        resolve();
-      }, timeout);
-
-      unobserve = store.observe(Config, (_, config) => {
-        if (config.updatedAt > 0) {
-          clearTimeout(timer);
-          unobserve();
-          resolve();
-        }
-      });
-    });
-  });
-}
-
 if (__DEBUG__) {
   // Enable all available flags
   store.set(Config, {

--- a/src/background/onboarding.js
+++ b/src/background/onboarding.js
@@ -19,8 +19,6 @@ import { SURVEY_POST_ONBOARDING_URL } from '/utils/urls.js';
 import { isBrave } from '/utils/browser-info.js';
 import * as OptionsObserver from '/utils/options-observer.js';
 
-import { waitForConfigSync } from './config.js';
-
 OptionsObserver.addListener('onboarding', async (onboarding) => {
   // Onboarding already shown
   if (onboarding) return;
@@ -28,10 +26,6 @@ OptionsObserver.addListener('onboarding', async (onboarding) => {
   // The onboarding page should not be shown in debug mode especially for the e2e tests
   // which fails if after initializing the extension additional tabs are opened
   if (__DEBUG__) return;
-
-  // TODO: Remove this after the `modes` flag is completed, as then the onboarding
-  // page will not depend on the config and can be shown immediately
-  await waitForConfigSync();
 
   const tab = await chrome.tabs.create({
     url: chrome.runtime.getURL('/pages/onboarding/index.html'),

--- a/src/background/telemetry/metrics.js
+++ b/src/background/telemetry/metrics.js
@@ -11,8 +11,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import { FLAG_MODES } from '@ghostery/config';
-
 import getDefaultLanguage from './language.js';
 import getBrowserInfo from '/utils/browser-info.js';
 
@@ -206,18 +204,16 @@ export default class Metrics {
       buildQueryPair('bv', browserInfo.version) +
       // Date of install (former install_date)
       buildQueryPair('id', this.storage.installDate) +
-      // ZAP mode (-1 = flag disabled, 0 = default, 1 = zap, 2 = default + touched, 3 = zap + touched)
+      // ZAP mode (0 = default, 1 = zap, 2 = default + touched, 3 = zap + touched)
       buildQueryPair(
         'zap',
-        !conf.config.hasFlag(FLAG_MODES)
-          ? '-1'
-          : this.storage.modeTouched
-            ? conf.options.mode === 'zap'
-              ? '3'
-              : '2'
-            : conf.options.mode === 'zap'
-              ? '1'
-              : '0',
+        this.storage.modeTouched
+          ? conf.options.mode === 'zap'
+            ? '3'
+            : '2'
+          : conf.options.mode === 'zap'
+            ? '1'
+            : '0',
       ) +
       // Onboarding complete
       buildQueryPair('oc', this.storage.install_complete_all ? '1' : '0') +

--- a/src/background/zapped.js
+++ b/src/background/zapped.js
@@ -9,34 +9,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-import { store } from 'hybrids';
-import { FLAG_MODES } from '@ghostery/config';
-
-import Config from '/store/config.js';
-import Options, { MODE_DEFAULT, MODE_ZAP } from '/store/options.js';
+import { MODE_ZAP } from '/store/options.js';
 
 import { isWebkit } from '/utils/browser-info.js';
 import { getDynamicRulesIds, PAUSED_ID_RANGE, PAUSED_RULE_PRIORITY } from '/utils/dnr.js';
 import * as OptionsObserver from '/utils/options-observer.js';
-
-// Clear filtering mode and zapped data if the flag is removed
-store.observe(Config, async (_, config, lastConfig) => {
-  if (lastConfig?.hasFlag(FLAG_MODES) && !config.hasFlag(FLAG_MODES)) {
-    // Clear out DNR rules related to zap mode
-    const removeRuleIds = await getDynamicRulesIds(PAUSED_ID_RANGE);
-    await chrome.declarativeNetRequest.updateDynamicRules({
-      removeRuleIds,
-    });
-
-    // Reset filtering mode and zapped data
-    await store.set(Options, {
-      mode: MODE_DEFAULT,
-      zapped: null,
-    });
-
-    console.log(`[zapped] Filtering mode flag removed, resetting filtering mode and zapped data`);
-  }
-});
 
 if (__CHROMIUM__) {
   OptionsObserver.addListener(async function zapped(options, lastOptions) {

--- a/src/pages/onboarding/views/main.js
+++ b/src/pages/onboarding/views/main.js
@@ -10,9 +10,7 @@
  */
 
 import { html, msg, router, store } from 'hybrids';
-import { FLAG_MODES } from '@ghostery/config';
 
-import Config from '/store/config.js';
 import Options from '/store/options.js';
 import ManagedConfig from '/store/managed-config.js';
 
@@ -43,12 +41,10 @@ export default {
   [router.connect]: {
     stack: () => [AddonHealth, WebTrackers, Performance, Privacy, Skip],
   },
-  config: store(Config),
   managedConfig: store(ManagedConfig),
   feedback: true,
-  mode: ({ config, managedConfig }) =>
-    store.ready(config, managedConfig) && config.hasFlag(FLAG_MODES) && !managedConfig.disableModes,
-  render: ({ feedback, mode }) => html`
+  modesEnabled: ({ managedConfig }) => store.ready(managedConfig) && !managedConfig.disableModes,
+  render: ({ feedback, modesEnabled }) => html`
     <template layout="column gap:2 width:::375px">
       <ui-card layout="gap:2" layout@390px="gap:3">
         <section layout="block:center column gap" layout@390px="margin:2:0:1">
@@ -111,7 +107,7 @@ export default {
         </div>
         <div layout="column gap:2">
           <ui-button type="success" layout="height:5.5" data-qa="button:enable">
-            <a href="${router.url(mode ? Modes : Success)}" onclick="${acceptTerms}">
+            <a href="${router.url(modesEnabled ? Modes : Success)}" onclick="${acceptTerms}">
               Enable Ghostery
             </a>
           </ui-button>

--- a/src/pages/settings/views/my-ghostery.js
+++ b/src/pages/settings/views/my-ghostery.js
@@ -10,12 +10,10 @@
  */
 
 import { html, msg, store } from 'hybrids';
-import { FLAG_MODES } from '@ghostery/config';
 
 import modeGhosteryScreenshotUrl from '/ui/assets/lottie-mode-default.json?url';
 import modeZapScreenshotUrl from '/ui/assets/lottie-mode-zap.json?url';
 
-import Config from '/store/config.js';
 import ManagedConfig from '/store/managed-config.js';
 import Options, { MODE_DEFAULT, MODE_ZAP } from '/store/options.js';
 
@@ -47,10 +45,9 @@ function updateMode(value) {
 
 export default {
   options: store(Options),
-  config: store(Config),
   managedConfig: store(ManagedConfig),
   importStatus: undefined,
-  render: ({ options, config, managedConfig, importStatus }) => html`
+  render: ({ options, managedConfig, importStatus }) => html`
     <template layout="contents">
       <settings-page-layout>
         <section layout="column gap:4" layout@768px="gap:5">
@@ -59,7 +56,6 @@ export default {
           </div>
           <div layout="column gap:4">
             ${
-              config.hasFlag(FLAG_MODES) &&
               !managedConfig.disableModes &&
               html`
                 <settings-option icon="ghosty-m">


### PR DESCRIPTION
The `MODES` flag was bumped to 100% rollout in [broken-page-reports@b3f24de](https://github.com/ghostery/broken-page-reports/commit/b3f24defb53729bb28bfd72ac013b89f18c058eb) on May 20, so the flag checks gating the filtering-mode UI and its rollback handling are no longer reachable and can be removed.

- Removed `FLAG_MODES` checks from the onboarding and settings "My Ghostery" views, keeping only the `managedConfig.disableModes` policy gate.
- Removed the `zapped.js` listener that reset filtering mode/zapped data when the flag was disabled, since it can no longer fire.
- Simplified the `zap` telemetry query parameter, dropping the now-unreachable "flag disabled" (`-1`) case.
- Removed the `waitForConfigSync()` wait in `onboarding.js` and the now-unused helper in `config.js`, so the onboarding tab opens immediately instead of waiting on remote config sync.