### PR TITLE
chore(custom-filters): remove customFiltersInput migration

### DIFF
--- a/src/store/custom-filters.js
+++ b/src/store/custom-filters.js
@@ -28,19 +28,8 @@ const CustomFilters = {
   [store.connect]: {
     cache: false,
     async get() {
-      let { customFilters } = await chrome.storage.local.get(['customFilters']);
-
-      // TODO: Remove migration from `customFiltersInput` after releasing this version
-      if (!customFilters) {
-        const { customFiltersInput } = await chrome.storage.local.get(['customFiltersInput']);
-        if (customFiltersInput !== undefined) {
-          customFilters = { text: customFiltersInput };
-          await chrome.storage.local.set({ customFilters });
-          await chrome.storage.local.remove('customFiltersInput');
-        }
-      }
-
-      return customFilters || {};
+      const { customFilters = {} } = await chrome.storage.local.get(['customFilters']);
+      return customFilters;
     },
     async set(_, values) {
       await chrome.storage.local.set({


### PR DESCRIPTION
The one-time migration from the legacy `customFiltersInput` storage key to `customFilters` was added in #3441 (shipped in v10.5.50) as a temporary shim, per its own TODO. Ten releases have shipped since then (up to v10.6.0), so all active installs have already migrated.

This removes the now-dead migration code from the `store.connect.get()` handler in `custom-filters.js`, keeping the store logic simpler.