### PR TITLE
feat(onboarding): switch to opt-out for chromium

### DIFF
--- a/src/background/adblocker/engines.js
+++ b/src/background/adblocker/engines.js
@@ -168,10 +168,13 @@ export const setup = asyncSetup('adblocker', [
       await reloadMainEngine();
     }
 
+    // Re-resolve `filtersUpdatedAt` as the above `reloadMainEngine` call might have updated it
+    const { filtersUpdatedAt } = await store.resolve(Options);
+
     // Update engine filters:
     // * when engines changed, so there might be re-enabled engines with outdated filters
     // * when filters are outdated (older than 1 hour)
-    if (enginesChanged || options.filtersUpdatedAt < Date.now() - UPDATE_ENGINES_DELAY) {
+    if (enginesChanged || filtersUpdatedAt < Date.now() - UPDATE_ENGINES_DELAY) {
       await updateEngines();
     }
   }),

--- a/src/background/helpers.js
+++ b/src/background/helpers.js
@@ -18,6 +18,7 @@ import { hasWTMStats } from '/utils/wtm-stats';
 import { isUserScriptsSupported } from '/utils/user-scripts.js';
 import { setup as adblockerSetup, updateEngines } from './adblocker/engines.js';
 import { openElementPicker } from './element-picker.js';
+import { captureAttribution } from './telemetry/index.js';
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   switch (msg.action) {
@@ -127,6 +128,13 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 
       sendResponse([]);
       break;
+
+    case 'e2e:captureAttribution':
+      captureAttribution().then(() => {
+        sendResponse('done');
+        console.debug('[helpers] "captureAttribution" finished');
+      }, sendResponse);
+      return true;
   }
 
   return false;

