### PR TITLE
fix(trackers-preview): resolve destinations from the "about this result" request

### DIFF
--- a/src/utils/link-destinations.js
+++ b/src/utils/link-destinations.js
@@ -52,12 +52,23 @@ function httpUrl(value) {
 // --- Google ---
 
 // Some links spell the destination out in the query string; the rest carry an
-// opaque token, and only the order of the data the page renders its results
-// from ties the two together:
+// opaque token, and only the data the page renders its results from ties the
+// two together. An older layout lists the destination right after the link:
 //
 //   [..., "/goto?url=<token>"],["https://example.com/", "<title>", ...]
+//
+// The current one keeps it only inside the "about this result" request of the
+// same result, a base64url protobuf that names the link it describes.
 const RENDER_DATA_REGEXP =
   /\/goto\?url\\u003d([\w-]{20,})"(?:,(?:null|-?\d+))*\],\["(https?:[^"]+)"/g;
+
+const ABOUT_THIS_RESULT_REGEXP = /\/search\/about-this-result\?[^"]*?req(?:=|\\u003d)([\w-]+)/g;
+
+// The request keeps the link at field 1 and the result it stands for under
+// field 3, extension 1024 - where field 6 is the destination.
+const ABOUT_THIS_RESULT_LINK = 1;
+const ABOUT_THIS_RESULT_PATH = [3, 1024];
+const ABOUT_THIS_RESULT_DESTINATION = 6;
 
 // The same token turns up with different padding and parameters around it.
 const TOKEN_REGEXP = /[?&]url=([\w-]{20,})/;
@@ -105,9 +116,95 @@ function indexRenderData(doc) {
     for (const [, token, url] of text.matchAll(RENDER_DATA_REGEXP)) {
       addDestination(destinations, token, unescapeJS(url));
     }
+
+    for (const [, request] of text.matchAll(ABOUT_THIS_RESULT_REGEXP)) {
+      const described = decodeAboutThisResult(request);
+      const [, token] = described?.link.match(TOKEN_REGEXP) || [];
+
+      if (token) addDestination(destinations, token, described.destination);
+    }
   }
 
   return destinations;
+}
+
+const UTF8 = new TextDecoder();
+
+function fromBase64Url(encoded) {
+  const base64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
+  const binary = atob(base64 + '='.repeat((4 - (base64.length % 4)) % 4));
+
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+// Splits a protobuf message into its length-delimited fields, the only ones
+// carrying anything here. A field set more than once keeps its last value.
+function readFields(bytes) {
+  if (!(bytes instanceof Uint8Array)) throw new TypeError('not a message');
+
+  const fields = new Map();
+  let i = 0;
+
+  const readVarint = () => {
+    let value = 0;
+    let shift = 0;
+    let byte;
+
+    do {
+      if (i >= bytes.length) throw new RangeError('truncated varint');
+      byte = bytes[i++];
+      value += (byte & 0x7f) * 2 ** shift;
+      shift += 7;
+    } while (byte & 0x80);
+
+    return value;
+  };
+
+  while (i < bytes.length) {
+    const key = readVarint();
+    const number = Math.floor(key / 8);
+
+    switch (key & 7) {
+      case 0:
+        readVarint();
+        break;
+      case 1:
+        i += 8;
+        break;
+      case 5:
+        i += 4;
+        break;
+      case 2: {
+        const length = readVarint();
+        if (i + length > bytes.length) throw new RangeError('truncated field');
+
+        fields.set(number, bytes.subarray(i, i + length));
+        i += length;
+        break;
+      }
+      default:
+        throw new TypeError('not a message');
+    }
+  }
+
+  return fields;
+}
+
+function decodeAboutThisResult(encoded) {
+  try {
+    const request = readFields(fromBase64Url(encoded));
+    const result = ABOUT_THIS_RESULT_PATH.reduce(
+      (fields, number) => readFields(fields.get(number)),
+      request,
+    );
+
+    return {
+      link: UTF8.decode(request.get(ABOUT_THIS_RESULT_LINK)),
+      destination: UTF8.decode(result.get(ABOUT_THIS_RESULT_DESTINATION)),
+    };
+  } catch {
+    return null;
+  }
 }
 
 function getAdDestination(el) {

--- a/tests/unit/link-destinations.test.js
+++ b/tests/unit/link-destinations.test.js
@@ -43,6 +43,44 @@ function visit(hostname, ...scripts) {
 const renderDataScript = (token = TOKEN, destination = DESTINATION, trailing = '') =>
   `x,"/goto?url\\u003d${token}"${trailing}],["${destination}","a title"],y`;
 
+const varint = (value) => {
+  const bytes = [];
+
+  do {
+    const byte = value % 128;
+    value = Math.floor(value / 128);
+    bytes.push(value ? byte | 0x80 : byte);
+  } while (value);
+
+  return bytes;
+};
+
+const bytesField = (number, payload) => [
+  ...varint(number * 8 + 2),
+  ...varint(payload.length),
+  ...payload,
+];
+const text = (value) => [...Buffer.from(value)];
+
+// A varint, a fixed64, a fixed32 and another string, none of them wanted
+const OTHER_FIELDS = [0x10, 0x05, 0x21, ...Array(8).fill(0), 0x2d, ...Array(4).fill(0)].concat(
+  bytesField(7, text('<b>a</b> title')),
+);
+
+const aboutThisResultRequest = (link, destination, otherFields = []) =>
+  Buffer.from([
+    ...bytesField(1, text(link)),
+    ...otherFields,
+    ...bytesField(3, bytesField(1024, [...otherFields, ...bytesField(6, text(destination))])),
+  ]).toString('base64url');
+
+const aboutThisResultScript = (
+  token = TOKEN,
+  destination = DESTINATION,
+  request = aboutThisResultRequest(`/goto?url=${token}`, destination),
+) =>
+  `x,"/goto?url\\u003d${token}",[null,"/search/about-this-result?origin\\u003dwww.google.com\\u0026req\\u003d${request}\\u0026hl\\u003den"],y`;
+
 describe('link destinations', () => {
   describe('a page that carries its results as data', () => {
     const wrapped = `https://${RENDER_DATA_PAGE}/goto?url=${TOKEN}`;
@@ -111,6 +149,51 @@ describe('link destinations', () => {
 
     it('tolerates extra fields trailing the token', () => {
       assert.equal(resolve(renderDataScript(TOKEN, DESTINATION, ',null,3')), DESTINATION);
+    });
+
+    describe('through its "about this result" request', () => {
+      it('resolves a wrapped link', () => {
+        assert.equal(resolve(aboutThisResultScript()), DESTINATION);
+      });
+
+      it('resolves a result the older layout no longer describes', () => {
+        const script = `${aboutThisResultScript()},["/goto?url\\u003d${TOKEN}","a title"]`;
+
+        assert.equal(resolve(script), DESTINATION);
+      });
+
+      it('skips the fields of the request it has no use for', () => {
+        const request = aboutThisResultRequest(`/goto?url=${TOKEN}`, DESTINATION, OTHER_FIELDS);
+
+        assert.equal(resolve(aboutThisResultScript(TOKEN, DESTINATION, request)), DESTINATION);
+      });
+
+      it('reads the request however its parameter is escaped', () => {
+        assert.equal(resolve(aboutThisResultScript().replace('req\\u003d', 'req=')), DESTINATION);
+      });
+
+      it('leaves a link alone when its request cannot be read', () => {
+        const truncated = aboutThisResultRequest(`/goto?url=${TOKEN}`, DESTINATION).slice(0, -12);
+
+        for (const request of [
+          'A',
+          'AAAA',
+          Buffer.from([0x0a, 0xff]).toString('base64url'),
+          truncated,
+        ]) {
+          assert.equal(resolve(aboutThisResultScript(TOKEN, DESTINATION, request)), null, request);
+        }
+      });
+
+      it('ignores a request that does not describe a wrapped link', () => {
+        const request = aboutThisResultRequest('https://example.com/', DESTINATION);
+
+        assert.equal(resolve(aboutThisResultScript(TOKEN, DESTINATION, request)), null);
+      });
+
+      it('ignores a destination that is not an http(s) URL', () => {
+        assert.equal(resolve(aboutThisResultScript(TOKEN, 'javascript:alert(1)')), null);
+      });
     });
 
     describe('while the page is still streaming in', () => {


### PR DESCRIPTION
Trackers Preview stopped showing wheels on Google search results: the page no longer lists a result's destination next to its wrapped link.

The destination is now also read from the result's "about this result" data, so wheels come back on the current layout while the older one keeps working.