### PR TITLE
chore(deps): update dependencies to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,17 @@
       "version": "10.6.0",
       "license": "GPL-3.0",
       "dependencies": {
-        "@duckduckgo/autoconsent": "^16.36.0",
+        "@duckduckgo/autoconsent": "^16.38.0",
         "@ghostery/adblocker": "^2.18.2",
         "@ghostery/adblocker-content": "^2.18.2",
         "@ghostery/adblocker-extended-selectors": "^2.18.2",
         "@ghostery/adblocker-webextension": "^2.18.2",
-        "@ghostery/config": "^0.0.17",
+        "@ghostery/config": "^0.0.18",
         "@ghostery/scriptlets": "github:ghostery/scriptlets",
-        "@ghostery/urlfilter2dnr": "^2.0.4",
+        "@ghostery/urlfilter2dnr": "^2.1.0",
         "@github/relative-time-element": "^5.3.1",
         "@sentry/browser": "^10.73.0",
-        "@whotracksme/reporting": "^12.0.0",
+        "@whotracksme/reporting": "^12.1.0",
         "apexsankey": "github:ghostery/apexsankey",
         "bowser": "^2.14.1",
         "csv-stringify": "^6.8.3",
@@ -28,17 +28,17 @@
         "lottie-web": "^5.13.0",
         "minixxh": "^0.4.0",
         "plotly.js-basic-dist": "^4.0.0",
-        "tldts-experimental": "^7.4.11"
+        "tldts-experimental": "^7.4.12"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/chrome": "^0.2.8",
-        "@wdio/browser-runner": "^9.31.5",
-        "@wdio/cli": "^9.31.5",
+        "@types/chrome": "^0.2.9",
+        "@wdio/browser-runner": "^9.31.6",
+        "@wdio/cli": "^9.31.6",
         "@wdio/globals": "^9.31.1",
-        "@wdio/mocha-framework": "^9.31.1",
+        "@wdio/mocha-framework": "^9.31.6",
         "@wdio/spec-reporter": "^9.31.2",
-        "eslint": "^10.9.1",
+        "eslint": "^10.10.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.6",
         "globals": "^17.12.0",
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@adguard/agtree": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@adguard/agtree/-/agtree-4.2.0.tgz",
-      "integrity": "sha512-rpdSH2oRESO2d0OhhLrvUPAh4nsX3uSCEz+1bNevUkGKtysGG404ZevSlSZEFEDNAuOPmyaCKA5dbQ5T2G20BA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@adguard/agtree/-/agtree-4.2.1.tgz",
+      "integrity": "sha512-SYS+88MBs7FxUovsjcWxxWS366toEjkvb3QzURJFlzHtGXNn4Sbx444RfHrBD2ZqojrJ7fFyWnlXPHxGE9/cZA==",
       "license": "MIT",
       "dependencies": {
         "@adguard/css-tokenizer": "^1.2.0",
@@ -77,10 +77,33 @@
       "integrity": "sha512-cUj5j/AU5z/T4//5M6KnIJBpykAY4QbDsoiQ2DaWX/r2XkepMkTb8DhIbUHJD/QLGEyLeQLpi+nlxAgf4NTRRQ==",
       "license": "MIT"
     },
+    "node_modules/@adguard/dnr-converter": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@adguard/dnr-converter/-/dnr-converter-1.1.2.tgz",
+      "integrity": "sha512-YYjKN5Oa87XGybUd1ByLf+b1AjV/TrNEDBtDDyeDdE5nCZ84Rt2BGW9qzKQRShk5YsLTD4NQkaW3GiKZr1vq6w==",
+      "license": "GPL-3.0-only",
+      "dependencies": {
+        "@adguard/agtree": "^4.2.1",
+        "@adguard/logger": "^2.0.0",
+        "@adguard/scriptlets": "2.5.1",
+        "commander": "^12.1.0",
+        "punycode": "2.3.1",
+        "valibot": "^1.1.0"
+      },
+      "bin": {
+        "dnr-converter": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "@adguard/re2-wasm": "1.2.0"
+      }
+    },
     "node_modules/@adguard/logger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@adguard/logger/-/logger-2.0.0.tgz",
-      "integrity": "sha512-jOiL0gy+uhrezJwI5j1mzpXyta1AFOhpEgKrqRlLN6puArFmHDmLH06civQs12tFWjtUCX+uGgUd1i4x/PCU1g==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@adguard/logger/-/logger-2.0.1.tgz",
+      "integrity": "sha512-ZHF6u0qN3RPjAJREOX0b9nDgkQnyIvu39yQOEl04BUXJqUSZvnOLcpaMTbqGIbT9/nuzR0hZx/nXBNuvRgTp9w==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
@@ -96,47 +119,17 @@
       }
     },
     "node_modules/@adguard/scriptlets": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@adguard/scriptlets/-/scriptlets-2.5.0.tgz",