--- a/src/background/telemetry/index.js
+++ b/src/background/telemetry/index.js
@@ -72,7 +72,9 @@ OptionsObserver.addListener(async function telemetry({ terms, feedback }, lastOp
   // Wait for setup to finish initializing the runner
   setup.pending && (await setup.pending);
 
-  if (runner.isJustInstalled()) {
+  // In debug builds, skip the automatic capture and let `e2e:captureAttribution`
+  // trigger it once the test has finished its setup.
+  if (!__DEBUG__ && runner.isJustInstalled()) {
     await runner.setUTMs(await detectAttribution());
   }
 
@@ -85,6 +87,11 @@ OptionsObserver.addListener(async function telemetry({ terms, feedback }, lastOp
     if (feedback) runner.ping('active');
   }
 });
+
+export async function captureAttribution() {
+  setup.pending && (await setup.pending);
+  await runner.setUTMs(await detectAttribution());
+}
 
 chrome.runtime.onInstalled.addListener(async (details) => {
   setup.pending && (await setup.pending);

--- a/src/pages/onboarding/index.js
+++ b/src/pages/onboarding/index.js
@@ -37,7 +37,7 @@ Promise.all([store.resolve(Options), store.resolve(ManagedConfig)]).then(
     store.set(Options, { onboarding: true });
 
     mount(document.body, {
-      stack: router(terms ? [Success, Modes] : [Main, Modes, Success]),
+      stack: router(terms && __FIREFOX__ ? [Success, Modes] : [Main, Modes, Success]),
       render: ({ stack }) => html`
         <template layout="grid height::100%">
           <ui-page-layout>${stack}</ui-page-layout>

--- a/src/pages/onboarding/views/main.js
+++ b/src/pages/onboarding/views/main.js
@@ -37,6 +37,11 @@ function acceptTerms(host, event) {
   );
 }
 
+function uninstall(host, event) {
+  event.preventDefault();
+  chrome.management.uninstallSelf({ showConfirmDialog: true });
+}
+
 export default {
   [router.connect]: {
     stack: () => [AddonHealth, WebTrackers, Performance, Privacy, Skip],
@@ -132,6 +137,17 @@ export default {
               <ui-button type="success" layout="height:5.5" data-qa="button:enable">
                 <a href="${router.url(modesEnabled ? Modes : Success)}">Continue</a>
               </ui-button>
+              ${
+                chrome.management?.uninstallSelf &&
+                html`
+                  <ui-text type="body-xs" color="tertiary" layout="block:center" underline>
+                    Changed your mind?
+                    <a href="#" onclick="${uninstall}" data-qa="button:uninstall"
+                      >Uninstall Ghostery</a
+                    >
+                  </ui-text>
+                `
+              }
             `
           }
         </div>

--- a/src/pages/onboarding/views/main.js
+++ b/src/pages/onboarding/views/main.js
@@ -49,16 +49,17 @@ export default {
       <ui-card layout="gap:2" layout@390px="gap:3">
         <section layout="block:center column gap" layout@390px="margin:2:0:1">
           <ui-text type="body-m">Welcome to Ghostery</ui-text>
-          <ui-text type="display-m">Enable Ghostery to get started</ui-text>
+          ${__FIREFOX__ && html`<ui-text type="display-m">Enable Ghostery to get started</ui-text>`}
+          ${__CHROMIUM__ && html`<ui-text type="display-m" layout="padding:0:4">Setup Ghostery to get started</ui-text>`}
         </section>
         <div layout="column gap:2">
           <ui-text type="display-2xs" layout="block:center">
             Your Community‑Powered Privacy Features:
           </ui-text>
           <div layout="grid:3 gap">
-            <onboarding-feature icon="onboarding-adblocking"> Ad-Blocking </onboarding-feature>
-            <onboarding-feature icon="onboarding-anti-tracking"> Anti-Tracking </onboarding-feature>
-            <onboarding-feature icon="onboarding-never-consent"> Never-Consent </onboarding-feature>
+            <onboarding-feature icon="onboarding-adblocking">Ad-Blocking</onboarding-feature>
+            <onboarding-feature icon="onboarding-anti-tracking">Anti-Tracking</onboarding-feature>
+            <onboarding-feature icon="onboarding-never-consent">Never-Consent</onboarding-feature>
           </div>
         </div>
         <div layout="column gap:2">
@@ -106,23 +107,37 @@ export default {
           </ui-text>
         </div>
         <div layout="column gap:2">
-          <ui-button type="success" layout="height:5.5" data-qa="button:enable">
-            <a href="${router.url(modesEnabled ? Modes : Success)}" onclick="${acceptTerms}">
-              Enable Ghostery
-            </a>
-          </ui-button>
-          <onboarding-error-card layout="margin:top">
-            <ui-text type="body-s" color="danger-secondary" layout="block:center">
-              With Ghostery disabled, only the basic functionality of naming trackers is available.
-            </ui-text>
-            <ui-button type="outline-danger" data-qa="button:skip">
-              <a href="${router.url(Skip)}">Keep Disabled</a>
-            </ui-button>
-          </onboarding-error-card>
+          ${
+            __FIREFOX__ &&
+            html`
+              <ui-button type="success" layout="height:5.5" data-qa="button:enable">
+                <a href="${router.url(modesEnabled ? Modes : Success)}" onclick="${acceptTerms}">
+                  Enable Ghostery
+                </a>
+              </ui-button>
+              <onboarding-error-card layout="margin:top">
+                <ui-text type="body-s" color="danger-secondary" layout="block:center">
+                  With Ghostery disabled, only the basic functionality of naming trackers is
+                  available.
+                </ui-text>
+                <ui-button type="outline-danger" data-qa="button:skip">
+                  <a href="${router.url(Skip)}">Keep Disabled</a>
+                </ui-button>
+              </onboarding-error-card>
+            `
+          }
+          ${
+            __CHROMIUM__ &&
+            html`
+              <ui-button type="success" layout="height:5.5" data-qa="button:enable">
+                <a href="${router.url(modesEnabled ? Modes : Success)}">Continue</a>
+              </ui-button>
+            `
+          }
         </div>
       </ui-card>
       <ui-button type="transparent" layout="self:center">
-        <a href="${TERMS_AND_CONDITIONS_URL}" target="_blank"> Terms & Conditions </a>
+        <a href="${TERMS_AND_CONDITIONS_URL}" target="_blank">Terms & Conditions</a>
       </ui-button>
     </template>
   `,

--- a/src/store/options.js
+++ b/src/store/options.js
@@ -78,7 +78,7 @@ const Options = {
   pauseAssistant: true,
 
   // Onboarding
-  terms: false,
+  terms: __CHROMIUM__ ? true : false,
   feedback: true,
   onboarding: false,
 

--- a/src/ui/components/page-layout.js
+++ b/src/ui/components/page-layout.js
@@ -23,7 +23,7 @@ export default {
         <header layout="row center padding:top:2" layout@1280px="absolute top:3 left:3 padding:0;">
           <ui-icon name="logo-with-slogan"></ui-icon>
         </header>
-        <div layout="grow row content:center padding:3:1:4">
+        <div layout="grow row content:center padding:3:1:4" layout@1280px="padding:7:1:4">
           <div layout="column items:center grow">
             <slot></slot>
           </div>

--- a/tests/e2e/spec/adblocker.spec.js
+++ b/tests/e2e/spec/adblocker.spec.js
@@ -10,7 +10,7 @@
  */
 import { browser, expect } from '@wdio/globals';
 import {
-  enableExtension,
+  setupExtension,
   setToggle,
   waitForIdleBackgroundTasks,
   setCustomFilters,
@@ -88,7 +88,7 @@ async function test(filters) {
 }
 
 describe('Adblocker Capabilities', function () {
-  before(enableExtension);
+  before(setupExtension);
   before(async () => {
     // Disable all community filters to ensure the pure adblocker capability
     // Community filters often ship generic hides to special hostnames like

--- a/tests/e2e/spec/clear-browsing-data.spec.js
+++ b/tests/e2e/spec/clear-browsing-data.spec.js
@@ -10,7 +10,7 @@
  */
 import { browser, expect } from '@wdio/globals';
 import {
-  enableExtension,
+  setupExtension,
   getExtensionElement,
   setCookieInBrowserContext,
   setToggle,
@@ -22,7 +22,7 @@ import {
 describe('Clear Browsing Data', () => {
   const COOKIE_NAME = 'test-cookie';
 
-  before(enableExtension);
+  before(setupExtension);
 
   beforeEach(async () => {
     await setCookieInBrowserContext(PAGE_URL, COOKIE_NAME, 'test-value');

--- a/tests/e2e/spec/custom-filters.spec.js
+++ b/tests/e2e/spec/custom-filters.spec.js
@@ -10,7 +10,7 @@
  */
 import { browser, expect, $ } from '@wdio/globals';
 import {
-  enableExtension,
+  setupExtension,
   getExtensionElement,
   setAdditionalFiltersToggle,
   setCustomFilters,
@@ -59,7 +59,7 @@ async function getCustomFiltersErrorsText() {
 }
 
 describe('Custom Filters', function () {
-  before(enableExtension);
+  before(setupExtension);
   before(async () => {
     await setCustomFilters([
       `${PAGE_DOMAIN}###custom-filter`,

--- a/tests/e2e/spec/distractions.spec.js
+++ b/tests/e2e/spec/distractions.spec.js
@@ -11,7 +11,7 @@
 import { browser, expect } from '@wdio/globals';
 
 import {
-  enableExtension,
+  setupExtension,
   getExtensionElement,
   loadThirdPartyScript,
   setToggle,
@@ -25,7 +25,7 @@ async function setDistractionToggle(name, value) {
 }
 
 describe('Distractions', function () {
-  before(enableExtension);
+  before(setupExtension);
 
   after(() => setDistractionToggle('signInWithGoogle', false));
 

--- a/tests/e2e/spec/exceptions.spec.js
+++ b/tests/e2e/spec/exceptions.spec.js
@@ -11,7 +11,7 @@
 import { browser, expect } from '@wdio/globals';
 
 import {
-  enableExtension,
+  setupExtension,
   getExtensionElement,
   TRACKER_IDS,
   waitForIdleBackgroundTasks,
@@ -20,7 +20,7 @@ import {
 } from '../utils.js';
 
 describe('Exceptions', function () {
-  before(enableExtension);
+  before(setupExtension);
 
   const TRACKER_ID = TRACKER_IDS[0];
 

--- a/tests/e2e/spec/main.spec.js
+++ b/tests/e2e/spec/main.spec.js
@@ -11,7 +11,7 @@
 
 import { browser, expect, $ } from '@wdio/globals';
 import {
-  enableExtension,
+  setupExtension,
   getExtensionElement,
   setPrivacyToggle,
   setAdditionalFiltersToggle,
@@ -25,7 +25,7 @@ import {
 } from '../utils.js';
 
 describe('Main Features', function () {
-  before(enableExtension);
+  before(setupExtension);
 
   describe('Never-consent', function () {
     const WEBSITE_URL = 'https://www.onetrust.com/';

--- a/tests/e2e/spec/managed.spec.js
+++ b/tests/e2e/spec/managed.spec.js
@@ -12,7 +12,7 @@
 import { browser, expect, $ } from '@wdio/globals';
 
 import {
-  enableExtension,
+  setupExtension,
   getExtensionElement,
   sendMessage,
   reloadExtension,
@@ -31,7 +31,7 @@ async function setManagedConfig(config = {}) {
 }
 
 describe('Managed Configuration', function () {
-  before(enableExtension);
+  before(setupExtension);
   before(() =>
     setManagedConfig({
       disableUserControl: true,

--- a/tests/e2e/spec/onboarding.spec.js
+++ b/tests/e2e/spec/onboarding.spec.js
@@ -10,26 +10,39 @@
  */
 
 import { browser, expect } from '@wdio/globals';
-import { enableExtension, getExtensionElement, setCookieInBrowserContext } from '../utils.js';
+import { setupExtension, getExtensionElement, sendMessage } from '../utils.js';
+
+async function setAttribution(values) {
+  await browser.url('ghostery:onboarding');
+  const mainHandle = await browser.getWindowHandle();
+
+  const { handle: pageHandle } = await browser.newWindow('https://www.ghostery.com/');
+
+  await browser.execute(function (v) {
+    sessionStorage.setItem('attribution', v);
+  }, values);
+
+  await browser.switchWindow(mainHandle);
+  await sendMessage({ action: 'e2e:captureAttribution' });
+
+  await browser.switchToWindow(pageHandle);
+  await browser.closeWindow();
+
+  await browser.switchToWindow(mainHandle);
+}
 
 describe('Onboarding', function () {
-  before(async () => {
-    await setCookieInBrowserContext(
-      'https://www.ghostery.com/',
-      'attribution',
-      's=source&c=campaign',
-    );
-  });
+  if (browser.isFirefox) {
+    it('keeps ghostery disabled', async function () {
+      await browser.url('ghostery:onboarding');
 
-  it('keeps ghostery disabled', async function () {
-    await browser.url('ghostery:onboarding');
+      await getExtensionElement('button:skip').click();
+      await expect(getExtensionElement('view:skip')).toBeDisplayed();
 
-    await getExtensionElement('button:skip').click();
-    await expect(getExtensionElement('view:skip')).toBeDisplayed();
-
-    await browser.url('ghostery:panel');
-    await expect(getExtensionElement('button:enable')).toBeDisplayed();
-  });
+      await browser.url('ghostery:panel');
+      await expect(getExtensionElement('button:enable')).toBeDisplayed();
+    });
+  }
 
   if (browser.isChromium) {
     it('shows the dialog with Privacy Policy', async function () {
@@ -41,12 +54,14 @@ describe('Onboarding', function () {
     });
   }
 
-  it('enables ghostery', enableExtension);
+  it('enables ghostery', setupExtension);
 
-  it('captures attribution from ghostery.com cookie', async () => {
+  it('captures attribution from ghostery.com sessionStorage', async () => {
+    await setAttribution('s=source&c=campaign');
+
     await browser.url('ghostery:settings');
 
-    await expect(getExtensionElement('text:utm-source')).toHaveText('source_c');
+    await expect(getExtensionElement('text:utm-source')).toHaveText('source');
     await expect(getExtensionElement('text:utm-campaign')).toHaveText('campaign');
   });
 });

--- a/tests/e2e/spec/panel.spec.js
+++ b/tests/e2e/spec/panel.spec.js
@@ -9,10 +9,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 import { browser, expect, $ } from '@wdio/globals';
-import { enableExtension, getExtensionElement } from '../utils.js';
+import { setupExtension, getExtensionElement } from '../utils.js';
 
 describe('Panel', function () {
-  before(enableExtension);
+  before(setupExtension);
 
   it('opens licenses page', async function () {
     await browser.url('ghostery:panel');

--- a/tests/e2e/spec/pause-assistant.spec.js
+++ b/tests/e2e/spec/pause-assistant.spec.js
@@ -13,7 +13,7 @@ import { browser, expect, $ } from '@wdio/globals';
 
 import {
   dismissPageNotification,
-  enableExtension,
+  setupExtension,
   expectNoPageNotification,
   sendMessage,
   setWhoTracksMeToggle,
@@ -31,7 +31,7 @@ describe('Pause Assistant', function () {
     await waitForIdleBackgroundTasks();
   }
 
-  before(enableExtension);
+  before(setupExtension);
 
   before(async () => {
     await browser.url('ghostery:panel');

--- a/tests/e2e/spec/redirect-protection.spec.js
+++ b/tests/e2e/spec/redirect-protection.spec.js
@@ -11,7 +11,7 @@
 import { browser, expect } from '@wdio/globals';
 
 import {
-  enableExtension,
+  setupExtension,
   getExtensionElement,
   setCustomFilters,
   setAdditionalFiltersToggle,
@@ -45,7 +45,7 @@ async function waitForNavigation() {
 }
 
 describe('Redirect Protection', function () {
-  before(enableExtension);
+  before(setupExtension);
   before(() => setCustomFilters([`||${PAGE_DOMAIN}^$document`]));
 
   after(() => disableCustomFilters());
@@ -197,7 +197,7 @@ describe('Redirect Protection', function () {
 // for type-less filters via @ghostery/adblocker's FROM_ANY mask; we now skip
 // those matches in src/background/adblocker/network.js.
 describe('Type-less filter does not affect main_frame', function () {
-  before(enableExtension);
+  before(setupExtension);
   before(() => setCustomFilters([`||${PAGE_DOMAIN}^`]));
   after(() => disableCustomFilters());
 

--- a/tests/e2e/spec/scriptlet-idempotency.spec.js
+++ b/tests/e2e/spec/scriptlet-idempotency.spec.js
@@ -10,7 +10,7 @@
  */
 import { browser, expect, $ } from '@wdio/globals';
 import {
-  enableExtension,
+  setupExtension,
   setCustomFilters,
   disableCustomFilters,
   setUserScriptsAllowed,
@@ -139,7 +139,7 @@ function idempotencyChecks() {
 }
 
 describe('Scriptlet injection idempotency', function () {
-  before(enableExtension);
+  before(setupExtension);
   before(async () => {
     await setCustomFilters([
       `${PAGE_DOMAIN}##+js(rpnt, rpnt-marker, aaa, aaa+)`,

--- a/tests/e2e/spec/scriptlet-refresh.spec.js
+++ b/tests/e2e/spec/scriptlet-refresh.spec.js
@@ -10,7 +10,7 @@
  */
 import { browser, expect } from '@wdio/globals';
 import {
-  enableExtension,
+  setupExtension,
   getExtensionElement,
   waitForIdleBackgroundTasks,
   setCustomFilters,
@@ -47,7 +47,7 @@ async function waitForRegistrationDrop() {
 
 if (browser.isChromium) {
   describe('Scriptlet registration refresh', function () {
-    before(enableExtension);
+    before(setupExtension);
 
     before(async function () {
       await setCustomFilters([`${PAGE_DOMAIN}##+js(rpnt, rpnt-marker, aaa, aaa+)`]);

--- a/tests/e2e/spec/subframe-scripting.spec.js
+++ b/tests/e2e/spec/subframe-scripting.spec.js
@@ -10,7 +10,7 @@
  */
 import { browser, expect } from '@wdio/globals';
 import {
-  enableExtension,
+  setupExtension,
   setCustomFilters,
   disableCustomFilters,
   reloadUntilActive,
@@ -78,7 +78,7 @@ const ensureFiltersActive = () =>
   );
 
 describe('Subframe scriptlet injection', function () {
-  before(enableExtension);
+  before(setupExtension);
   before(async () => {
     await setCustomFilters([
       `${PAGE_DOMAIN}>>##+js(set, __ghostery_subframe__, true)`,

--- a/tests/e2e/spec/whats-new.spec.js
+++ b/tests/e2e/spec/whats-new.spec.js
@@ -10,7 +10,7 @@
  */
 import { browser, expect, $ } from '@wdio/globals';
 import {
-  enableExtension,
+  setupExtension,
   getExtensionElement,
   getExtensionPageURL,
   reloadExtension,
@@ -18,7 +18,7 @@ import {
 } from '../utils.js';
 
 describe("What's new", function () {
-  before(enableExtension);
+  before(setupExtension);
 
   it('shows the panel notification and recap page', async function () {
     // Debug builds announce the recap on every reload of the unpacked extension

--- a/tests/e2e/spec/whotracksme.spec.js
+++ b/tests/e2e/spec/whotracksme.spec.js
@@ -10,14 +10,14 @@
  */
 import { expect, browser } from '@wdio/globals';
 import {
-  enableExtension,
+  setupExtension,
   getExtensionElement,
   getExtensionPageURL,
   setWhoTracksMeToggle,
 } from '../utils.js';
 
 describe('WhoTracksMe', function () {
-  before(enableExtension);
+  before(setupExtension);
 
   describe('Trackers Preview', function () {
     it('displays trackers stats', async function () {

--- a/tests/e2e/spec/zapped.spec.js
+++ b/tests/e2e/spec/zapped.spec.js
@@ -12,7 +12,7 @@
 import { browser, expect, $ } from '@wdio/globals';
 
 import {
-  enableExtension,
+  setupExtension,
   getExtensionElement,
   waitForIdleBackgroundTasks,
   expectAdsBlocked,
@@ -47,7 +47,7 @@ async function toggleZapInPanel(type) {
 }
 
 describe('ZAP Mode', function () {
-  before(enableExtension);
+  before(setupExtension);
 
   before(() => setFilteringMode('zap'));
   after(() => setFilteringMode('ghostery'));

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -344,24 +344,27 @@ async function dismissNotifications() {
   await expectNoPageNotification(PAGE_URL, 'review');
 }
 
-export async function enableExtension() {
-  if (enableExtension.done) return;
+export async function setupExtension() {
+  if (setupExtension.done) return;
 
   await browser.url('ghostery:onboarding');
 
   if (await getExtensionElement('view:success').isDisplayed()) {
+    setupExtension.done = true;
     return;
   }
 
-  await getExtensionElement('button:enable').click();
-  await getExtensionElement('button:filtering-mode:ghostery').click();
+  if (browser.isFirefox) {
+    await getExtensionElement('button:enable').click();
+    await getExtensionElement('button:filtering-mode:ghostery').click();
 
-  await expect(getExtensionElement('view:success')).toBeDisplayed();
-  await waitForIdleBackgroundTasks();
+    await expect(getExtensionElement('view:success')).toBeDisplayed();
+    await waitForIdleBackgroundTasks();
+  }
 
   await dismissNotifications();
 
-  enableExtension.done = true;
+  setupExtension.done = true;
 }
 
 // Loads a third-party `<script>` from the page context and reports whether


### PR DESCRIPTION
For Chromium-based browsers, terms are now enabled by default, and onboarding becomes opt-out (uninstalling the extension) instead of opt-in.

Attribution capture (from a sessionStorage value set on ghostery.com) is now deferred in debug builds and exposed via a new `e2e:captureAttribution` message, since it previously raced the extension's auto-enable on install. E2E tests and helpers were updated accordingly, including renaming `enableExtension` to `setupExtension`.

<img width="1159" height="947" alt="Zrzut ekranu 2026-09-8 o 12 31 53" src="https://github.com/user-attachments/assets/04048acf-22e8-4697-8bc9-1a49ad6daba6" />

