### PR TITLE
feat(telemetry): add whatsNew parameter

### DIFF
--- a/src/background/telemetry/metrics.js
+++ b/src/background/telemetry/metrics.js
@@ -238,8 +238,11 @@ export default class Metrics {
         buildQueryPair('sm', conf.options.blockAnnoyances ? '1' : '0') +
         // Antitracking state
         buildQueryPair('at', conf.options.blockTrackers ? '1' : '0') +
-        // What's New announced version
-        buildQueryPair('wn', conf.options.whatsNew.version) +
+        // What's New announced version and whether the recap page was shown
+        buildQueryPair(
+          'wn',
+          `${conf.options.whatsNew.version}-${conf.options.whatsNew.shown ? '1' : '0'}`,
+        ) +
         // Page views yesterday (-1=undefined, 0=none, 1=<10, 2=>=10)
         // prettier-ignore
         buildQueryPair('pv', conf.yesterdayPages === undefined ? '-1' : conf.yesterdayPages >= 10 ? '2' : conf.yesterdayPages > 0 ? '1' : '0') +

--- a/src/background/telemetry/metrics.js
+++ b/src/background/telemetry/metrics.js
@@ -238,10 +238,10 @@ export default class Metrics {
         buildQueryPair('sm', conf.options.blockAnnoyances ? '1' : '0') +
         // Antitracking state
         buildQueryPair('at', conf.options.blockTrackers ? '1' : '0') +
-        // What's New announced version and whether the recap page was shown
+        // What's New announced version, whether the recap popup was auto-opened, and whether the recap page was shown
         buildQueryPair(
           'wn',
-          `${conf.options.whatsNew.version}-${conf.options.whatsNew.shown ? '1' : '0'}`,
+          `${conf.options.whatsNew.version}-${conf.options.whatsNew.popup ? '1' : '0'}-${conf.options.whatsNew.shown ? '1' : '0'}`,
         ) +
         // Page views yesterday (-1=undefined, 0=none, 1=<10, 2=>=10)
         // prettier-ignore

--- a/src/background/telemetry/metrics.js
+++ b/src/background/telemetry/metrics.js
@@ -238,6 +238,8 @@ export default class Metrics {
         buildQueryPair('sm', conf.options.blockAnnoyances ? '1' : '0') +
         // Antitracking state
         buildQueryPair('at', conf.options.blockTrackers ? '1' : '0') +
+        // What's New announced version
+        buildQueryPair('wn', conf.options.whatsNew.version) +
         // Page views yesterday (-1=undefined, 0=none, 1=<10, 2=>=10)
         // prettier-ignore
         buildQueryPair('pv', conf.yesterdayPages === undefined ? '-1' : conf.yesterdayPages >= 10 ? '2' : conf.yesterdayPages > 0 ? '1' : '0') +

--- a/src/background/whats-new.js
+++ b/src/background/whats-new.js
@@ -35,7 +35,7 @@ async function openPanel() {
   if (!options.terms || options.whatsNew.version === version) return;
 
   const { notifications } = options.panel;
-  await store.set(options, { whatsNew: { version, shown: !notifications } });
+  await store.set(options, { whatsNew: { version, popup: false, shown: !notifications } });
 
   const managedConfig = await store.resolve(ManagedConfig);
   if (managedConfig.disableUserControl || !notifications) return;
@@ -49,6 +49,8 @@ async function openPanel() {
     // Point the popup at the recap view for this single open, then restore the default
     await chromeAction.setPopup({ popup: `${PANEL_URL}?whatsNew` });
     await chromeAction.openPopup();
+
+    await store.set(options, { whatsNew: { popup: true } });
 
     console.log('[whats-new] Opening the panel with the recap view...');
   } catch (e) {

--- a/src/store/options.js
+++ b/src/store/options.js
@@ -103,9 +103,10 @@ const Options = {
   // Filters update timestamp
   filtersUpdatedAt: 0,
 
-  // What's new: the announced minor version, and whether the recap page was already shown.
+  // What's new: the announced minor version, whether the recap popup was auto-opened,
+  // and whether the recap page was already shown.
   // It starts as shown, so fresh installations have nothing to catch up on
-  whatsNew: { version: '', shown: true },
+  whatsNew: { version: '', popup: false, shown: true },
 
   [store.connect]: {
     async get() {


### PR DESCRIPTION
The telemetry ping did not report which "What's New" version was announced, whether the recap popup auto-opened, or whether the recap page was actually shown, making it hard to correlate engagement metrics with recap page rollouts.

This adds a `wn` query parameter to the metrics ping URL, combining `options.whatsNew.version`, `options.whatsNew.popup`, and `options.whatsNew.shown` as `<version>-<popup>-<shown>` (e.g. `10.6-0-1` means version 10.6, popup not auto-opened, recap page shown). The `wn` alias was chosen to avoid clashing with existing parameters used by the metrics-server.

- Added a new `popup` field to `options.whatsNew`, defaulting to `false` and reset whenever a new version is announced.
- `background/whats-new.js` now flips `popup` to `true` once the recap popup is successfully auto-opened.