-      "integrity": "sha512-1DISQycmS1+KkYYvn9bl6PQIV84MdykM/Jyyu+iI8h3xpWJCudH0KR/b5g4qDYmKGBoGg6LclMsyLxzPdeje0A==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@adguard/scriptlets/-/scriptlets-2.5.1.tgz",
+      "integrity": "sha512-008B4qm6mXU4mqHOl1HE/jfRa0D/LUX2Lx4k00G45csiBF/fnIGzVivPsT1Q+Uhp9C+zj5tKoekkL39W8HqjzA==",
       "license": "GPL-3.0",
       "dependencies": {
-        "@adguard/agtree": "4.2.0",
+        "@adguard/agtree": "4.2.1",
         "@types/trusted-types": "2.0.7",
         "js-yaml": "3.14.1"
       },
       "engines": {
         "pnpm": ">=10.33.4 <11"
-      }
-    },
-    "node_modules/@adguard/tsurlfilter": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@adguard/tsurlfilter/-/tsurlfilter-4.0.5.tgz",
-      "integrity": "sha512-s/Iv86M9KUXXAfeyps/hmEbX5tismn19lAVqIkFptBujnrV6uEY2bxthzRsBWxY39Y8ZFwrjhe9nyZ3HILbU3g==",
-      "license": "GPL-3.0-only",
-      "dependencies": {
-        "@adguard/agtree": "^4.0.4",
-        "@adguard/css-tokenizer": "^1.2.0",
-        "@adguard/logger": "^2.0.0",
-        "@adguard/scriptlets": "^2.3.1",
-        "cidr-tools": "^6.4.1",
-        "commander": "^12.1.0",
-        "is-cidr": "4.0.2",
-        "is-ip": "3.1.0",
-        "lru-cache": "^11.0.2",
-        "punycode": "2.3.1",
-        "tldts": "^5.7.112",
-        "zod": "3.24.4",
-        "zod-validation-error": "^3.4.0"
-      },
-      "bin": {
-        "tsurlfilter": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "peerDependencies": {
-        "@adguard/re2-wasm": "1.2.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -425,6 +418,67 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@cacheable/memory": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.2.0.tgz",
+      "integrity": "sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.5.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/memory/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+      "integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
     "node_modules/@devicefarmer/adbkit": {
       "version": "3.3.9",
       "resolved": "https://registry.npmjs.org/@devicefarmer/adbkit/-/adbkit-3.3.9.tgz",
@@ -496,9 +550,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "16.36.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.36.0.tgz",
-      "integrity": "sha512-a5W0QGkRJgOQdFko4LRtRpdxnFzTBwTAaMcgrJG6cEsj+WvFB7C9hB3P+gc/Oyke3dNgIsdqEqUx3vl9hQurgQ==",
+      "version": "16.38.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.38.0.tgz",
+      "integrity": "sha512-DNMsSOX9P5btSXc1Y8aWmdm0/P1eHWtKomaa97rL/XrCdq+LXPa8/38TOcLYsU5mdprHzYnqPwxWJm6V/xVS/w==",
       "license": "MPL-2.0",
       "dependencies": {
         "tldts-experimental": "^7.4.3"
@@ -1133,9 +1187,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -1200,9 +1254,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
-      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.3.tgz",
+      "integrity": "sha512-IkO+/KEUvwbVpiURZg+P7zF74z5Jxe0UgJxVni+RtoHQ6IZieXaO02kmadomap/q+l6bc/jdPGGqTjhuZnuz1Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1343,9 +1397,9 @@
       }
     },
     "node_modules/@ghostery/config": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@ghostery/config/-/config-0.0.17.tgz",
-      "integrity": "sha512-V+KD9AMgUJ+UQDdJ1IuucmFAo9MldIiRV6MB9R3QWt8ELpw5ueps6iVK8TTYsq4fpQuENVkhsP/FhZ+Q+WLWUg==",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@ghostery/config/-/config-0.0.18.tgz",
+      "integrity": "sha512-vFB2orgqfGShUWYF+tCUHoV7pz4PcFswQPIaJWdxmxVtjNy/i6A73rahN3Ot14H+yYdRqZBq5Z/EwO75B6dfFw==",
       "license": "MIT"
     },
     "node_modules/@ghostery/scriptlets": {
@@ -1363,14 +1417,14 @@
       }
     },
     "node_modules/@ghostery/urlfilter2dnr": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@ghostery/urlfilter2dnr/-/urlfilter2dnr-2.0.4.tgz",
-      "integrity": "sha512-ZnxsdMU5UXEIVcyAsu9Ht9cK9OXZJt/gKie4nKmce//NMiVV+wFqCRmAdsw6osgtwcSfIb/uPwXpbaGg2BPQyA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/urlfilter2dnr/-/urlfilter2dnr-2.1.0.tgz",
+      "integrity": "sha512-Q6WuXJ3+3hiP7ZSBgizt/4my5ItltQimyG5Viye4rkWnXKCeJmOZ3kimZgLI+3uUKNS6H9k5wvE+ADOCcJIkhw==",
       "license": "GPL-3.0",
       "dependencies": {
+        "@adguard/dnr-converter": "^1.1.2",
         "@adguard/re2-wasm": "^1.2.0",
         "@adguard/scriptlets": "^2.2.16",
-        "@adguard/tsurlfilter": "^4.0.2",
         "@eyeo/webext-ad-filtering-solution": "^4.0.0"
       }
     },
@@ -3789,9 +3843,9 @@
       "license": "MIT"
     },
     "node_modules/@types/chrome": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.2.8.tgz",
