### PR TITLE
fix(utils): rename debug errors helper to captureError

### DIFF
--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -127,4 +127,4 @@ export async function captureError(error, { critical = false, once = false } = {
 }
 
 // Debug tools
-(globalThis.ghostery ??= {}).errors = { captureException: captureError };
+(globalThis.ghostery ??= {}).errors = { captureError };


### PR DESCRIPTION
The `globalThis.ghostery.errors` debug helper exposed the error-capturing function under the key `captureException`, which no longer matched the actual exported function name and was confusing when debugging error reporting from the console. The debug tool object now exposes the function as `captureError`, matching the name of the underlying `captureError` function.