-      "integrity": "sha512-dznDYMiJUyuc7b+78PxnWhaGOonmbX/OmcWu7NE42sg/yTLJMYnJ7Uah40SLPNFiCh8reqcthk7vOva2+MSvzw==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.2.9.tgz",
+      "integrity": "sha512-6rXrDPkkWv4D2Q23HqT+iED4voODU5CpOSc2VFgKyecSFItuEsIBvz9CY6jUQ3dd+Q7zo1bnCE9pKRMtkYut5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4061,23 +4115,23 @@
       }
     },
     "node_modules/@wdio/browser-runner": {
-      "version": "9.31.5",
-      "resolved": "https://registry.npmjs.org/@wdio/browser-runner/-/browser-runner-9.31.5.tgz",
-      "integrity": "sha512-/zAOkadQIZZ/EO6RCvObBiUgVeCh/Te2Bgt+3Uaalt36n+9qSyrWoDLhjHvdZUH7TtAc4djG3wnIE8uz3Q1vqg==",
+      "version": "9.31.6",
+      "resolved": "https://registry.npmjs.org/@wdio/browser-runner/-/browser-runner-9.31.6.tgz",
+      "integrity": "sha512-QX+18cb/ZgJ/2EZjcaYXEV3IlmO2pHuwma4MEWVDLNSBvT0hO+IAL624OxFW0tF2ZCmw0BjW+rRAal69AWtJog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@originjs/vite-plugin-commonjs": "^1.0.3",
         "@vitest/spy": "^2.0.4",
         "@wdio/globals": "9.31.3",
-        "@wdio/local-runner": "9.31.5",
+        "@wdio/local-runner": "9.31.6",
         "@wdio/logger": "9.29.1",
-        "@wdio/mocha-framework": "9.31.5",
+        "@wdio/mocha-framework": "9.31.6",
         "@wdio/protocols": "9.31.5",
-        "@wdio/runner": "9.31.5",
+        "@wdio/runner": "9.31.6",
         "@wdio/types": "9.31.2",
-        "@wdio/utils": "9.31.5",
-        "deepmerge-ts": "^7.0.3",
+        "@wdio/utils": "9.31.6",
+        "deepmerge-ts": "^8.0.0",
         "expect": "30.4.1",
         "get-port": "^7.1.0",
         "import-meta-resolve": "^4.0.0",
@@ -4090,10 +4144,10 @@
         "recast": "^0.23.6",
         "safe-stringify": "^1.1.0",
         "source-map-support": "^0.5.21",
-        "vite": "^5.4.10",
+        "vite": "^6.4.3",
         "vite-plugin-istanbul": "^6.0.0",
         "vite-plugin-top-level-await": "^1.4.1",
-        "webdriver": "9.31.5"
+        "webdriver": "9.31.6"
       },
       "engines": {
         "node": ">=18.20.0"
@@ -4121,9 +4175,9 @@
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
       "cpu": [
         "ppc64"
       ],
@@ -4134,7 +4188,7 @@
         "aix"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/@esbuild/android-arm": {
@@ -4425,6 +4479,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@wdio/browser-runner/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@wdio/browser-runner/node_modules/@esbuild/netbsd-x64": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
@@ -4443,6 +4514,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@wdio/browser-runner/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@wdio/browser-runner/node_modules/@esbuild/openbsd-x64": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
@@ -4459,6 +4547,23 @@
       "peer": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@wdio/browser-runner/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/@esbuild/sunos-x64": {
@@ -4632,21 +4737,24 @@
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite": {
-      "version": "5.4.21",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.21.3",
-        "postcss": "^8.4.43",
-        "rollup": "^4.20.0"
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -4655,17 +4763,23 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
         "less": "*",
         "lightningcss": "^1.21.0",
         "sass": "*",
         "sass-embedded": "*",
         "stylus": "*",
         "sugarss": "*",
-        "terser": "^5.4.0"
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
       },
       "peerDependenciesMeta": {
         "@types/node": {
+          "optional": true
+        },
+        "jiti": {
           "optional": true
         },
         "less": {
@@ -4687,6 +4801,12 @@
           "optional": true
         },
         "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
           "optional": true
         }
       }
@@ -4710,9 +4830,9 @@
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
       "cpu": [
         "arm"
       ],
@@ -4723,13 +4843,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
       "cpu": [
         "arm64"
       ],
@@ -4740,13 +4860,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
       "cpu": [
         "x64"
       ],
@@ -4757,13 +4877,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
       "cpu": [
         "arm64"
       ],
@@ -4774,13 +4894,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
       "cpu": [
         "x64"
       ],
@@ -4791,13 +4911,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
       "cpu": [
         "arm64"
       ],
@@ -4808,13 +4928,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
       "cpu": [
         "x64"
       ],
@@ -4825,13 +4945,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
       "cpu": [
         "arm"
       ],
@@ -4842,13 +4962,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
       "cpu": [
         "arm64"
       ],
@@ -4859,13 +4979,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
       "cpu": [
         "ia32"
       ],
@@ -4876,13 +4996,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
       "cpu": [
         "loong64"
       ],
@@ -4893,13 +5013,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
       "cpu": [
         "mips64el"
       ],
@@ -4910,13 +5030,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
       "cpu": [
         "ppc64"
       ],
@@ -4927,13 +5047,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
       "cpu": [
         "riscv64"
       ],
@@ -4944,13 +5064,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
       "cpu": [
         "s390x"
       ],
@@ -4961,13 +5081,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
       "cpu": [
         "x64"
       ],
@@ -4978,13 +5098,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
       "cpu": [
         "x64"
       ],
@@ -4995,13 +5115,13 @@
         "netbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
       "cpu": [
         "x64"
       ],
@@ -5012,13 +5132,13 @@
         "openbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
       "cpu": [
         "x64"
       ],
@@ -5029,13 +5149,13 @@
         "sunos"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
       "cpu": [
         "arm64"
       ],
@@ -5046,13 +5166,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
       "cpu": [
         "ia32"
       ],
@@ -5063,13 +5183,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
       "cpu": [
         "x64"
       ],
@@ -5080,13 +5200,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@wdio/browser-runner/node_modules/vite/node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -5094,52 +5214,55 @@
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/@wdio/cli": {
-      "version": "9.31.5",
-      "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-9.31.5.tgz",
-      "integrity": "sha512-Z040xR3VJ67fGbIj2tAzQmQSWDME6gcTefVVPqOCj3zOrjdIfMKvc+7FPwKwGblR67+6E4q94Yt4P5x0r9P88A==",
+      "version": "9.31.6",
+      "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-9.31.6.tgz",
+      "integrity": "sha512-MgHm8ndBn+sq4EdbRk32TaAMQzeGBxQDN/xi29pQr4bHBF8Nkf77YuKEXnKXZK2gDrjIa6J0Fi2Gzhklu5UqOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/snapshot": "^2.1.1",
-        "@wdio/config": "9.31.5",
+        "@wdio/config": "9.31.6",
         "@wdio/globals": "9.31.3",
         "@wdio/logger": "9.29.1",
         "@wdio/protocols": "9.31.5",
         "@wdio/types": "9.31.2",
-        "@wdio/utils": "9.31.5",
+        "@wdio/utils": "9.31.6",
         "async-exit-hook": "^2.0.1",
         "chalk": "^5.4.1",
         "chokidar": "^4.0.0",
-        "create-wdio": "9.31.2",
+        "create-wdio": "9.31.6",
         "dotenv": "^17.2.0",
         "import-meta-resolve": "^4.0.0",
         "lodash.flattendeep": "^4.4.0",
@@ -5147,7 +5270,7 @@
         "lodash.union": "^4.6.0",
         "read-pkg-up": "^10.0.0",
         "tsx": "^4.7.2",
-        "webdriverio": "9.31.5",
+        "webdriverio": "9.31.6",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -5158,16 +5281,16 @@
       }
     },
     "node_modules/@wdio/config": {
-      "version": "9.31.5",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.31.5.tgz",
-      "integrity": "sha512-Xdjo6+Qxg31kMflG2uBp7oCOlr0/BGxjsNJXdz9gT6J3pkNwiQf2O5wSUuJYqOYnuYLAimAklC47/0L//+3H4w==",
+      "version": "9.31.6",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.31.6.tgz",
+      "integrity": "sha512-+Dk/firI6xPUSsx66Po2nF3CFEjVBC07hHq7K3Vhni/9lxbEO/uAxjyJbYz2ghKhGVHThHtQyggIvZqiBxUUgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@wdio/logger": "9.29.1",
         "@wdio/types": "9.31.2",
-        "@wdio/utils": "9.31.5",
-        "deepmerge-ts": "^7.0.3",
+        "@wdio/utils": "9.31.6",
+        "deepmerge-ts": "^8.0.0",
         "glob": "^10.2.2",
         "import-meta-resolve": "^4.0.0",
         "jiti": "^2.6.1"
@@ -5214,16 +5337,16 @@
       }
     },
     "node_modules/@wdio/local-runner": {
-      "version": "9.31.5",
-      "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-9.31.5.tgz",
-      "integrity": "sha512-5jZcUpZGxWXr4Mido8DgiCzZ+B7EMXtPo8wGe96KwTWkHnCjFj53ZIjpT9GVYIxnJsX0zslqsuA28/2An0pq2g==",
+      "version": "9.31.6",
+      "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-9.31.6.tgz",
+      "integrity": "sha512-JHRQyMy6qEb/cmYcFrRsIzwOtn/Io3Vpb7o0Fjv+dLPB/7NgItJOEIg4t7k9prDUT2XQRHNdF9Ki+sGoty9iuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0",
         "@wdio/logger": "9.29.1",
         "@wdio/repl": "9.16.2",
-        "@wdio/runner": "9.31.5",
+        "@wdio/runner": "9.31.6",
         "@wdio/types": "9.31.2",
         "@wdio/xvfb": "9.31.2",
         "exit-hook": "^4.0.0",
@@ -5253,9 +5376,9 @@
       }
     },
     "node_modules/@wdio/mocha-framework": {
-      "version": "9.31.5",
-      "resolved": "https://registry.npmjs.org/@wdio/mocha-framework/-/mocha-framework-9.31.5.tgz",
-      "integrity": "sha512-UYGNF8M77T7PKvRGidN+Iu++LSPLKbKpQ+K3eJEaDnP7hWcHk+x7VYKrXWPWorPuJfS2ocT+QWAgZlkEhTo6fQ==",
+      "version": "9.31.6",
+      "resolved": "https://registry.npmjs.org/@wdio/mocha-framework/-/mocha-framework-9.31.6.tgz",
+      "integrity": "sha512-huGMzC912yUIPKPuJht/GMtrpBZLC68L9vGoPSaPwAohkB3UZZxq6QNg0c+VV1iTPE0LcU7iptYk/Lf/hwC/7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5263,7 +5386,7 @@
         "@types/node": "^20.11.28",
         "@wdio/logger": "9.29.1",
         "@wdio/types": "9.31.2",
-        "@wdio/utils": "9.31.5",
+        "@wdio/utils": "9.31.6",
         "mocha": "^10.3.0"
       },
       "engines": {
@@ -5308,22 +5431,22 @@
       }
     },
     "node_modules/@wdio/runner": {
-      "version": "9.31.5",
-      "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-9.31.5.tgz",
-      "integrity": "sha512-ffr8v2X104yrETxaVxq0oi0oFBfL3Q7xTrGLGneOsCSpwS+fuq6TkQr51zNZzB06ikjaFZnTmNMMh3GblC6jBQ==",
+      "version": "9.31.6",
+      "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-9.31.6.tgz",
+      "integrity": "sha512-AFeoDl+75VV6tEIzDUWJTEK+2cNgTYwksHgn1BNx5lsRfSC5AoAz1AoOtBkzevN4kaQpdZe2L8Bxz+hvJrO9VA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.11.28",
-        "@wdio/config": "9.31.5",
+        "@wdio/config": "9.31.6",
         "@wdio/dot-reporter": "9.31.2",
         "@wdio/globals": "9.31.3",
         "@wdio/logger": "9.29.1",
         "@wdio/types": "9.31.2",
-        "@wdio/utils": "9.31.5",
-        "deepmerge-ts": "^7.0.3",
-        "webdriver": "9.31.5",
-        "webdriverio": "9.31.5"
+        "@wdio/utils": "9.31.6",
+        "deepmerge-ts": "^8.0.0",
+        "webdriver": "9.31.6",
+        "webdriverio": "9.31.6"
       },
       "engines": {
         "node": ">=18.20.0"
@@ -5372,9 +5495,9 @@
       }
     },
     "node_modules/@wdio/utils": {
-      "version": "9.31.5",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.31.5.tgz",
-      "integrity": "sha512-wufYrRdz0Dr8Oa9OiaFsitQJsD8HWG5J4FQi/r3nZv/W3S+1h1lpBCAmDisH1Q6wN7Ed9v20E56ZU0UOaP5v3g==",
+      "version": "9.31.6",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.31.6.tgz",
+      "integrity": "sha512-yPEvnkCrxacYMP5x5EcscFgG5cjaedwJ4tg9aSgQFDWLR0zGUkuCHW95ufYlH1nMgiIhlxSqGvku5h6bjZvzAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5382,7 +5505,7 @@
         "@wdio/logger": "9.29.1",
         "@wdio/types": "9.31.2",
         "decamelize": "^6.0.0",
-        "deepmerge-ts": "^7.0.3",
+        "deepmerge-ts": "^8.0.0",
         "edgedriver": "^6.1.2",
         "geckodriver": "^6.1.1",
         "get-port": "^7.0.0",
@@ -5411,9 +5534,9 @@
       }
     },
     "node_modules/@whotracksme/reporting": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@whotracksme/reporting/-/reporting-12.0.0.tgz",
-      "integrity": "sha512-Xk3vzO8OydAZsWqXJJdvbW6Sg1+OteFEfol6Z/4DM+M376rak6Jx6XHO+k2xFNCdv6knmPzS2QRslIEXQARS9A==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@whotracksme/reporting/-/reporting-12.1.0.tgz",
+      "integrity": "sha512-9E52aj+9lqS1UWmqfV3owKGSHXaI0sucfZKoG8JKstDlbaEZB00tP3q7JvuK51mXg2RGHKn7xuHReUgZcrTmaA==",
       "license": "MPL-2.0",
       "workspaces": [
         "reporting",
@@ -6764,6 +6887,20 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/cacheable": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
+      "integrity": "sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.2.0",
+        "@cacheable/utils": "^2.5.0",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.10.1"
+      }
+    },
     "node_modules/cacheable-lookup": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
@@ -6794,6 +6931,16 @@
       }
     },
     "node_modules/cacheable-request/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/cacheable/node_modules/keyv": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
@@ -7202,33 +7349,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/cidr-regex": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-4.0.3.tgz",
-      "integrity": "sha512-HOwDIy/rhKeMf6uOzxtv7FAbrz8zPjmVKfSpM+U7/bNBXC5rtOyr758jxcptiSx6ZZn5LOhPJT5WWxPAGDV8dw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "ip-regex": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/cidr-tools": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/cidr-tools/-/cidr-tools-6.4.2.tgz",
-      "integrity": "sha512-KZC8t2ipCqU2M+ISmTxRDGu9bku5MRU3V1cWyGEFJTZEzRhGvBJvVsbpZO5UAu12fExRFihtYGXAlgFFpmK9jw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "cidr-regex": "4.0.3",
-        "ip-bigint": "7.3.0",
-        "ip-regex": "5.0.0",
-        "string-natural-compare": "3.0.1"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/citty": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
@@ -7617,9 +7737,9 @@
       }
     },
     "node_modules/create-wdio": {
-      "version": "9.31.2",
-      "resolved": "https://registry.npmjs.org/create-wdio/-/create-wdio-9.31.2.tgz",
-      "integrity": "sha512-5dEHfcBbaOwL+XPAlVSdC9YzOTe+bjZRQk2mQnR0/QeeAffdY6ZaJ0QS0NiMTyZsphwoJZW4Mokialsgz1Hn6A==",
+      "version": "9.31.6",
+      "resolved": "https://registry.npmjs.org/create-wdio/-/create-wdio-9.31.6.tgz",
+      "integrity": "sha512-1crqGGcJPRY4wA0Z9USae81MswbIYOVSfula/4lQYPbuimcwv3AZUsU1hJgZEfIRdRB9KepKqojOk+itWnlGlg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7871,9 +7991,9 @@
       }
     },
     "node_modules/deepmerge-ts": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.6.tgz",
-      "integrity": "sha512-gQhL1ksGBLQbHeAo47YU6cs2ahd3Pv+8PFYoWogNZbQnNwQyOh9Ad5kbeHFiWwbKdeWQJ5Z7Y7mwb9ew2hXBLw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.2.tgz",
+      "integrity": "sha512-uqbvqLUMrc6p0MO+WBRtTxY55hmyh94WRwI5a++PZe54X+bfVh59FSN7uWCBCW1CCVjzjnrwzfI8zidE2obMMw==",
       "dev": true,
       "funding": [
         {
@@ -7887,7 +8007,7 @@
       ],
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=16.9.0"
       }
     },
     "node_modules/default-browser": {
@@ -8766,9 +8886,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz",
-      "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.10.0.tgz",
+      "integrity": "sha512-NPXn6r5zl4uET1DAVPaOwzX3rut4c0wcmw3dWJAfOsTM5+TogXo0DDjz8pwm/hL8cyVNpHqeK4JpN0NjnyFFNw==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -8780,7 +8900,7 @@
         "@eslint/config-array": "^0.23.5",
         "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.2",
+        "@eslint/plugin-kit": "^0.7.3",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -8795,7 +8915,7 @@
         "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^8.0.0",
+        "file-entry-cache": "11.1.5 || >11.1.6 <12",
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
         "ignore": "^5.2.0",
@@ -8911,6 +9031,28 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/file-entry-cache": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.5.tgz",
+      "integrity": "sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^6.1.23"
+      }
+    },
+    "node_modules/eslint/node_modules/flat-cache": {
+      "version": "6.1.23",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.23.tgz",
+      "integrity": "sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cacheable": "^2.5.0",
+        "flatted": "^3.4.2",
+        "hookified": "^1.15.0"
       }
     },
     "node_modules/eslint/node_modules/ignore": {
@@ -9923,9 +10065,9 @@
       }
     },
     "node_modules/got/node_modules/type-fest": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
-      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.9.0.tgz",
+      "integrity": "sha512-yANm3Jr3GiJ1qgJlxGAVxTOIcEOk1rhQHamlXtnrCK7EHP4HeM9OGxtMg/W7HFdrVzw/ZWJKGVIJusVH85sLtw==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
@@ -9976,6 +10118,19 @@
       "integrity": "sha512-qhl8+l4Zwi1eLlL3lja5ywmDQnBzLEJxd0QJoAVIgZpgQbdtVZrN5ypB0y3VHwBlvAalpcbM2/A6x7oUks5zNg==",
       "license": "MIT"
     },
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -9984,6 +10139,13 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hosted-git-info": {
       "version": "8.1.0",
@@ -9997,13 +10159,6 @@
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
-    },
-    "node_modules/hosted-git-info/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -10233,9 +10388,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.8.tgz",
+      "integrity": "sha512-YYNsSlXBjMk92SKnkwvB5LOVSa6OznlFUGcsvrFgNJbJCd0M1XKeFVRc8ZByeCqz32FivYNHJVooLmdqrmvp/Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -10388,25 +10543,13 @@
         "node": ">= 12"
       }
     },
-    "node_modules/ip-bigint": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/ip-bigint/-/ip-bigint-7.3.0.tgz",
-      "integrity": "sha512-2qVAe0Q9+Y+5nGvmogwK9y4kefD5Ks5l/IG0Jo1lhU9gIF34jifhqrwXwzkIl+LC594Q6SyAlngs4p890xsXVw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/ip-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/is-arrayish": {
@@ -10424,39 +10567,6 @@
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-cidr": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-4.0.2.tgz",
-      "integrity": "sha512-z4a1ENUajDbEl/Q6/pVBpTR1nBjjEE1X7qb7bmWYanNnPoKAvUCPFKeXV6Fe4mgTkWKBqiHIcwsI3SndiO5FeA==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "cidr-regex": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/is-cidr/node_modules/cidr-regex": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-3.1.1.tgz",
-      "integrity": "sha512-RBqYd32aDwbCMFJRL6wHOlDNYJsPNTt8vC82ErHF5vKt8QQzxm1FrkW8s/R5pVrXMf17sba09Uoy91PKiddAsw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "ip-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/is-cidr/node_modules/ip-regex": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -10596,15 +10706,6 @@
       "dependencies": {
         "ip-regex": "^4.0.0"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-ip/node_modules/ip-regex": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -12048,13 +12149,11 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -12414,9 +12513,9 @@
       }
     },
     "node_modules/mocha/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",
@@ -13150,13 +13249,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -13187,9 +13279,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13240,17 +13332,25 @@
       "license": "MIT"
     },
     "node_modules/pkg-types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
-      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.3.tgz",
+      "integrity": "sha512-j/lCFdcppV0JxWpCEITdbDltBxPP6cHT+yNJ6Go2OgoSA9518X847X9z0p6LtA4Nc16+eQzCZjRrWanTGvHJ5w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "confbox": "^0.2.4",
-        "exsolve": "^1.0.8",
+        "confbox": "^0.3.1",
+        "exsolve": "^1.1.1",
         "pathe": "^2.0.3"
       }
+    },
+    "node_modules/pkg-types/node_modules/confbox": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.3.1.tgz",
+      "integrity": "sha512-cKUSoKa8YxFZZSmraVi7onONx3amu77ngK3kGpsYHDH7drPwCRkQE1RYMPlLRrMtnciRj274XNRxcHxnKmDSnA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/plotly.js-basic-dist": {
       "version": "4.0.0",
@@ -13507,6 +13607,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/qified": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+      "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/quansync": {
       "version": "0.2.11",
@@ -13795,13 +13915,6 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "node_modules/read-pkg/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/read-pkg/node_modules/normalize-package-data": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
@@ -13935,9 +14048,9 @@
       }
     },
     "node_modules/recast/node_modules/ast-types": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
-      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.3.tgz",
+      "integrity": "sha512-FvWoWYfSCM6kRxCSH+MGLHIKKGRL6A6AW7Zek2O32REPQRdg131428uRTKMBYAeRd3XXAaHDS60Wpri7CdKDrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14848,12 +14961,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/string-natural-compare": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/string-natural-compare/-/string-natural-compare-3.0.1.tgz",
-      "integrity": "sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==",
-      "license": "MIT"
-    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -15444,18 +15551,18 @@
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.4.11",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.11.tgz",
-      "integrity": "sha512-xbNzxktqwNYSryb4FclztEZ+G5waTnMCVBnwoWD1Fq0gjOykgr0rQWe4/2TdIJYHbyjIol5pdNh7OmCRWxIltw==",
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.12.tgz",
+      "integrity": "sha512-9ekSzO1PiwKHPS+WfA4EIXj49c8hFLi5TeEnW1xAlc6EufOX4Owp1rSC6HoSWq34z3cFLa7Ov2wUQm4fy+31xA==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.11"
+        "tldts-core": "^7.4.12"
       }
     },
     "node_modules/tldts-experimental/node_modules/tldts-core": {
-      "version": "7.4.11",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
-      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.12.tgz",
+      "integrity": "sha512-nYNzS2WRf4QJmjzFFgAxLOBjyBxAGRbCy9PVBPaglcYyYajh40VBn+v5Ngr96ZMc7oM0+aCJdtQnNejvdBnXMQ==",
       "license": "MIT"
     },
     "node_modules/tmp": {
@@ -15583,9 +15690,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15636,6 +15743,14 @@
         "unplugin": "^1.16.1"
       }
     },
+    "node_modules/unimport/node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/unimport/node_modules/escape-string-regexp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -15680,16 +15795,24 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/unimport/node_modules/local-pkg/node_modules/confbox": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.3.1.tgz",
+      "integrity": "sha512-cKUSoKa8YxFZZSmraVi7onONx3amu77ngK3kGpsYHDH7drPwCRkQE1RYMPlLRrMtnciRj274XNRxcHxnKmDSnA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/unimport/node_modules/local-pkg/node_modules/pkg-types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
-      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.3.tgz",
+      "integrity": "sha512-j/lCFdcppV0JxWpCEITdbDltBxPP6cHT+yNJ6Go2OgoSA9518X847X9z0p6LtA4Nc16+eQzCZjRrWanTGvHJ5w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "confbox": "^0.2.4",
-        "exsolve": "^1.0.8",
+        "confbox": "^0.3.1",
+        "exsolve": "^1.1.1",
         "pathe": "^2.0.3"
       }
     },
@@ -15705,14 +15828,6 @@
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
       }
-    },
-    "node_modules/unimport/node_modules/pkg-types/node_modules/confbox": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/unimport/node_modules/unplugin": {
       "version": "1.16.1",
@@ -15900,6 +16015,20 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
+      "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/validate-npm-package-license": {
@@ -16220,20 +16349,20 @@
       }
     },
     "node_modules/webdriver": {
-      "version": "9.31.5",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.31.5.tgz",
-      "integrity": "sha512-ppQ3sKydQ59CVDsODri/pIdVfVp5nSP78qfwbK9LrrICbLkXktCd0pK/Nbc3EclbJ2hOfhfHpU8vuodJ73e4uA==",
+      "version": "9.31.6",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.31.6.tgz",
+      "integrity": "sha512-4l+G2vu7PqVFXlUbMPZ7ueX95o2TgivTjvyBUAUSbllb8qUHIchBC26dscC4LRU44mAfBk1+GmZ6YkG9c0vxCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0",
         "@types/ws": "^8.5.3",
-        "@wdio/config": "9.31.5",
+        "@wdio/config": "9.31.6",
         "@wdio/logger": "9.29.1",
         "@wdio/protocols": "9.31.5",
         "@wdio/types": "9.31.2",
-        "@wdio/utils": "9.31.5",
-        "deepmerge-ts": "^7.0.3",
+        "@wdio/utils": "9.31.6",
+        "deepmerge-ts": "^8.0.0",
         "https-proxy-agent": "^7.0.6",
         "undici": "^6.27.0",
         "ws": "^8.21.0"
@@ -16243,9 +16372,9 @@
       }
     },
     "node_modules/webdriver/node_modules/undici": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
-      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.1.tgz",
+      "integrity": "sha512-zWpdTVD54H48CIybL0rWQ3ukpb9d23wM7eH5RtfdmeP70cWHNjtfo7P4vZX+5CoDcO53J4Pu5uXp7lNfjc6DRA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16253,20 +16382,20 @@
       }
     },
     "node_modules/webdriverio": {
-      "version": "9.31.5",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.31.5.tgz",
-      "integrity": "sha512-XfbzuhqNcpdZeX70bEEmYCvpQ9fgfXVVOkQWF+rCZBkmqW4W61Ol4bqUnKLIhXI4vysSATi2S19vxPK+WTAeWA==",
+      "version": "9.31.6",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.31.6.tgz",
+      "integrity": "sha512-5TUI4meKkGiNrkhClXmQVbr0r1SBq3nSuxrut58QMbYrqFQ5xjPCDV7OTqNUC3CydojRkWkVapUGmxG88ELwEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",
-        "@wdio/config": "9.31.5",
+        "@wdio/config": "9.31.6",
         "@wdio/logger": "9.29.1",
         "@wdio/protocols": "9.31.5",
         "@wdio/repl": "9.16.2",
         "@wdio/types": "9.31.2",
-        "@wdio/utils": "9.31.5",
+        "@wdio/utils": "9.31.6",
         "archiver": "^7.0.1",
         "aria-query": "^5.3.0",
         "cheerio": "^1.0.0-rc.12",
@@ -16283,7 +16412,7 @@
         "rgb2hex": "0.2.5",
         "serialize-error": "^12.0.0",
         "urlpattern-polyfill": "^10.0.0",
-        "webdriver": "9.31.5"
+        "webdriver": "9.31.6"
       },
       "engines": {
         "node": ">=18.20.0"
@@ -16928,18 +17057,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-validation-error": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.5.4.tgz",
-      "integrity": "sha512-+hEiRIiPobgyuFlEojnqjJnhFvg4r/i3cqgcm67eehZf/WBaK3g6cD02YU9mtdVxZjv8CzCA9n/Rhrs3yAAvAw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "zod": "^3.24.4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@types/chrome": "^0.2.8",
-    "@wdio/browser-runner": "^9.31.5",
-    "@wdio/cli": "^9.31.5",
+    "@types/chrome": "^0.2.9",
+    "@wdio/browser-runner": "^9.31.6",
+    "@wdio/cli": "^9.31.6",
     "@wdio/globals": "^9.31.1",
-    "@wdio/mocha-framework": "^9.31.1",
+    "@wdio/mocha-framework": "^9.31.6",
     "@wdio/spec-reporter": "^9.31.2",
-    "eslint": "^10.9.1",
+    "eslint": "^10.10.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",
     "globals": "^17.12.0",
@@ -43,17 +43,17 @@
     "web-ext": "^10.6.0"
   },
   "dependencies": {
-    "@duckduckgo/autoconsent": "^16.36.0",
+    "@duckduckgo/autoconsent": "^16.38.0",
     "@ghostery/adblocker": "^2.18.2",
     "@ghostery/adblocker-content": "^2.18.2",
     "@ghostery/adblocker-extended-selectors": "^2.18.2",
     "@ghostery/adblocker-webextension": "^2.18.2",
-    "@ghostery/config": "^0.0.17",
+    "@ghostery/config": "^0.0.18",
     "@ghostery/scriptlets": "github:ghostery/scriptlets",
-    "@ghostery/urlfilter2dnr": "^2.0.4",
+    "@ghostery/urlfilter2dnr": "^2.1.0",
     "@github/relative-time-element": "^5.3.1",
     "@sentry/browser": "^10.73.0",
-    "@whotracksme/reporting": "^12.0.0",
+    "@whotracksme/reporting": "^12.1.0",
     "apexsankey": "github:ghostery/apexsankey",
     "bowser": "^2.14.1",
     "csv-stringify": "^6.8.3",
@@ -62,7 +62,7 @@
     "lottie-web": "^5.13.0",
     "minixxh": "^0.4.0",
     "plotly.js-basic-dist": "^4.0.0",
-    "tldts-experimental": "^7.4.11"
+    "tldts-experimental": "^7.4.12"
   },
   "overrides": {
     "yauzl": "3.4.0"


### PR DESCRIPTION
Regular dependencies were falling behind their latest patch/minor releases, as reported by `npm outdated`. This keeps the project current and picks up upstream fixes.

Bumped versions in `package.json` and refreshed `package-lock.json` via `npm install` for each package:
- `@duckduckgo/autoconsent` 16.36.0 → 16.38.0
- `@ghostery/config` 0.0.17 → 0.0.18
- `@ghostery/urlfilter2dnr` 2.0.4 → 2.1.0
- `@whotracksme/reporting` 12.0.0 → 12.1.0
- `tldts-experimental` 7.4.11 → 7.4.12
- `@types/chrome` 0.2.8 → 0.2.9
- `@wdio/browser-runner` 9.31.5 → 9.31.6
- `@wdio/cli` 9.31.5 → 9.31.6
- `@wdio/mocha-framework` 9.31.1 → 9.31.6
- `eslint` 10.9.1 → 10.10.0